### PR TITLE
Reduce /<robot_name>/pose topic bandwidth

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,3 @@
 # DARPA SubT Virtual Competition Software
 
-Please visit the [wiki](https://bitbucket.org/osrf/subt/wiki/Home) for more information
+Please visit the [wiki](https://github.com/osrf/subt/wiki) for more information

--- a/ign_migration_scripts/launch/preview.ign
+++ b/ign_migration_scripts/launch/preview.ign
@@ -210,6 +210,9 @@
             <publish_collision_pose>false</publish_collision_pose>
             <publish_visual_pose>false</publish_visual_pose>
             <publish_nested_model_pose>#{$enableGroundTruth}</publish_nested_model_pose>
+            <use_pose_vector_msg>true</use_pose_vector_msg>
+            <static_pose_publisher>true</static_pose_publisher>
+            <static_pose_update_frequency>1</static_pose_update_frequency>
           </plugin>
           <!-- Battery plugin -->
         </include>
@@ -256,6 +259,9 @@
             <publish_collision_pose>false</publish_collision_pose>
             <publish_visual_pose>false</publish_visual_pose>
             <publish_nested_model_pose>#{$enableGroundTruth}</publish_nested_model_pose>
+            <use_pose_vector_msg>true</use_pose_vector_msg>
+            <static_pose_publisher>true</static_pose_publisher>
+            <static_pose_update_frequency>1</static_pose_update_frequency>
           </plugin>
           <plugin filename="libignition-gazebo-multicopter-motor-model-system.so"
             name="ignition::gazebo::systems::MulticopterMotorModel">

--- a/ign_migration_scripts/scripts/spawn_preview_model.py
+++ b/ign_migration_scripts/scripts/spawn_preview_model.py
@@ -74,6 +74,9 @@ def spawn_preview_model(args):
     etree.SubElement(plugin, 'publish_collision_pose').text = 'false'
     etree.SubElement(plugin, 'publish_visual_pose').text = 'false'
     etree.SubElement(plugin, 'publish_nested_model_pose').text = 'true'
+    etree.SubElement(plugin, 'use_pose_vector_msg').text = 'true'
+    etree.SubElement(plugin, 'static_pose_publisher').text = 'true'
+    etree.SubElement(plugin, 'static_pose_update_frequency').text = '1'
 
     sdf_esc = etree.tostring(sdf, encoding="unicode",
                              with_tail=False).replace('"', r'\"').replace('\n', '')

--- a/submitted_models/costar_husky_sensor_config_1/launch/spawner.rb
+++ b/submitted_models/costar_husky_sensor_config_1/launch/spawner.rb
@@ -30,6 +30,9 @@ def spawner(_name, _modelURI, _worldName, _x, _y, _z, _roll, _pitch, _yaw)
         <publish_collision_pose>false</publish_collision_pose>
         <publish_visual_pose>false</publish_visual_pose>
         <publish_nested_model_pose>#{$enableGroundTruth}</publish_nested_model_pose>
+        <use_pose_vector_msg>true</use_pose_vector_msg>
+        <static_pose_publisher>true</static_pose_publisher>
+        <static_pose_update_frequency>1</static_pose_update_frequency>
       </plugin>
       <!-- Battery plugin -->
       <plugin filename="libignition-gazebo-linearbatteryplugin-system.so"

--- a/submitted_models/costar_husky_sensor_config_1/launch/vehicle_topics.launch
+++ b/submitted_models/costar_husky_sensor_config_1/launch/vehicle_topics.launch
@@ -10,8 +10,15 @@
       pkg="ros_ign_bridge"
       type="parameter_bridge"
       name="ros_ign_bridge_pose"
-      args="/model/$(arg name)/pose@geometry_msgs/TransformStamped[ignition.msgs.Pose">
+      args="/model/$(arg name)/pose@tf2_msgs/TFMessage[ignition.msgs.Pose_V">
       <remap from="/model/$(arg name)/pose" to="pose"/>
+    </node>
+    <node
+      pkg="ros_ign_bridge"
+      type="parameter_bridge"
+      name="ros_ign_bridge_pose_static"
+      args="/model/$(arg name)/pose_static@tf2_msgs/TFMessage[ignition.msgs.Pose_V">
+      <remap from="/model/$(arg name)/pose_static" to="pose_static"/>
     </node>
 
     <node

--- a/submitted_models/explorer_x1_sensor_config_1/launch/spawner.rb
+++ b/submitted_models/explorer_x1_sensor_config_1/launch/spawner.rb
@@ -30,6 +30,9 @@ def spawner(_name, _modelURI, _worldName, _x, _y, _z, _roll, _pitch, _yaw)
         <publish_collision_pose>false</publish_collision_pose>
         <publish_visual_pose>false</publish_visual_pose>
         <publish_nested_model_pose>#{$enableGroundTruth}</publish_nested_model_pose>
+        <use_pose_vector_msg>true</use_pose_vector_msg>
+        <static_pose_publisher>true</static_pose_publisher>
+        <static_pose_update_frequency>1</static_pose_update_frequency>
       </plugin>
       <!-- Battery plugin -->
       <plugin filename="libignition-gazebo-linearbatteryplugin-system.so"

--- a/submitted_models/explorer_x1_sensor_config_1/launch/vehicle_topics.launch
+++ b/submitted_models/explorer_x1_sensor_config_1/launch/vehicle_topics.launch
@@ -10,10 +10,16 @@
       pkg="ros_ign_bridge"
       type="parameter_bridge"
       name="ros_ign_bridge_pose"
-      args="/model/$(arg name)/pose@geometry_msgs/TransformStamped[ignition.msgs.Pose">
+      args="/model/$(arg name)/pose@tf2_msgs/TFMessage[ignition.msgs.Pose_V">
       <remap from="/model/$(arg name)/pose" to="pose"/>
     </node>
-
+    <node
+      pkg="ros_ign_bridge"
+      type="parameter_bridge"
+      name="ros_ign_bridge_pose_static"
+      args="/model/$(arg name)/pose_static@tf2_msgs/TFMessage[ignition.msgs.Pose_V">
+      <remap from="/model/$(arg name)/pose_static" to="pose_static"/>
+    </node>
     <node
       pkg="subt_ros"
       type="pose_tf_broadcaster"

--- a/submitted_models/robotika_x2_sensor_config_1/launch/spawner.rb
+++ b/submitted_models/robotika_x2_sensor_config_1/launch/spawner.rb
@@ -29,6 +29,9 @@ def spawner(_name, _modelURI, _worldName, _x, _y, _z, _roll, _pitch, _yaw)
   "      <publish_collision_pose>false</publish_collision_pose>\n"\
   "      <publish_visual_pose>false</publish_visual_pose>\n"\
   "      <publish_nested_model_pose>#{$enableGroundTruth}</publish_nested_model_pose>\n"\
+  "      <use_pose_vector_msg>true</use_pose_vector_msg>\n"\
+  "      <static_pose_publisher>true</static_pose_publisher>\n"\
+  "      <static_pose_update_frequency>1</static_pose_update_frequency>\n"\
   "    </plugin>\n"\
   "    <!-- Battery plugin -->\n"\
   "    <plugin filename=\"libignition-gazebo-linearbatteryplugin-system.so\"\n"\

--- a/submitted_models/robotika_x2_sensor_config_1/launch/vehicle_topics.launch
+++ b/submitted_models/robotika_x2_sensor_config_1/launch/vehicle_topics.launch
@@ -24,8 +24,15 @@
       pkg="ros_ign_bridge"
       type="parameter_bridge"
       name="ros_ign_bridge_pose"
-      args="/model/$(arg name)/pose@geometry_msgs/TransformStamped[ignition.msgs.Pose">
+      args="/model/$(arg name)/pose@tf2_msgs/TFMessage[ignition.msgs.Pose_V">
       <remap from="/model/$(arg name)/pose" to="pose"/>
+    </node>
+    <node
+      pkg="ros_ign_bridge"
+      type="parameter_bridge"
+      name="ros_ign_bridge_pose_static"
+      args="/model/$(arg name)/pose_static@tf2_msgs/TFMessage[ignition.msgs.Pose_V">
+      <remap from="/model/$(arg name)/pose_static" to="pose_static"/>
     </node>
     <node
       pkg="ros_ign_bridge"

--- a/submitted_models/sophisticated_engineering_x2_sensor_config_1/launch/spawner.rb
+++ b/submitted_models/sophisticated_engineering_x2_sensor_config_1/launch/spawner.rb
@@ -32,6 +32,9 @@ def spawner(_name, _modelURI, _worldName, _x, _y, _z, _roll, _pitch, _yaw)
         <publish_collision_pose>false</publish_collision_pose>
         <publish_visual_pose>false</publish_visual_pose>
         <publish_nested_model_pose>#{$enableGroundTruth}</publish_nested_model_pose>
+        <use_pose_vector_msg>true</use_pose_vector_msg>
+        <static_pose_publisher>true</static_pose_publisher>
+        <static_pose_update_frequency>1</static_pose_update_frequency>
       </plugin>
       <!-- Battery plugin -->
       <plugin filename="libignition-gazebo-linearbatteryplugin-system.so"

--- a/submitted_models/sophisticated_engineering_x2_sensor_config_1/launch/vehicle_topics.launch
+++ b/submitted_models/sophisticated_engineering_x2_sensor_config_1/launch/vehicle_topics.launch
@@ -18,8 +18,15 @@
       pkg="ros_ign_bridge"
       type="parameter_bridge"
       name="ros_ign_bridge_pose"
-      args="/model/$(arg name)/pose@geometry_msgs/TransformStamped[ignition.msgs.Pose">
+      args="/model/$(arg name)/pose@tf2_msgs/TFMessage[ignition.msgs.Pose_V">
       <remap from="/model/$(arg name)/pose" to="pose"/>
+    </node>
+    <node
+      pkg="ros_ign_bridge"
+      type="parameter_bridge"
+      name="ros_ign_bridge_pose_static"
+      args="/model/$(arg name)/pose_static@tf2_msgs/TFMessage[ignition.msgs.Pose_V">
+      <remap from="/model/$(arg name)/pose_static" to="pose_static"/>
     </node>
     <node
       pkg="ros_ign_bridge"

--- a/submitted_models/sophisticated_engineering_x4_sensor_config_1/launch/spawner.rb
+++ b/submitted_models/sophisticated_engineering_x4_sensor_config_1/launch/spawner.rb
@@ -21,6 +21,9 @@ def spawner(_name, _modelURI, _worldName, _x, _y, _z, _roll, _pitch, _yaw)
         <publish_collision_pose>false</publish_collision_pose>
         <publish_visual_pose>false</publish_visual_pose>
         <publish_nested_model_pose>#{$enableGroundTruth}</publish_nested_model_pose>
+        <use_pose_vector_msg>true</use_pose_vector_msg>
+        <static_pose_publisher>true</static_pose_publisher>
+        <static_pose_update_frequency>1</static_pose_update_frequency>
       </plugin>
       <plugin filename="libignition-gazebo-multicopter-motor-model-system.so"
         name="ignition::gazebo::systems::MulticopterMotorModel">

--- a/submitted_models/sophisticated_engineering_x4_sensor_config_1/launch/vehicle_topics.launch
+++ b/submitted_models/sophisticated_engineering_x4_sensor_config_1/launch/vehicle_topics.launch
@@ -18,8 +18,15 @@
       pkg="ros_ign_bridge"
       type="parameter_bridge"
       name="ros_ign_bridge_pose"
-      args="/model/$(arg name)/pose@geometry_msgs/TransformStamped[ignition.msgs.Pose">
+      args="/model/$(arg name)/pose@tf2_msgs/TFMessage[ignition.msgs.Pose_V">
       <remap from="/model/$(arg name)/pose" to="pose"/>
+    </node>
+    <node
+      pkg="ros_ign_bridge"
+      type="parameter_bridge"
+      name="ros_ign_bridge_pose_static"
+      args="/model/$(arg name)/pose_static@tf2_msgs/TFMessage[ignition.msgs.Pose_V">
+      <remap from="/model/$(arg name)/pose_static" to="pose_static"/>
     </node>
     <node
       pkg="ros_ign_bridge"

--- a/submitted_models/ssci_x2_sensor_config_1/launch/spawner.rb
+++ b/submitted_models/ssci_x2_sensor_config_1/launch/spawner.rb
@@ -44,6 +44,9 @@ def spawner(_name, _modelURI, _worldName, _x, _y, _z, _roll, _pitch, _yaw)
           <publish_collision_pose>false</publish_collision_pose>
           <publish_visual_pose>false</publish_visual_pose>
           <publish_nested_model_pose>#{$enableGroundTruth}</publish_nested_model_pose>
+          <use_pose_vector_msg>true</use_pose_vector_msg>
+          <static_pose_publisher>true</static_pose_publisher>
+          <static_pose_update_frequency>1</static_pose_update_frequency>
         </plugin>
         <!-- Battery plugin -->
         <plugin filename=\"libignition-gazebo-linearbatteryplugin-system.so\"

--- a/submitted_models/ssci_x2_sensor_config_1/launch/vehicle_topics.launch
+++ b/submitted_models/ssci_x2_sensor_config_1/launch/vehicle_topics.launch
@@ -36,8 +36,15 @@
       pkg="ros_ign_bridge"
       type="parameter_bridge"
       name="ros_ign_bridge_pose"
-      args="/model/$(arg name)/pose@geometry_msgs/TransformStamped[ignition.msgs.Pose">
+      args="/model/$(arg name)/pose@tf2_msgs/TFMessage[ignition.msgs.Pose_V">
       <remap from="/model/$(arg name)/pose" to="pose"/>
+    </node>
+    <node
+      pkg="ros_ign_bridge"
+      type="parameter_bridge"
+      name="ros_ign_bridge_pose_static"
+      args="/model/$(arg name)/pose_static@tf2_msgs/TFMessage[ignition.msgs.Pose_V">
+      <remap from="/model/$(arg name)/pose_static" to="pose_static"/>
     </node>
     <node
       pkg="ros_ign_bridge"

--- a/submitted_models/ssci_x4_sensor_config_1/launch/spawner.rb
+++ b/submitted_models/ssci_x4_sensor_config_1/launch/spawner.rb
@@ -43,6 +43,9 @@ def spawner(_name, _modelURI, _worldName, _x, _y, _z, _roll, _pitch, _yaw)
           <publish_collision_pose>false</publish_collision_pose>
           <publish_visual_pose>false</publish_visual_pose>
           <publish_nested_model_pose>#{$enableGroundTruth}</publish_nested_model_pose>
+          <use_pose_vector_msg>true</use_pose_vector_msg>
+          <static_pose_publisher>true</static_pose_publisher>
+          <static_pose_update_frequency>1</static_pose_update_frequency>
         </plugin>
         <plugin filename="libignition-gazebo-multicopter-motor-model-system.so"
           name="ignition::gazebo::systems::MulticopterMotorModel">

--- a/submitted_models/ssci_x4_sensor_config_1/launch/vehicle_topics.launch
+++ b/submitted_models/ssci_x4_sensor_config_1/launch/vehicle_topics.launch
@@ -34,8 +34,15 @@
       pkg="ros_ign_bridge"
       type="parameter_bridge"
       name="ros_ign_bridge_pose"
-      args="/model/$(arg name)/pose@geometry_msgs/TransformStamped[ignition.msgs.Pose">
+      args="/model/$(arg name)/pose@tf2_msgs/TFMessage[ignition.msgs.Pose_V">
       <remap from="/model/$(arg name)/pose" to="pose"/>
+    </node>
+    <node
+      pkg="ros_ign_bridge"
+      type="parameter_bridge"
+      name="ros_ign_bridge_pose_static"
+      args="/model/$(arg name)/pose_static@tf2_msgs/TFMessage[ignition.msgs.Pose_V">
+      <remap from="/model/$(arg name)/pose_static" to="pose_static"/>
     </node>
     <node
       pkg="ros_ign_bridge"

--- a/submitted_models/ssci_x4_sensor_config_2/launch/spawner.rb
+++ b/submitted_models/ssci_x4_sensor_config_2/launch/spawner.rb
@@ -38,6 +38,9 @@ def spawner(_name, _modelURI, _worldName, _x, _y, _z, _roll, _pitch, _yaw)
           <publish_collision_pose>false</publish_collision_pose>
           <publish_visual_pose>false</publish_visual_pose>
           <publish_nested_model_pose>#{$enableGroundTruth}</publish_nested_model_pose>
+          <use_pose_vector_msg>true</use_pose_vector_msg>
+          <static_pose_publisher>true</static_pose_publisher>
+          <static_pose_update_frequency>1</static_pose_update_frequency>
         </plugin>
         <plugin filename="libignition-gazebo-multicopter-motor-model-system.so"
           name="ignition::gazebo::systems::MulticopterMotorModel">

--- a/submitted_models/ssci_x4_sensor_config_2/launch/vehicle_topics.launch
+++ b/submitted_models/ssci_x4_sensor_config_2/launch/vehicle_topics.launch
@@ -34,8 +34,15 @@
       pkg="ros_ign_bridge"
       type="parameter_bridge"
       name="ros_ign_bridge_pose"
-      args="/model/$(arg name)/pose@geometry_msgs/TransformStamped[ignition.msgs.Pose">
+      args="/model/$(arg name)/pose@tf2_msgs/TFMessage[ignition.msgs.Pose_V">
       <remap from="/model/$(arg name)/pose" to="pose"/>
+    </node>
+    <node
+      pkg="ros_ign_bridge"
+      type="parameter_bridge"
+      name="ros_ign_bridge_pose_static"
+      args="/model/$(arg name)/pose_static@tf2_msgs/TFMessage[ignition.msgs.Pose_V">
+      <remap from="/model/$(arg name)/pose_static" to="pose_static"/>
     </node>
     <node
       pkg="ros_ign_bridge"

--- a/submitted_models/x1_sensor_config_6/launch/spawner.rb
+++ b/submitted_models/x1_sensor_config_6/launch/spawner.rb
@@ -30,6 +30,9 @@ def spawner(_name, _modelURI, _worldName, _x, _y, _z, _roll, _pitch, _yaw)
         <publish_collision_pose>false</publish_collision_pose>
         <publish_visual_pose>false</publish_visual_pose>
         <publish_nested_model_pose>#{$enableGroundTruth}</publish_nested_model_pose>
+        <use_pose_vector_msg>true</use_pose_vector_msg>
+        <static_pose_publisher>true</static_pose_publisher>
+        <static_pose_update_frequency>1</static_pose_update_frequency>
       </plugin>
       <!-- Battery plugin -->
       <plugin filename="libignition-gazebo-linearbatteryplugin-system.so"

--- a/submitted_models/x1_sensor_config_6/launch/vehicle_topics.launch
+++ b/submitted_models/x1_sensor_config_6/launch/vehicle_topics.launch
@@ -56,8 +56,15 @@
       pkg="ros_ign_bridge"
       type="parameter_bridge"
       name="ros_ign_bridge_pose"
-      args="/model/$(arg name)/pose@geometry_msgs/TransformStamped[ignition.msgs.Pose">
+      args="/model/$(arg name)/pose@tf2_msgs/TFMessage[ignition.msgs.Pose_V">
       <remap from="/model/$(arg name)/pose" to="pose"/>
+    </node>
+    <node
+      pkg="ros_ign_bridge"
+      type="parameter_bridge"
+      name="ros_ign_bridge_pose_static"
+      args="/model/$(arg name)/pose_static@tf2_msgs/TFMessage[ignition.msgs.Pose_V">
+      <remap from="/model/$(arg name)/pose_static" to="pose_static"/>
     </node>
     <node
       pkg="ros_ign_bridge"

--- a/submitted_models/x2_sensor_config_7/launch/spawner.rb
+++ b/submitted_models/x2_sensor_config_7/launch/spawner.rb
@@ -30,6 +30,9 @@ def spawner(_name, _modelURI, _worldName, _x, _y, _z, _roll, _pitch, _yaw)
         <publish_collision_pose>false</publish_collision_pose>
         <publish_visual_pose>false</publish_visual_pose>
         <publish_nested_model_pose>#{$enableGroundTruth}</publish_nested_model_pose>
+        <use_pose_vector_msg>true</use_pose_vector_msg>
+        <static_pose_publisher>true</static_pose_publisher>
+        <static_pose_update_frequency>1</static_pose_update_frequency>
       </plugin>
       <!-- Battery plugin -->
       <plugin filename="libignition-gazebo-linearbatteryplugin-system.so"

--- a/submitted_models/x2_sensor_config_7/launch/vehicle_topics.launch
+++ b/submitted_models/x2_sensor_config_7/launch/vehicle_topics.launch
@@ -56,8 +56,15 @@
       pkg="ros_ign_bridge"
       type="parameter_bridge"
       name="ros_ign_bridge_pose"
-      args="/model/$(arg name)/pose@geometry_msgs/TransformStamped[ignition.msgs.Pose">
+      args="/model/$(arg name)/pose@tf2_msgs/TFMessage[ignition.msgs.Pose_V">
       <remap from="/model/$(arg name)/pose" to="pose"/>
+    </node>
+    <node
+      pkg="ros_ign_bridge"
+      type="parameter_bridge"
+      name="ros_ign_bridge_pose_static"
+      args="/model/$(arg name)/pose_static@tf2_msgs/TFMessage[ignition.msgs.Pose_V">
+      <remap from="/model/$(arg name)/pose_static" to="pose_static"/>
     </node>
     <node
       pkg="ros_ign_bridge"

--- a/submitted_models/x3_sensor_config_5/launch/spawner.rb
+++ b/submitted_models/x3_sensor_config_5/launch/spawner.rb
@@ -19,6 +19,9 @@ def spawner(_name, _modelURI, _worldName, _x, _y, _z, _roll, _pitch, _yaw)
         <publish_collision_pose>false</publish_collision_pose>
         <publish_visual_pose>false</publish_visual_pose>
         <publish_nested_model_pose>#{$enableGroundTruth}</publish_nested_model_pose>
+        <use_pose_vector_msg>true</use_pose_vector_msg>
+        <static_pose_publisher>true</static_pose_publisher>
+        <static_pose_update_frequency>1</static_pose_update_frequency>
       </plugin>
       <plugin filename="libignition-gazebo-multicopter-motor-model-system.so"
         name="ignition::gazebo::systems::MulticopterMotorModel">

--- a/submitted_models/x3_sensor_config_5/launch/vehicle_topics.launch
+++ b/submitted_models/x3_sensor_config_5/launch/vehicle_topics.launch
@@ -24,8 +24,15 @@
       pkg="ros_ign_bridge"
       type="parameter_bridge"
       name="ros_ign_bridge_pose"
-      args="/model/$(arg name)/pose@geometry_msgs/TransformStamped[ignition.msgs.Pose">
+      args="/model/$(arg name)/pose@tf2_msgs/TFMessage[ignition.msgs.Pose_V">
       <remap from="/model/$(arg name)/pose" to="pose"/>
+    </node>
+    <node
+      pkg="ros_ign_bridge"
+      type="parameter_bridge"
+      name="ros_ign_bridge_pose_static"
+      args="/model/$(arg name)/pose_static@tf2_msgs/TFMessage[ignition.msgs.Pose_V">
+      <remap from="/model/$(arg name)/pose_static" to="pose_static"/>
     </node>
     <node
       pkg="ros_ign_bridge"

--- a/submitted_models/x4_sensor_config_6/launch/spawner.rb
+++ b/submitted_models/x4_sensor_config_6/launch/spawner.rb
@@ -19,6 +19,9 @@ def spawner(_name, _modelURI, _worldName, _x, _y, _z, _roll, _pitch, _yaw)
           <publish_collision_pose>false</publish_collision_pose>
           <publish_visual_pose>false</publish_visual_pose>
           <publish_nested_model_pose>#{$enableGroundTruth}</publish_nested_model_pose>
+          <use_pose_vector_msg>true</use_pose_vector_msg>
+          <static_pose_publisher>true</static_pose_publisher>
+          <static_pose_update_frequency>1</static_pose_update_frequency>
         </plugin>
         <plugin filename="libignition-gazebo-multicopter-motor-model-system.so"
           name="ignition::gazebo::systems::MulticopterMotorModel">

--- a/submitted_models/x4_sensor_config_6/launch/vehicle_topics.launch
+++ b/submitted_models/x4_sensor_config_6/launch/vehicle_topics.launch
@@ -24,8 +24,15 @@
       pkg="ros_ign_bridge"
       type="parameter_bridge"
       name="ros_ign_bridge_pose"
-      args="/model/$(arg name)/pose@geometry_msgs/TransformStamped[ignition.msgs.Pose">
+      args="/model/$(arg name)/pose@tf2_msgs/TFMessage[ignition.msgs.Pose_V">
       <remap from="/model/$(arg name)/pose" to="pose"/>
+    </node>
+    <node
+      pkg="ros_ign_bridge"
+      type="parameter_bridge"
+      name="ros_ign_bridge_pose_static"
+      args="/model/$(arg name)/pose_static@tf2_msgs/TFMessage[ignition.msgs.Pose_V">
+      <remap from="/model/$(arg name)/pose_static" to="pose_static"/>
     </node>
     <node
       pkg="ros_ign_bridge"

--- a/subt_ign/launch/cave_circuit.ign
+++ b/subt_ign/launch/cave_circuit.ign
@@ -452,6 +452,9 @@
     "      <publish_collision_pose>false</publish_collision_pose>\n"\
     "      <publish_visual_pose>false</publish_visual_pose>\n"\
     "      <publish_nested_model_pose>#{$enableGroundTruth}</publish_nested_model_pose>\n"\
+    "      <use_pose_vector_msg>true</use_pose_vector_msg>\n"\
+    "      <static_pose_publisher>true</static_pose_publisher>\n"\
+    "      <static_pose_update_frequency>1</static_pose_update_frequency>\n"\
     "    </plugin>\n"\
     "    <!-- Battery plugin -->\n"\
     "    <plugin filename=\"libignition-gazebo-linearbatteryplugin-system.so\"\n"\
@@ -532,6 +535,9 @@
     "      <publish_collision_pose>false</publish_collision_pose>\n"\
     "      <publish_visual_pose>false</publish_visual_pose>\n"\
     "      <publish_nested_model_pose>#{$enableGroundTruth}</publish_nested_model_pose>\n"\
+    "      <use_pose_vector_msg>true</use_pose_vector_msg>\n"\
+    "      <static_pose_publisher>true</static_pose_publisher>\n"\
+    "      <static_pose_update_frequency>1</static_pose_update_frequency>\n"\
     "    </plugin>\n"\
     "    <!-- Battery plugin -->\n"\
     "    <plugin filename=\"libignition-gazebo-linearbatteryplugin-system.so\"\n"\
@@ -598,6 +604,9 @@
     "      <publish_collision_pose>false</publish_collision_pose>\n"\
     "      <publish_visual_pose>false</publish_visual_pose>\n"\
     "      <publish_nested_model_pose>#{$enableGroundTruth}</publish_nested_model_pose>\n"\
+    "      <use_pose_vector_msg>true</use_pose_vector_msg>\n"\
+    "      <static_pose_publisher>true</static_pose_publisher>\n"\
+    "      <static_pose_update_frequency>1</static_pose_update_frequency>\n"\
     "    </plugin>\n"\
     "    <plugin filename=\"libignition-gazebo-multicopter-motor-model-system.so\"\n"\
     "      name=\"ignition::gazebo::systems::MulticopterMotorModel\">\n"\
@@ -794,6 +803,9 @@
     "      <publish_collision_pose>false</publish_collision_pose>\n"\
     "      <publish_visual_pose>false</publish_visual_pose>\n"\
     "      <publish_nested_model_pose>#{$enableGroundTruth}</publish_nested_model_pose>\n"\
+    "      <use_pose_vector_msg>true</use_pose_vector_msg>\n"\
+    "      <static_pose_publisher>true</static_pose_publisher>\n"\
+    "      <static_pose_update_frequency>1</static_pose_update_frequency>\n"\
     "    </plugin>\n"\
     "    <plugin filename=\"libignition-gazebo-multicopter-motor-model-system.so\"\n"\
     "      name=\"ignition::gazebo::systems::MulticopterMotorModel\">\n"\

--- a/subt_ign/launch/cloudsim_sim.ign
+++ b/subt_ign/launch/cloudsim_sim.ign
@@ -518,6 +518,9 @@
     "      <publish_collision_pose>false</publish_collision_pose>\n"\
     "      <publish_visual_pose>false</publish_visual_pose>\n"\
     "      <publish_nested_model_pose>#{$enableGroundTruth}</publish_nested_model_pose>\n"\
+    "      <use_pose_vector_msg>true</use_pose_vector_msg>\n"\
+    "      <static_pose_publisher>true</static_pose_publisher>\n"\
+    "      <static_pose_update_frequency>1</static_pose_update_frequency>\n"\
     "    </plugin>\n"\
     "    <!-- Battery plugin -->\n"\
     "    <plugin filename=\"libignition-gazebo-linearbatteryplugin-system.so\"\n"\
@@ -577,6 +580,9 @@
     "      <publish_collision_pose>false</publish_collision_pose>\n"\
     "      <publish_visual_pose>false</publish_visual_pose>\n"\
     "      <publish_nested_model_pose>#{$enableGroundTruth}</publish_nested_model_pose>\n"\
+    "      <use_pose_vector_msg>true</use_pose_vector_msg>\n"\
+    "      <static_pose_publisher>true</static_pose_publisher>\n"\
+    "      <static_pose_update_frequency>1</static_pose_update_frequency>\n"\
     "    </plugin>\n"\
     "    <!-- Battery plugin -->\n"\
     "    <plugin filename=\"libignition-gazebo-linearbatteryplugin-system.so\"\n"\
@@ -625,6 +631,9 @@
     "      <publish_collision_pose>false</publish_collision_pose>\n"\
     "      <publish_visual_pose>false</publish_visual_pose>\n"\
     "      <publish_nested_model_pose>#{$enableGroundTruth}</publish_nested_model_pose>\n"\
+    "      <use_pose_vector_msg>true</use_pose_vector_msg>\n"\
+    "      <static_pose_publisher>true</static_pose_publisher>\n"\
+    "      <static_pose_update_frequency>1</static_pose_update_frequency>\n"\
     "    </plugin>\n"\
     "    <plugin filename=\"libignition-gazebo-multicopter-motor-model-system.so\"\n"\
     "      name=\"ignition::gazebo::systems::MulticopterMotorModel\">\n"\
@@ -800,6 +809,9 @@
     "      <publish_collision_pose>false</publish_collision_pose>\n"\
     "      <publish_visual_pose>false</publish_visual_pose>\n"\
     "      <publish_nested_model_pose>#{$enableGroundTruth}</publish_nested_model_pose>\n"\
+    "      <use_pose_vector_msg>true</use_pose_vector_msg>\n"\
+    "      <static_pose_publisher>true</static_pose_publisher>\n"\
+    "      <static_pose_update_frequency>1</static_pose_update_frequency>\n"\
     "    </plugin>\n"\
     "    <plugin filename=\"libignition-gazebo-multicopter-motor-model-system.so\"\n"\
     "      name=\"ignition::gazebo::systems::MulticopterMotorModel\">\n"\

--- a/subt_ign/launch/competition.ign
+++ b/subt_ign/launch/competition.ign
@@ -432,6 +432,9 @@
     "      <publish_collision_pose>false</publish_collision_pose>\n"\
     "      <publish_visual_pose>false</publish_visual_pose>\n"\
     "      <publish_nested_model_pose>#{$enableGroundTruth}</publish_nested_model_pose>\n"\
+    "      <use_pose_vector_msg>true</use_pose_vector_msg>\n"\
+    "      <static_pose_publisher>true</static_pose_publisher>\n"\
+    "      <static_pose_update_frequency>1</static_pose_update_frequency>\n"\
     "    </plugin>\n"\
     "    <!-- Battery plugin -->\n"\
     "    <plugin filename=\"libignition-gazebo-linearbatteryplugin-system.so\"\n"\
@@ -502,6 +505,9 @@
     "      <publish_collision_pose>false</publish_collision_pose>\n"\
     "      <publish_visual_pose>false</publish_visual_pose>\n"\
     "      <publish_nested_model_pose>#{$enableGroundTruth}</publish_nested_model_pose>\n"\
+    "      <use_pose_vector_msg>true</use_pose_vector_msg>\n"\
+    "      <static_pose_publisher>true</static_pose_publisher>\n"\
+    "      <static_pose_update_frequency>1</static_pose_update_frequency>\n"\
     "    </plugin>\n"\
     "    <!-- Battery plugin -->\n"\
     "    <plugin filename=\"libignition-gazebo-linearbatteryplugin-system.so\"\n"\
@@ -558,6 +564,9 @@
     "      <publish_collision_pose>false</publish_collision_pose>\n"\
     "      <publish_visual_pose>false</publish_visual_pose>\n"\
     "      <publish_nested_model_pose>#{$enableGroundTruth}</publish_nested_model_pose>\n"\
+    "      <use_pose_vector_msg>true</use_pose_vector_msg>\n"\
+    "      <static_pose_publisher>true</static_pose_publisher>\n"\
+    "      <static_pose_update_frequency>1</static_pose_update_frequency>\n"\
     "    </plugin>\n"\
     "    <plugin filename=\"libignition-gazebo-multicopter-motor-model-system.so\"\n"\
     "      name=\"ignition::gazebo::systems::MulticopterMotorModel\">\n"\
@@ -744,6 +753,9 @@
     "      <publish_collision_pose>false</publish_collision_pose>\n"\
     "      <publish_visual_pose>false</publish_visual_pose>\n"\
     "      <publish_nested_model_pose>#{$enableGroundTruth}</publish_nested_model_pose>\n"\
+    "      <use_pose_vector_msg>true</use_pose_vector_msg>\n"\
+    "      <static_pose_publisher>true</static_pose_publisher>\n"\
+    "      <static_pose_update_frequency>1</static_pose_update_frequency>\n"\
     "    </plugin>\n"\
     "    <plugin filename=\"libignition-gazebo-multicopter-motor-model-system.so\"\n"\
     "      name=\"ignition::gazebo::systems::MulticopterMotorModel\">\n"\

--- a/subt_ign/launch/competition_no_ros.ign
+++ b/subt_ign/launch/competition_no_ros.ign
@@ -431,6 +431,9 @@
     "      <publish_collision_pose>false</publish_collision_pose>\n"\
     "      <publish_visual_pose>false</publish_visual_pose>\n"\
     "      <publish_nested_model_pose>#{$enableGroundTruth}</publish_nested_model_pose>\n"\
+    "      <use_pose_vector_msg>true</use_pose_vector_msg>\n"\
+    "      <static_pose_publisher>true</static_pose_publisher>\n"\
+    "      <static_pose_update_frequency>1</static_pose_update_frequency>\n"\
     "    </plugin>\n"\
     "    <!-- Battery plugin -->\n"\
     "    <plugin filename=\"libignition-gazebo-linearbatteryplugin-system.so\"\n"\
@@ -495,6 +498,9 @@
     "      <publish_collision_pose>false</publish_collision_pose>\n"\
     "      <publish_visual_pose>false</publish_visual_pose>\n"\
     "      <publish_nested_model_pose>#{$enableGroundTruth}</publish_nested_model_pose>\n"\
+    "      <use_pose_vector_msg>true</use_pose_vector_msg>\n"\
+    "      <static_pose_publisher>true</static_pose_publisher>\n"\
+    "      <static_pose_update_frequency>1</static_pose_update_frequency>\n"\
     "    </plugin>\n"\
     "    <!-- Battery plugin -->\n"\
     "    <plugin filename=\"libignition-gazebo-linearbatteryplugin-system.so\"\n"\
@@ -545,6 +551,9 @@
     "      <publish_collision_pose>false</publish_collision_pose>\n"\
     "      <publish_visual_pose>false</publish_visual_pose>\n"\
     "      <publish_nested_model_pose>#{$enableGroundTruth}</publish_nested_model_pose>\n"\
+    "      <use_pose_vector_msg>true</use_pose_vector_msg>\n"\
+    "      <static_pose_publisher>true</static_pose_publisher>\n"\
+    "      <static_pose_update_frequency>1</static_pose_update_frequency>\n"\
     "    </plugin>\n"\
     "    <plugin filename=\"libignition-gazebo-multicopter-motor-model-system.so\"\n"\
     "      name=\"ignition::gazebo::systems::MulticopterMotorModel\">\n"\
@@ -725,6 +734,9 @@
     "      <publish_collision_pose>false</publish_collision_pose>\n"\
     "      <publish_visual_pose>false</publish_visual_pose>\n"\
     "      <publish_nested_model_pose>#{$enableGroundTruth}</publish_nested_model_pose>\n"\
+    "      <use_pose_vector_msg>true</use_pose_vector_msg>\n"\
+    "      <static_pose_publisher>true</static_pose_publisher>\n"\
+    "      <static_pose_update_frequency>1</static_pose_update_frequency>\n"\
     "    </plugin>\n"\
     "    <plugin filename=\"libignition-gazebo-multicopter-motor-model-system.so\"\n"\
     "      name=\"ignition::gazebo::systems::MulticopterMotorModel\">\n"\

--- a/subt_ign/launch/tunnel_circuit_practice.ign
+++ b/subt_ign/launch/tunnel_circuit_practice.ign
@@ -424,6 +424,9 @@
     "      <publish_collision_pose>false</publish_collision_pose>\n"\
     "      <publish_visual_pose>false</publish_visual_pose>\n"\
     "      <publish_nested_model_pose>#{$enableGroundTruth}</publish_nested_model_pose>\n"\
+    "      <use_pose_vector_msg>true</use_pose_vector_msg>\n"\
+    "      <static_pose_publisher>true</static_pose_publisher>\n"\
+    "      <static_pose_update_frequency>1</static_pose_update_frequency>\n"\
     "    </plugin>\n"\
     "    <!-- Battery plugin -->\n"\
     "    <plugin filename=\"libignition-gazebo-linearbatteryplugin-system.so\"\n"\
@@ -494,6 +497,9 @@
     "      <publish_collision_pose>false</publish_collision_pose>\n"\
     "      <publish_visual_pose>false</publish_visual_pose>\n"\
     "      <publish_nested_model_pose>#{$enableGroundTruth}</publish_nested_model_pose>\n"\
+    "      <use_pose_vector_msg>true</use_pose_vector_msg>\n"\
+    "      <static_pose_publisher>true</static_pose_publisher>\n"\
+    "      <static_pose_update_frequency>1</static_pose_update_frequency>\n"\
     "    </plugin>\n"\
     "    <!-- Battery plugin -->\n"\
     "    <plugin filename=\"libignition-gazebo-linearbatteryplugin-system.so\"\n"\
@@ -550,6 +556,9 @@
     "      <publish_collision_pose>false</publish_collision_pose>\n"\
     "      <publish_visual_pose>false</publish_visual_pose>\n"\
     "      <publish_nested_model_pose>#{$enableGroundTruth}</publish_nested_model_pose>\n"\
+    "      <use_pose_vector_msg>true</use_pose_vector_msg>\n"\
+    "      <static_pose_publisher>true</static_pose_publisher>\n"\
+    "      <static_pose_update_frequency>1</static_pose_update_frequency>\n"\
     "    </plugin>\n"\
     "    <plugin filename=\"libignition-gazebo-multicopter-motor-model-system.so\"\n"\
     "      name=\"ignition::gazebo::systems::MulticopterMotorModel\">\n"\
@@ -736,6 +745,9 @@
     "      <publish_collision_pose>false</publish_collision_pose>\n"\
     "      <publish_visual_pose>false</publish_visual_pose>\n"\
     "      <publish_nested_model_pose>#{$enableGroundTruth}</publish_nested_model_pose>\n"\
+    "      <use_pose_vector_msg>true</use_pose_vector_msg>\n"\
+    "      <static_pose_publisher>true</static_pose_publisher>\n"\
+    "      <static_pose_update_frequency>1</static_pose_update_frequency>\n"\
     "    </plugin>\n"\
     "    <plugin filename=\"libignition-gazebo-multicopter-motor-model-system.so\"\n"\
     "      name=\"ignition::gazebo::systems::MulticopterMotorModel\">\n"\

--- a/subt_ign/launch/urban_circuit.ign
+++ b/subt_ign/launch/urban_circuit.ign
@@ -448,6 +448,9 @@
     "      <publish_collision_pose>false</publish_collision_pose>\n"\
     "      <publish_visual_pose>false</publish_visual_pose>\n"\
     "      <publish_nested_model_pose>#{$enableGroundTruth}</publish_nested_model_pose>\n"\
+    "      <use_pose_vector_msg>true</use_pose_vector_msg>\n"\
+    "      <static_pose_publisher>true</static_pose_publisher>\n"\
+    "      <static_pose_update_frequency>1</static_pose_update_frequency>\n"\
     "    </plugin>\n"\
     "    <!-- Battery plugin -->\n"\
     "    <plugin filename=\"libignition-gazebo-linearbatteryplugin-system.so\"\n"\
@@ -528,6 +531,9 @@
     "      <publish_collision_pose>false</publish_collision_pose>\n"\
     "      <publish_visual_pose>false</publish_visual_pose>\n"\
     "      <publish_nested_model_pose>#{$enableGroundTruth}</publish_nested_model_pose>\n"\
+    "      <use_pose_vector_msg>true</use_pose_vector_msg>\n"\
+    "      <static_pose_publisher>true</static_pose_publisher>\n"\
+    "      <static_pose_update_frequency>1</static_pose_update_frequency>\n"\
     "    </plugin>\n"\
     "    <!-- Battery plugin -->\n"\
     "    <plugin filename=\"libignition-gazebo-linearbatteryplugin-system.so\"\n"\
@@ -594,6 +600,9 @@
     "      <publish_collision_pose>false</publish_collision_pose>\n"\
     "      <publish_visual_pose>false</publish_visual_pose>\n"\
     "      <publish_nested_model_pose>#{$enableGroundTruth}</publish_nested_model_pose>\n"\
+    "      <use_pose_vector_msg>true</use_pose_vector_msg>\n"\
+    "      <static_pose_publisher>true</static_pose_publisher>\n"\
+    "      <static_pose_update_frequency>1</static_pose_update_frequency>\n"\
     "    </plugin>\n"\
     "    <plugin filename=\"libignition-gazebo-multicopter-motor-model-system.so\"\n"\
     "      name=\"ignition::gazebo::systems::MulticopterMotorModel\">\n"\
@@ -790,6 +799,9 @@
     "      <publish_collision_pose>false</publish_collision_pose>\n"\
     "      <publish_visual_pose>false</publish_visual_pose>\n"\
     "      <publish_nested_model_pose>#{$enableGroundTruth}</publish_nested_model_pose>\n"\
+    "      <use_pose_vector_msg>true</use_pose_vector_msg>\n"\
+    "      <static_pose_publisher>true</static_pose_publisher>\n"\
+    "      <static_pose_update_frequency>1</static_pose_update_frequency>\n"\
     "    </plugin>\n"\
     "    <plugin filename=\"libignition-gazebo-multicopter-motor-model-system.so\"\n"\
     "      name=\"ignition::gazebo::systems::MulticopterMotorModel\">\n"\

--- a/subt_ign/launch/validate_connections.ign
+++ b/subt_ign/launch/validate_connections.ign
@@ -385,6 +385,9 @@ ign service -s /connection/prev \
           <publish_collision_pose>false</publish_collision_pose>
           <publish_visual_pose>false</publish_visual_pose>
           <publish_nested_model_pose>true</publish_nested_model_pose>
+          <use_pose_vector_msg>true</use_pose_vector_msg>
+          <static_pose_publisher>true</static_pose_publisher>
+          <static_pose_update_frequency>1</static_pose_update_frequency>
         </plugin>
       </model>
     </sdf>

--- a/subt_ign/launch/virtual_stix.ign
+++ b/subt_ign/launch/virtual_stix.ign
@@ -394,6 +394,9 @@
     "      <publish_collision_pose>false</publish_collision_pose>\n"\
     "      <publish_visual_pose>false</publish_visual_pose>\n"\
     "      <publish_nested_model_pose>#{$enableGroundTruth}</publish_nested_model_pose>\n"\
+    "      <use_pose_vector_msg>true</use_pose_vector_msg>\n"\
+    "      <static_pose_publisher>true</static_pose_publisher>\n"\
+    "      <static_pose_update_frequency>1</static_pose_update_frequency>\n"\
     "    </plugin>\n"\
     "    <!-- Battery plugin -->\n"\
     "    <plugin filename=\"libignition-gazebo-linearbatteryplugin-system.so\"\n"\
@@ -464,6 +467,9 @@
     "      <publish_collision_pose>false</publish_collision_pose>\n"\
     "      <publish_visual_pose>false</publish_visual_pose>\n"\
     "      <publish_nested_model_pose>#{$enableGroundTruth}</publish_nested_model_pose>\n"\
+    "      <use_pose_vector_msg>true</use_pose_vector_msg>\n"\
+    "      <static_pose_publisher>true</static_pose_publisher>\n"\
+    "      <static_pose_update_frequency>1</static_pose_update_frequency>\n"\
     "    </plugin>\n"\
     "    <!-- Battery plugin -->\n"\
     "    <plugin filename=\"libignition-gazebo-linearbatteryplugin-system.so\"\n"\
@@ -520,6 +526,9 @@
     "      <publish_collision_pose>false</publish_collision_pose>\n"\
     "      <publish_visual_pose>false</publish_visual_pose>\n"\
     "      <publish_nested_model_pose>#{$enableGroundTruth}</publish_nested_model_pose>\n"\
+    "      <use_pose_vector_msg>true</use_pose_vector_msg>\n"\
+    "      <static_pose_publisher>true</static_pose_publisher>\n"\
+    "      <static_pose_update_frequency>1</static_pose_update_frequency>\n"\
     "    </plugin>\n"\
     "    <plugin filename=\"libignition-gazebo-multicopter-motor-model-system.so\"\n"\
     "      name=\"ignition::gazebo::systems::MulticopterMotorModel\">\n"\
@@ -706,6 +715,9 @@
     "      <publish_collision_pose>false</publish_collision_pose>\n"\
     "      <publish_visual_pose>false</publish_visual_pose>\n"\
     "      <publish_nested_model_pose>#{$enableGroundTruth}</publish_nested_model_pose>\n"\
+    "      <use_pose_vector_msg>true</use_pose_vector_msg>\n"\
+    "      <static_pose_publisher>true</static_pose_publisher>\n"\
+    "      <static_pose_update_frequency>1</static_pose_update_frequency>\n"\
     "    </plugin>\n"\
     "    <plugin filename=\"libignition-gazebo-multicopter-motor-model-system.so\"\n"\
     "      name=\"ignition::gazebo::systems::MulticopterMotorModel\">\n"\

--- a/subt_ign/launch/virtual_stix_headless.ign
+++ b/subt_ign/launch/virtual_stix_headless.ign
@@ -306,6 +306,9 @@
     "      <publish_collision_pose>false</publish_collision_pose>\n"\
     "      <publish_visual_pose>false</publish_visual_pose>\n"\
     "      <publish_nested_model_pose>#{$enableGroundTruth}</publish_nested_model_pose>\n"\
+    "      <use_pose_vector_msg>true</use_pose_vector_msg>\n"\
+    "      <static_pose_publisher>true</static_pose_publisher>\n"\
+    "      <static_pose_update_frequency>1</static_pose_update_frequency>\n"\
     "    </plugin>\n"\
     "    <!-- Battery plugin -->\n"\
     "    <plugin filename=\"libignition-gazebo-linearbatteryplugin-system.so\"\n"\
@@ -376,6 +379,9 @@
     "      <publish_collision_pose>false</publish_collision_pose>\n"\
     "      <publish_visual_pose>false</publish_visual_pose>\n"\
     "      <publish_nested_model_pose>#{$enableGroundTruth}</publish_nested_model_pose>\n"\
+    "      <use_pose_vector_msg>true</use_pose_vector_msg>\n"\
+    "      <static_pose_publisher>true</static_pose_publisher>\n"\
+    "      <static_pose_update_frequency>1</static_pose_update_frequency>\n"\
     "    </plugin>\n"\
     "    <!-- Battery plugin -->\n"\
     "    <plugin filename=\"libignition-gazebo-linearbatteryplugin-system.so\"\n"\
@@ -432,6 +438,9 @@
     "      <publish_collision_pose>false</publish_collision_pose>\n"\
     "      <publish_visual_pose>false</publish_visual_pose>\n"\
     "      <publish_nested_model_pose>#{$enableGroundTruth}</publish_nested_model_pose>\n"\
+    "      <use_pose_vector_msg>true</use_pose_vector_msg>\n"\
+    "      <static_pose_publisher>true</static_pose_publisher>\n"\
+    "      <static_pose_update_frequency>1</static_pose_update_frequency>\n"\
     "    </plugin>\n"\
     "    <plugin filename=\"libignition-gazebo-multicopter-motor-model-system.so\"\n"\
     "      name=\"ignition::gazebo::systems::MulticopterMotorModel\">\n"\
@@ -618,6 +627,9 @@
     "      <publish_collision_pose>false</publish_collision_pose>\n"\
     "      <publish_visual_pose>false</publish_visual_pose>\n"\
     "      <publish_nested_model_pose>#{$enableGroundTruth}</publish_nested_model_pose>\n"\
+    "      <use_pose_vector_msg>true</use_pose_vector_msg>\n"\
+    "      <static_pose_publisher>true</static_pose_publisher>\n"\
+    "      <static_pose_update_frequency>1</static_pose_update_frequency>\n"\
     "    </plugin>\n"\
     "    <plugin filename=\"libignition-gazebo-multicopter-motor-model-system.so\"\n"\
     "      name=\"ignition::gazebo::systems::MulticopterMotorModel\">\n"\

--- a/subt_ign/test/test.ign
+++ b/subt_ign/test/test.ign
@@ -325,6 +325,9 @@
     "      <publish_collision_pose>false</publish_collision_pose>\n"\
     "      <publish_visual_pose>false</publish_visual_pose>\n"\
     "      <publish_nested_model_pose>#{$enableGroundTruth}</publish_nested_model_pose>\n"\
+    "      <use_pose_vector_msg>true</use_pose_vector_msg>\n"\
+    "      <static_pose_publisher>true</static_pose_publisher>\n"\
+    "      <static_pose_update_frequency>1</static_pose_update_frequency>\n"\
     "    </plugin>\n"\
     "    <!-- Battery plugin -->\n"\
     "    <plugin filename=\"libignition-gazebo-linearbatteryplugin-system.so\"\n"\
@@ -388,6 +391,9 @@
     "      <publish_collision_pose>false</publish_collision_pose>\n"\
     "      <publish_visual_pose>false</publish_visual_pose>\n"\
     "      <publish_nested_model_pose>#{$enableGroundTruth}</publish_nested_model_pose>\n"\
+    "      <use_pose_vector_msg>true</use_pose_vector_msg>\n"\
+    "      <static_pose_publisher>true</static_pose_publisher>\n"\
+    "      <static_pose_update_frequency>1</static_pose_update_frequency>\n"\
     "    </plugin>\n"\
     "    <!-- Battery plugin -->\n"\
     "    <plugin filename=\"libignition-gazebo-linearbatteryplugin-system.so\"\n"\
@@ -437,6 +443,9 @@
     "      <publish_collision_pose>false</publish_collision_pose>\n"\
     "      <publish_visual_pose>false</publish_visual_pose>\n"\
     "      <publish_nested_model_pose>#{$enableGroundTruth}</publish_nested_model_pose>\n"\
+    "      <use_pose_vector_msg>true</use_pose_vector_msg>\n"\
+    "      <static_pose_publisher>true</static_pose_publisher>\n"\
+    "      <static_pose_update_frequency>1</static_pose_update_frequency>\n"\
     "    </plugin>\n"\
     "    <plugin filename=\"libignition-gazebo-multicopter-motor-model-system.so\"\n"\
     "      name=\"ignition::gazebo::systems::MulticopterMotorModel\">\n"\
@@ -565,6 +574,9 @@
     "      <publish_collision_pose>false</publish_collision_pose>\n"\
     "      <publish_visual_pose>false</publish_visual_pose>\n"\
     "      <publish_nested_model_pose>#{$enableGroundTruth}</publish_nested_model_pose>\n"\
+    "      <use_pose_vector_msg>true</use_pose_vector_msg>\n"\
+    "      <static_pose_publisher>true</static_pose_publisher>\n"\
+    "      <static_pose_update_frequency>1</static_pose_update_frequency>\n"\
     "    </plugin>\n"\
     "    <plugin filename=\"libignition-gazebo-multicopter-motor-model-system.so\"\n"\
     "      name=\"ignition::gazebo::systems::MulticopterMotorModel\">\n"\

--- a/subt_ros/launch/vehicle_topics.launch
+++ b/subt_ros/launch/vehicle_topics.launch
@@ -23,8 +23,15 @@
       pkg="ros_ign_bridge"
       type="parameter_bridge"
       name="ros_ign_bridge_pose"
-      args="/model/$(arg name)/pose@geometry_msgs/TransformStamped[ignition.msgs.Pose">
+      args="/model/$(arg name)/pose@tf2_msgs/TFMessage[ignition.msgs.Pose_V">
       <remap from="/model/$(arg name)/pose" to="pose"/>
+    </node>
+    <node
+      pkg="ros_ign_bridge"
+      type="parameter_bridge"
+      name="ros_ign_bridge_pose_static"
+      args="/model/$(arg name)/pose_static@tf2_msgs/TFMessage[ignition.msgs.Pose_V">
+      <remap from="/model/$(arg name)/pose_static" to="pose_static"/>
     </node>
     <node
       pkg="ros_ign_bridge"

--- a/subt_ros/src/BridgeLogger.cc
+++ b/subt_ros/src/BridgeLogger.cc
@@ -16,6 +16,7 @@
 */
 #include <chrono>
 #include <mutex>
+#include <thread>
 #include <fstream>
 #include <ros/ros.h>
 #include <std_msgs/String.h>
@@ -51,6 +52,9 @@ class BridgeLogger
   private: void OnSensorMsg(const topic_tools::ShapeShifter::ConstPtr &_msg,
                             const std::string &_topic);
 
+  /// \brief Check heartbeat for all topics monitored
+  private: void CheckHeartbeat();
+
   /// \brief ROS node handler.
   private: ros::NodeHandle n;
 
@@ -70,10 +74,13 @@ class BridgeLogger
   /// \brief Timer that triggers the update function.
   private: ros::Timer updateTimer;
 
+  /// \brief A map of topic names and time when their last heartbeat was
+  /// received.
   private: std::map<std::string,
       std::chrono::time_point<std::chrono::steady_clock>> topicTimestamp;
 
-  private: std::chrono::time_point<std::chrono::steady_clock> lastHeartbeatTime;
+  /// \brief Check heartbeat in separate thread
+  private: std::thread heartbeatThread;
 };
 
 /////////////////////////////////////////////////
@@ -84,6 +91,8 @@ BridgeLogger::BridgeLogger()
 
   this->updateTimer = this->n.createTimer(ros::Duration(10.0),
       &BridgeLogger::Update, this);
+
+  this->heartbeatThread = std::thread(&BridgeLogger::CheckHeartbeat, this);
 }
 
 /////////////////////////////////////////////////
