### PR TITLE
Update cave_circuit.ign to call the corect spawner method

### DIFF
--- a/subt_ign/launch/cave_circuit.ign
+++ b/subt_ign/launch/cave_circuit.ign
@@ -1083,7 +1083,7 @@
 
       spawnerScript =  "#{installDir}/launch/spawner.rb"
       begin
-        require spawnerScript
+        load spawnerScript
       rescue LoadError
         raise "Unknown robot configuration #{config}. #{spawnerScript} could not be found."
       else
@@ -1102,11 +1102,11 @@
             robotType = config[1]
             robotConfigN = config[-1]
             if robotType == "3" or robotType == "4"
-              UAVStr = "UAV "
+              mUAVStr = "UAV "
             else
-              UAVStr = ""
+              mUAVStr = ""
             end
-            robotName = "X#{robotType} #{UAVStr}Config #{robotConfigN}"
+            robotName = "X#{robotType} #{mUAVStr}Config #{robotConfigN}"
           else
             robotName = config
           end


### PR DESCRIPTION
This fix was made by @iche033 in [Bitbucket PR #400](https://osrf-migration.github.io/subt-gh-pages/#!/osrf/subt/pull-requests/400/page/1), but they didn't make into cave_circuit.ign

To test this, you can try running the following before checking out this PR

```
ign launch -v 4 cave_circuit.ign  robotName1:=X3 robotConfig1:=X3_SENSOR_CONFIG_5 robotName2:=X4 robotConfig2:=X4_SENSOR_CONFIG_6 robotName3:=X5 robotConfig3:=X3_SENSOR_CONFIG_5
```
and it should fail.