### PR TITLE
Remove scientific notation in model.sdf for marble qav500

### DIFF
--- a/submitted_models/marble_qav500_sensor_config_1/launch/spawner.rb
+++ b/submitted_models/marble_qav500_sensor_config_1/launch/spawner.rb
@@ -128,12 +128,12 @@ def spawner(_name, _modelURI, _worldName, _x, _y, _z, _roll, _pitch, _yaw)
           <motorControlPubTopic>command/motor_speed</motorControlPubTopic>
           <enableSubTopic>velocity_controller/enable</enableSubTopic>
           <comLinkName>base_link</comLinkName>
-          <velocityGain>6 6 10</velocityGain>
-          <attitudeGain>4 4 2</attitudeGain>
-          <angularRateGain>0.7 0.7 0.7</angularRateGain>
-          <maximumLinearAcceleration>1 1 2</maximumLinearAcceleration>
-          <maximumLinearVelocity>5 5 5</maximumLinearVelocity>
-          <maximumAngularVelocity>3 3 3</maximumAngularVelocity>
+          <velocityGain>8 8 10</velocityGain>
+          <attitudeGain>6 6 6</attitudeGain>
+          <angularRateGain>2.5 2.5 4.0</angularRateGain>
+          <maximumLinearAcceleration>5 5 5</maximumLinearAcceleration>
+          <maximumLinearVelocity>20 20 20</maximumLinearVelocity>
+          <maximumAngularVelocity>5 5 10</maximumAngularVelocity>
           <linearVelocityNoiseMean>0 0 0</linearVelocityNoiseMean>
           <!-- linearVelocityNoiseStdDev based on error values reported in the paper Shen et. al., -->
           <!-- Vision-Based State Estimation and Trajectory Control Towards High-Speed Flight with a Quadrotor -->

--- a/submitted_models/marble_qav500_sensor_config_1/launch/vehicle_topics.launch
+++ b/submitted_models/marble_qav500_sensor_config_1/launch/vehicle_topics.launch
@@ -78,8 +78,8 @@
         pkg="ros_ign_bridge"
         type="parameter_bridge"
         name="ros_ign_bridge_tof_top"
-        args="$(arg sensor_prefix)/tof_top/points@sensor_msgs/PointCloud2[ignition.msgs.PointCloudPacked">
-        <remap from="$(arg sensor_prefix)/tof_top/points" to="tof_top/depth/points"/>
+        args="$(arg sensor_prefix)/tof_top/depth_image/points@sensor_msgs/PointCloud2[ignition.msgs.PointCloudPacked">
+        <remap from="$(arg sensor_prefix)/tof_top/depth_image/points" to="tof_top/depth/points"/>
       </node>
       <node
         pkg="ros_ign_image"
@@ -96,8 +96,8 @@
         pkg="ros_ign_bridge"
         type="parameter_bridge"
         name="ros_ign_bridge_tof_bottom"
-        args="$(arg sensor_prefix)/tof_bottom/points@sensor_msgs/PointCloud2[ignition.msgs.PointCloudPacked">
-        <remap from="$(arg sensor_prefix)/tof_bottom/points" to="tof_bottom/depth/points"/>
+        args="$(arg sensor_prefix)/tof_bottom/depth_image/points@sensor_msgs/PointCloud2[ignition.msgs.PointCloudPacked">
+        <remap from="$(arg sensor_prefix)/tof_bottom/depth_image/points" to="tof_bottom/depth/points"/>
       </node>
       <node
         pkg="ros_ign_image"

--- a/submitted_models/marble_qav500_sensor_config_1/model.sdf
+++ b/submitted_models/marble_qav500_sensor_config_1/model.sdf
@@ -344,12 +344,12 @@
                     <lens>
                         <intrinsics>
                             <!-- fx = fy = width / ( 2 * tan (hfov / 2 ) ) -->
-                            <fx>277.1</fx>
-                            <fy>277.1</fy>
+                            <fx>337.22195</fx>
+                            <fy>337.22195</fy>
                             <!-- cx = ( width + 1 ) / 2 -->
-                            <cx>640.5</cx>
+                            <cx>320.5</cx>
                             <!-- cy = ( height + 1 ) / 2 -->
-                            <cy>360.5</cy>
+                            <cy>240.5</cy>
                             <s>0</s>
                         </intrinsics>
                     </lens>
@@ -362,8 +362,8 @@
                         <center>0.5 0.5</center>
                     </distortion>
                     <image>
-                        <width>1280</width>
-                        <height>720</height>
+                        <width>640</width>
+                        <height>480</height>
                         <format>R8G8B8</format>
                     </image>
                     <clip>

--- a/submitted_models/marble_qav500_sensor_config_1/model.sdf
+++ b/submitted_models/marble_qav500_sensor_config_1/model.sdf
@@ -120,8 +120,10 @@
                 <diffuse>0.8 0.8 0.5 1</diffuse>
                 <specular>0.8 0.8 0.5 1</specular>
                 <spot>
-                    <inner_angle>1</inner_angle>
-                    <outer_angle>1.1</outer_angle>
+                  <!-- The real vehicle doesn't have a light currently, but for simulation
+                    purposes, we added one like the ones on the husky and hd2 -->
+                    <inner_angle>2.8</inner_angle>
+                    <outer_angle>2.9</outer_angle>
                     <falloff>1</falloff>
                 </spot>
                 <direction>0 0 -1</direction>