@@ -102,7 +111,6 @@ void BridgeLogger::Update(const ros::TimerEvent &)
 
     // Skip if the topic has already been added to `this->streams` or if
     // the topic is one that we don't monitor, such as parameter updates.
-
     if (this->streams.find(info.name) != this->streams.end() ||
         info.name.find("parameter_descriptions") != std::string::npos ||
         info.name.find("parameter_updates") != std::string::npos ||
@@ -156,7 +164,6 @@ void BridgeLogger::Update(const ros::TimerEvent &)
       this->subscribers.push_back(
           this->n.subscribe(info.name, 1000, callback));
     }
-
   }
 }
 
@@ -218,33 +225,6 @@ void BridgeLogger::OnSensorMsg(const topic_tools::ShapeShifter::ConstPtr &_msg,
     return;
   }
 
-  // check heartbeat
-  auto tdiff = systemTime - this->lastHeartbeatTime;
-  auto seconds =
-      std::chrono::duration_cast<std::chrono::milliseconds>(tdiff).count() /
-      1000.0;
-  if (seconds > 5.0)
-  {
-    // check topic heartbeat
-    for (auto &tIt : this->streams)
-    {
-      std::string topic = tIt.first;
-      auto it = this->topicTimestamp.find(topic);
-      if (it != this->topicTimestamp.end())
-      {
-        auto d = systemTime - it->second;
-        seconds =
-            std::chrono::duration_cast<std::chrono::milliseconds>(d).count() /
-            1000.0;
-        if (seconds > 5.0)
-        {
-          this->streams[topic] << "***Error: No messages received for more than"
-                               << " 5 seconds ***\n";
-        }
-      }
-    }
-    this->lastHeartbeatTime = systemTime;
-  }
   // log msg time received in wall clock time
   this->topicTimestamp[_topic] = systemTime;
 
