### PR TITLE
Make breadcrumb model static after specified time

### DIFF
--- a/submitted_models/costar_husky_sensor_config_2/launch/spawner.rb
+++ b/submitted_models/costar_husky_sensor_config_2/launch/spawner.rb
@@ -56,6 +56,7 @@ def spawner(_name, _modelURI, _worldName, _x, _y, _z, _roll, _pitch, _yaw)
         name="ignition::gazebo::systems::Breadcrumbs">
         <topic>/model/#{_name}/breadcrumb/deploy</topic>
         <max_deployments>12</max_deployments>"
+        <disable_physics_time>3.0</disable_physics_time>
         <breadcrumb>"
           <sdf version="1.6">
             <model name="#{_name}__breadcrumb__">

--- a/submitted_models/explorer_x1_sensor_config_2/launch/spawner.rb
+++ b/submitted_models/explorer_x1_sensor_config_2/launch/spawner.rb
@@ -56,6 +56,7 @@ def spawner(_name, _modelURI, _worldName, _x, _y, _z, _roll, _pitch, _yaw)
         name="ignition::gazebo::systems::Breadcrumbs">
         <topic>/model/#{_name}/breadcrumb/deploy</topic>
         <max_deployments>12</max_deployments>"
+        <disable_physics_time>3.0</disable_physics_time>
         <breadcrumb>"
           <sdf version="1.6">
             <model name="#{_name}__breadcrumb__">

--- a/subt_ign/launch/cave_circuit.ign
+++ b/subt_ign/launch/cave_circuit.ign
@@ -527,6 +527,7 @@
     "      name=\"ignition::gazebo::systems::Breadcrumbs\">\n"\
     "      <topic>/model/#{_name}/breadcrumb/deploy</topic>\n"\
     "      <max_deployments>#{max_breadcrumbs}</max_deployments>"\
+    "      <disable_physics_time>3.0</disable_physics_time>"\
     "      <breadcrumb>\n"\
     "        <sdf version=\"1.6\">\n"\
     "          <model name=\"#{_name}__breadcrumb__\">\n"\
@@ -627,6 +628,7 @@
     "      name=\"ignition::gazebo::systems::Breadcrumbs\">\n"\
     "      <topic>/model/#{_name}/breadcrumb/deploy</topic>\n"\
     "      <max_deployments>#{max_breadcrumbs}</max_deployments>"\
+    "      <disable_physics_time>3.0</disable_physics_time>"\
     "      <breadcrumb>\n"\
     "        <sdf version=\"1.6\">\n"\
     "          <model name=\"#{_name}__breadcrumb__\">\n"\

--- a/subt_ign/launch/cloudsim_sim.ign
+++ b/subt_ign/launch/cloudsim_sim.ign
@@ -583,6 +583,7 @@
     "      name=\"ignition::gazebo::systems::Breadcrumbs\">\n"\
     "      <topic>/model/#{_name}/breadcrumb/deploy</topic>\n"\
     "      <max_deployments>#{max_breadcrumbs}</max_deployments>"\
+    "      <disable_physics_time>3.0</disable_physics_time>"\
     "      <breadcrumb>\n"\
     "        <sdf version=\"1.6\">\n"\
     "          <model name=\"#{_name}__breadcrumb__\">\n"\
@@ -662,6 +663,7 @@
     "      name=\"ignition::gazebo::systems::Breadcrumbs\">\n"\
     "      <topic>/model/#{_name}/breadcrumb/deploy</topic>\n"\
     "      <max_deployments>#{max_breadcrumbs}</max_deployments>"\
+    "      <disable_physics_time>3.0</disable_physics_time>"\
     "      <breadcrumb>\n"\
     "        <sdf version=\"1.6\">\n"\
     "          <model name=\"#{_name}__breadcrumb__\">\n"\

--- a/subt_ign/src/CommsBrokerPlugin.cc
+++ b/subt_ign/src/CommsBrokerPlugin.cc
@@ -19,6 +19,7 @@
 
 #include <functional>
 #include <mutex>
+#include <regex>
 
 #include <ignition/common/Console.hh>
 #include <ignition/common/Util.hh>
@@ -310,7 +311,9 @@ void CommsBrokerPlugin::UpdateIfNewBreadcrumbs()
   for (const auto& [name, pose] : this->poses)
   {
     // New breadcrumb found.
-    if (name.find("__breadcrumb__") != std::string::npos &&
+    // A static model is spawned when the breadcrumb is made static
+    if (std::regex_match(name,
+        std::regex(".*__breadcrumb___(\\d+)__static__")) &&
         this->breadcrumbs.find(name) == this->breadcrumbs.end())
     {
       this->breadcrumbs[name] = pose;


### PR DESCRIPTION
depends on [ignition-gazebo pull request #90](https://github.com/ignitionrobotics/ign-gazebo/pull/90)

Add `disable_physics_time` param to breadcrumb plugin that turns the breadcrumb model static after ~3 sim time seconds. A static entity is created when the model becomes static, and that indicates to the comms broker that it should update its visibility graph.

You should see output similar to this:

```
[Msg] Deploying X1__breadcrumb___0 at 3.55 5 0.13228 0 0 0
[Dbg] [EntityComponentManager.cc:627] Using components of type [285520019272511910] / [ign_gazebo_components.DetachableJoint].
[Msg] Breadcrumb 'X1__breadcrumb___0' is now static.
[Dbg] [Physics.cc:864] Creating detachable joint [729]
[GUI] [Dbg] [EntityComponentManager.cc:627] Using components of type [285520019272511910] / [ign_gazebo_components.DetachableJoint].
[Msg] New breadcrumb detected, visibility graph updated
```

Signed-off-by: Ian Chen <ichen@osrfoundation.org>