--- a/submitted_models/marble_qav500_sensor_config_1/model.sdf
+++ b/submitted_models/marble_qav500_sensor_config_1/model.sdf
@@ -420,12 +420,12 @@
                     <range>
                         <min>0.05</min>
                         <max>120</max>
-                        <resolution>0.01</resolution>
+                        <resolution>0.003</resolution>
                     </range>
                     <noise>
                         <type>gaussian</type>
                         <mean>0</mean>
-                        <stddev>0.01</stddev>
+                        <stddev>0.03</stddev>
                     </noise>
                 </lidar>
             </sensor>

--- a/submitted_models/marble_qav500_sensor_config_1/model.sdf
+++ b/submitted_models/marble_qav500_sensor_config_1/model.sdf
@@ -204,30 +204,30 @@
 		    <x>
 		      <noise type="gaussian">
 		        <mean>0</mean>
-		        <stddev>8.72664e-5</stddev>
-		        <bias_mean>7.5e-6</bias_mean>
-		        <bias_stddev>8.0e-7</bias_stddev>
-		        <dynamic_bias_stddev>4e-7</dynamic_bias_stddev>
+            <stddev>0.0000872664</stddev>
+            <bias_mean>0.0000075</bias_mean>
+            <bias_stddev>0.00000080</bias_stddev>
+            <dynamic_bias_stddev>0.0000004</dynamic_bias_stddev>
 		        <dynamic_bias_correlation_time>1000.0</dynamic_bias_correlation_time>
 		      </noise>
 		    </x>
 		    <y>
 		      <noise type="gaussian">
 		        <mean>0</mean>
-		        <stddev>8.72664e-5</stddev>
-		        <bias_mean>7.5e-6</bias_mean>
-		        <bias_stddev>8.0e-7</bias_stddev>
-		        <dynamic_bias_stddev>4e-7</dynamic_bias_stddev>
+            <stddev>0.0000872664</stddev>
+            <bias_mean>0.0000075</bias_mean>
+            <bias_stddev>0.00000080</bias_stddev>
+            <dynamic_bias_stddev>0.0000004</dynamic_bias_stddev>
 		        <dynamic_bias_correlation_time>1000.0</dynamic_bias_correlation_time>
 		      </noise>
 		    </y>
 		    <z>
 		      <noise type="gaussian">
 		        <mean>0</mean>
-		        <stddev>8.72664e-5</stddev>
-		        <bias_mean>7.5e-6</bias_mean>
-		        <bias_stddev>8.0e-7</bias_stddev>
-		        <dynamic_bias_stddev>4e-7</dynamic_bias_stddev>
+            <stddev>0.0000872664</stddev>
+            <bias_mean>0.0000075</bias_mean>
+            <bias_stddev>0.00000080</bias_stddev>
+            <dynamic_bias_stddev>0.0000004</dynamic_bias_stddev>
 		        <dynamic_bias_correlation_time>1000.0</dynamic_bias_correlation_time>
 		      </noise>
 		    </z>
@@ -236,30 +236,30 @@
 		    <x>
 		      <noise type="gaussian">
 		        <mean>0</mean>
-		        <stddev>1.962e-4</stddev>
-		        <bias_mean>1.0e-3</bias_mean>
-		        <bias_stddev>1.0-4</bias_stddev>
-		        <dynamic_bias_stddev>1.0e-3</dynamic_bias_stddev>
+            <stddev>0.0001962</stddev>
+            <bias_mean>0.001</bias_mean>
+            <bias_stddev>0.0001</bias_stddev>
+            <dynamic_bias_stddev>0.001</dynamic_bias_stddev>
 		        <dynamic_bias_correlation_time>300.0</dynamic_bias_correlation_time>
 		      </noise>
 		    </x>
 		    <y>
 		      <noise type="gaussian">
 		        <mean>0</mean>
-		        <stddev>1.962e-4</stddev>
-		        <bias_mean>1.0e-3</bias_mean>
-		        <bias_stddev>1.0-4</bias_stddev>
-		        <dynamic_bias_stddev>1.0e-3</dynamic_bias_stddev>
+            <stddev>0.0001962</stddev>
+            <bias_mean>0.001</bias_mean>
+            <bias_stddev>0.0001</bias_stddev>
+            <dynamic_bias_stddev>0.001</dynamic_bias_stddev>
 		        <dynamic_bias_correlation_time>300.0</dynamic_bias_correlation_time>
 		      </noise>
 		    </y>
 		    <z>
 		      <noise type="gaussian">
 		        <mean>0</mean>
-		        <stddev>1.962e-4</stddev>
-		        <bias_mean>1.0e-3</bias_mean>
-		        <bias_stddev>1.0-4</bias_stddev>
-		        <dynamic_bias_stddev>1.0e-3</dynamic_bias_stddev>
+            <stddev>0.0001962</stddev>
+            <bias_mean>0.001</bias_mean>
+            <bias_stddev>0.0001</bias_stddev>
+            <dynamic_bias_stddev>0.001</dynamic_bias_stddev>
 		        <dynamic_bias_correlation_time>300.0</dynamic_bias_correlation_time>
 		      </noise>
 		    </z>


### PR DESCRIPTION
Remove scientific notation of parameters in IMU settings in model.sdf (causes strange values from IMU is scientific notation is used).  This is for marble qav500.  Same change was done in separate PRs for hd2 and husky.  