@@ -260,6 +240,40 @@ void BridgeLogger::OnSensorMsg(const topic_tools::ShapeShifter::ConstPtr &_msg,
     << diff.count() << std::endl;
 
   this->prevSeq[_topic] = seq;
+}
+
+/////////////////////////////////////////////////
+void BridgeLogger::CheckHeartbeat()
+{
+  // check heartbeat
+  using namespace std::chrono_literals;
+  double heartbeatCheckPeriod = 5.0;
+  while (ros::ok)
+  {
+    std::this_thread::sleep_for(5s);
+    auto systemTime = std::chrono::steady_clock::now();
+    {
+      std::lock_guard<std::mutex> lock(this->mutex);
+      // check topic heartbeat
+      for (auto &tIt : this->streams)
+      {
+        std::string topic = tIt.first;
+        auto it = this->topicTimestamp.find(topic);
+        if (it != this->topicTimestamp.end())
+        {
+          auto d = systemTime - it->second;
+          auto seconds =
+              std::chrono::duration_cast<std::chrono::milliseconds>(d).count() /
+              1000.0;
+          if (seconds > heartbeatCheckPeriod)
+          {
+            this->streams[topic] << "***Error: No messages received for more "
+                                 << "than 5 seconds ***\n";
+          }
+        }
+      }
+    }
+  }
 }
 
 /////////////////////////////////////////////////

--- a/subt_ros/src/BridgeLogger.cc
+++ b/subt_ros/src/BridgeLogger.cc
@@ -19,7 +19,6 @@
 #include <fstream>
 #include <ros/ros.h>
 #include <std_msgs/String.h>
-#include <geometry_msgs/TransformStamped.h>
 #include <sensor_msgs/BatteryState.h>
 #include <sensor_msgs/CompressedImage.h>
 #include <sensor_msgs/Image.h>
@@ -212,11 +211,6 @@ void BridgeLogger::OnSensorMsg(const topic_tools::ShapeShifter::ConstPtr &_msg,
     const auto msg = _msg->instantiate<theora_image_transport::Packet>();
     seq = msg->header.seq;
   }
-  else if (_msg->getDataType() == "geometry_msgs/TransformStamped")
-  {
-    const auto msg = _msg->instantiate<geometry_msgs::TransformStamped>();
-    seq = msg->header.seq;
-  }
   else
   {
     // Debug output.
@@ -239,12 +233,13 @@ void BridgeLogger::OnSensorMsg(const topic_tools::ShapeShifter::ConstPtr &_msg,
       if (it != this->topicTimestamp.end())
       {
         auto d = systemTime - it->second;
-        seconds = std::chrono::duration_cast<std::chrono::milliseconds>(d).count() /
-                  1000.0;
+        seconds =
+            std::chrono::duration_cast<std::chrono::milliseconds>(d).count() /
+            1000.0;
         if (seconds > 5.0)
         {
-          this->streams[topic] << "***Error: No messages received for more than "
-                               << "5 seconds ***\n";
+          this->streams[topic] << "***Error: No messages received for more than"
+                               << " 5 seconds ***\n";
         }
       }
     }
@@ -265,8 +260,6 @@ void BridgeLogger::OnSensorMsg(const topic_tools::ShapeShifter::ConstPtr &_msg,
     << diff.count() << std::endl;
 
   this->prevSeq[_topic] = seq;
-
-
 }
 
 /////////////////////////////////////////////////

--- a/subt_ros/src/BridgeLogger.cc
+++ b/subt_ros/src/BridgeLogger.cc
@@ -122,8 +122,7 @@ void BridgeLogger::Update(const ros::TimerEvent &)
         info.name.find("magnetic_field") != std::string::npos ||
         info.name.find("air_pressure") != std::string::npos ||
         info.name.find("battery_state") != std::string::npos ||
-        info.name.find("imu") != std::string::npos ||
-        info.name.find("pose") != std::string::npos)
+        info.name.find("imu") != std::string::npos)
     {
       boost::function<
         void(const topic_tools::ShapeShifter::ConstPtr&)> callback;

--- a/subt_ros/src/pose_tf_broadcaster.cpp
+++ b/subt_ros/src/pose_tf_broadcaster.cpp
@@ -13,8 +13,6 @@
 // limitations under the License.
 
 #include <iostream>
-#include <memory>
-#include <string>
 
 // include ROS 1
 #ifdef __clang__
@@ -27,21 +25,34 @@
 #endif
 
 #include <geometry_msgs/TransformStamped.h>
-#include <tf/transform_broadcaster.h>
+#include <tf2_msgs/TFMessage.h>
+#include <tf2_ros/transform_broadcaster.h>
+#include <tf2_ros/static_transform_broadcaster.h>
 
-void poseCallback(const geometry_msgs::TransformStamped& msg)
+void poseCallback(const tf2_msgs::TFMessage &_msg)
 {
   static tf2_ros::TransformBroadcaster br;
-  br.sendTransform(msg);
+  br.sendTransform(_msg.transforms);
+}
+
+void poseStaticCallback(const tf2_msgs::TFMessage &_msg)
+{
+   static tf2_ros::StaticTransformBroadcaster brStatic;
+   brStatic.sendTransform(_msg.transforms);
 }
 
 //////////////////////////////////////////////////
 int main(int argc, char * argv[])
 {
   ros::init(argc, argv, "pose_tf_broadcaster");
+
   ros::NodeHandle node;
   ros::Subscriber sub = node.subscribe("pose", 10, &poseCallback);
 
+  ros::Subscriber subStatic = node.subscribe(
+      "pose_static", 10, &poseStaticCallback);
+
   ros::spin();
+
   return 0;
 }


### PR DESCRIPTION
Addresses issue #338, and potentially #389 and #261  

Depends on [ign-gazebo pull request 65](https://github.com/ignitionrobotics/ign-gazebo/pull/65) and [ros_ign pull request 67](https://github.com/osrf/ros_ign/pull/67)

New SDF params were added to the pose publisher system to help reduce bandwidth of the `/<robot_name>/pose` topic. The system now:
* subscribes to the new `/<robot_name>/pose_static` topic for static transforms (non-latched, published at 1Hz)
* changes the message type of the `/<robot_name>/pose[_static]` topics from `geometry_msgs/TransformStamped` to `tf2_messages/TFMessage` that consists a vector of transforms. This significantly reduces the number of messages that  need to be transmitted over the pose topic, e.g. for X1_C1, the publishing rate reduced from 2000Hz to 250Hz.

**Note:** The message type change is a breaking change but the `/<robot_name>/pose` topic is not an API that's publicly documented in https://github.com/osrf/subt/wiki/api. 

The changes address the critical / intermittent TF data loss issue for me. More tests are required to confirm whether or not this resolves #261 but with these changes I have not yet been able to reproduce the issue with message drops or delays on other topics. 

This PR also includes a heartbeat logger in BridgeLogger to help detect delays in messages.

Some ideas for testing:
* run subt and monitor `/tf` topic. Before the change, I see the the publishing rate slowly reduces and becomes intermittent
*  look for `Error: No messages received` or `Error: Missed message(s)` in ~/.ros. 
* Add the `pose` topic [here](https://github.com/osrf/subt/blob/master/subt_ros/src/BridgeLogger.cc#L118) to the list of topics monitored by BridgeLogger. Interestingly with this change, I start to see error messages about dropped messages in `~/.ros` within a few minutes of running subt.