### PR TITLE
Adding team base

### DIFF
--- a/subt_ign/launch/cave_circuit.ign
+++ b/subt_ign/launch/cave_circuit.ign
@@ -1038,6 +1038,47 @@
     "  <command>roslaunch --wait subt_ros vehicle_topics.launch world_name:=#{$worldName} name:=#{_name} uav:=#{uav} laser_scan:=#{laserScan} stereo_cam:=#{stereoCam} rgbd_cam:=#{rgbdCam}</command>\n"\
     "</executable>\n"
   end
+
+  def spawnTeamBase(_x, _y, _z, _yaw)
+    "<plugin name=\"ignition::launch::GazeboFactory\"\n"\
+    "        filename=\"libignition-launch-gazebo-factory.so\">\n"\
+    "  <name>TeamBase</name>\n"\
+    "  <allow_renaming>false</allow_renaming>\n"\
+    "  <world>#{$worldName}</world>\n"\
+    "  <is_performer>false</is_performer>\n"\
+    "  <sdf version='1.6'>\n"\
+    "  <model name='TeamBase'>\n"\
+    "    <pose>#{_x} #{_y} #{_z} 0 0 #{_yaw}</pose>\n"\
+    "    <static>true</static>\n"\
+    "    <link name='link'>\n"\
+    "      <pose>0 0 0.05 0 0 0</pose>\n"\
+    "      <visual name='visual'>\n"\
+    "        <geometry>\n"\
+    "          <box>\n"\
+    "            <size>.1 .1 .1</size>\n"\
+    "          </box>\n"\
+    "        </geometry>\n"\
+    "      </visual>\n"\
+    "    </link>\n"\
+    "    <!-- Publish robot state information -->\n"\
+    "    <plugin filename=\"libignition-gazebo-pose-publisher-system.so\"\n"\
+    "      name=\"ignition::gazebo::systems::PosePublisher\">\n"\
+    "      <publish_link_pose>true</publish_link_pose>\n"\
+    "      <publish_sensor_pose>false</publish_sensor_pose>\n"\
+    "      <publish_collision_pose>false</publish_collision_pose>\n"\
+    "      <publish_visual_pose>false</publish_visual_pose>\n"\
+    "      <publish_nested_model_pose>false</publish_nested_model_pose>\n"\
+    "    </plugin>\n"\
+    "  </model>\n"\
+    "  </sdf>\n"\
+    "</plugin>\n"\
+    "<executable name='teambase_description'>\n"\
+    "  <command>roslaunch --wait subt_ros teambase_description.launch world_name:=#{$worldName}</command>\n"\
+    "</executable>\n"\
+    "<executable name='teambase_ros_ign_bridge'>\n"\
+      "  <command>roslaunch --wait subt_ros teambase_topics.launch world_name:=#{$worldName}</command>\n"\
+    "</executable>\n"
+  end
 %>
 
 <%
@@ -1072,6 +1113,12 @@
       robotSpawned += 1
 %>
 <%=   spawnX4(name, robotConfigN, posX, posY, spawnWorldZPos, spawnWorldYaw) %>
+<%
+    elsif (name.downcase == "teambase" || name.downcase == "team_base") &&
+          (config.downcase == "teambase" || config.downcase == "team_base")
+      robotSpawned += 1
+%>
+<%=   spawnTeamBase(posX, posY, spawnWorldZPos, spawnWorldYaw) %>
 <%
     else
       # Try a team-submitted vehicle.

--- a/subt_ign/launch/cave_circuit.ign
+++ b/subt_ign/launch/cave_circuit.ign
@@ -1062,15 +1062,6 @@
     "        </geometry>\n"\
     "      </visual>\n"\
     "    </link>\n"\
-    "    <!-- Publish robot state information -->\n"\
-    "    <plugin filename=\"libignition-gazebo-pose-publisher-system.so\"\n"\
-    "      name=\"ignition::gazebo::systems::PosePublisher\">\n"\
-    "      <publish_link_pose>true</publish_link_pose>\n"\
-    "      <publish_sensor_pose>false</publish_sensor_pose>\n"\
-    "      <publish_collision_pose>false</publish_collision_pose>\n"\
-    "      <publish_visual_pose>false</publish_visual_pose>\n"\
-    "      <publish_nested_model_pose>false</publish_nested_model_pose>\n"\
-    "    </plugin>\n"\
     "  </model>\n"\
     "  </sdf>\n"\
     "</plugin>\n"\

--- a/subt_ign/launch/cave_circuit.ign
+++ b/subt_ign/launch/cave_circuit.ign
@@ -36,6 +36,8 @@
   spawnWorldYaw = 0
   guiCameraPose = "-6.3 -4.2 3.6 0 0.268 0.304"
 
+  teamBaseSpawned = false
+
   # Check if robotNameX and robotConfigX exists
   spawnRowSize = 4
   spawnColSize = 5
@@ -1117,9 +1119,12 @@
     elsif (name.downcase == "teambase" || name.downcase == "team_base") &&
           (config.downcase == "teambase" || config.downcase == "team_base")
       robotSpawned += 1
+      if !teamBaseSpawned
+        teamBaseSpawned = true
 %>
-<%=   spawnTeamBase(posX, posY, spawnWorldZPos, spawnWorldYaw) %>
-<%
+<%=     spawnTeamBase(posX, posY, spawnWorldZPos, spawnWorldYaw) %>
+<% 
+      end
     else
       # Try a team-submitted vehicle.
       package = config.downcase

--- a/subt_ign/launch/cloudsim_bridge.ign
+++ b/subt_ign/launch/cloudsim_bridge.ign
@@ -174,6 +174,15 @@
     "  <command>roslaunch --wait subt_ros vehicle_topics.launch world_name:=#{$worldName} name:=#{_name} uav:=#{uav} laser_scan:=#{laserScan} stereo_cam:=#{stereoCam} rgbd_cam:=#{rgbdCam}</command>\n"\
     "</executable>\n"
   end
+
+  def spawnTeamBase(_x, _y, _z, _yaw)
+    "<executable name='teambase_description'>\n"\
+    "  <command>roslaunch --wait subt_ros teambase_description.launch world_name:=#{$worldName}</command>\n"\
+    "</executable>\n"\
+    "<executable name='teambase_ros_ign_bridge'>\n"\
+      "  <command>roslaunch --wait subt_ros teambase_topics.launch world_name:=#{$worldName}</command>\n"\
+    "</executable>\n"
+  end
 %>
 
 <%

--- a/subt_ign/launch/cloudsim_bridge.ign
+++ b/subt_ign/launch/cloudsim_bridge.ign
@@ -41,6 +41,8 @@
 %>
 
 <%
+  teamBaseSpawned = false
+
   # Check if robotNameX and robotConfigX exists
   maxRobotCount = 20
   robotNames = []
@@ -198,7 +200,16 @@
 <%=   spawnX3(robotNames[i], robotConfigs[i][-1]) %>
 <%  elsif robotConfigs[i][1] == "4" and (robotConfigN == "1" or robotConfigN == "2" or robotConfigN == "3" or robotConfigN == "4" or robotConfigN == "5") %>
 <%=   spawnX4(robotNames[i],  robotConfigs[i][-1]) %>
-<%  else
+<%
+    elsif (name.downcase == "teambase" || name.downcase == "team_base") &&
+          (config.downcase == "teambase" || config.downcase == "team_base")
+      robotSpawned += 1
+      if !teamBaseSpawned
+        teamBaseSpawned = true
+%>
+<%=     spawnTeamBase(posX, posY, spawnWorldZPos, spawnWorldYaw) %>
+<%    end
+    else
       # Try a team-submitted vehicle.
       package = config.downcase
       installDir = `rospack find #{package}`.chomp

--- a/subt_ign/launch/cloudsim_sim.ign
+++ b/subt_ign/launch/cloudsim_sim.ign
@@ -1062,15 +1062,6 @@
     "        </geometry>\n"\
     "      </visual>\n"\
     "    </link>\n"\
-    "    <!-- Publish robot state information -->\n"\
-    "    <plugin filename=\"libignition-gazebo-pose-publisher-system.so\"\n"\
-    "      name=\"ignition::gazebo::systems::PosePublisher\">\n"\
-    "      <publish_link_pose>true</publish_link_pose>\n"\
-    "      <publish_sensor_pose>false</publish_sensor_pose>\n"\
-    "      <publish_collision_pose>false</publish_collision_pose>\n"\
-    "      <publish_visual_pose>false</publish_visual_pose>\n"\
-    "      <publish_nested_model_pose>false</publish_nested_model_pose>\n"\
-    "    </plugin>\n"\
     "  </model>\n"\
     "  </sdf>\n"\
     "</plugin>\n"

--- a/subt_ign/launch/cloudsim_sim.ign
+++ b/subt_ign/launch/cloudsim_sim.ign
@@ -57,6 +57,8 @@
     guiCameraPose = "-6.3 -4.2 3.6 0 0.268 0.304"
   end
 
+  teamBaseSpawned = false
+
   # Check if robotNameX and robotConfigX exists
   spawnRowSize = 4
   spawnColSize = 5
@@ -1111,9 +1113,12 @@
     elsif (name.downcase == "teambase" || name.downcase == "team_base") &&
           (config.downcase == "teambase" || config.downcase == "team_base")
       robotSpawned += 1
+      if !teamBaseSpawned
+        teamBaseSpawned = true
 %>
-<%=   spawnTeamBase(posX, posY, spawnWorldZPos, spawnWorldYaw) %>
+<%=     spawnTeamBase(posX, posY, spawnWorldZPos, spawnWorldYaw) %>
 <%
+      end
     else
       # Try a team-submitted vehicle.
       package = config.downcase

--- a/subt_ign/launch/cloudsim_sim.ign
+++ b/subt_ign/launch/cloudsim_sim.ign
@@ -1038,6 +1038,41 @@
     "  </sdf>\n"\
     "</plugin>\n"
   end
+
+  def spawnTeamBase(_x, _y, _z, _yaw)
+    "<plugin name=\"ignition::launch::GazeboFactory\"\n"\
+    "        filename=\"libignition-launch-gazebo-factory.so\">\n"\
+    "  <name>TeamBase</name>\n"\
+    "  <allow_renaming>false</allow_renaming>\n"\
+    "  <world>#{$worldName}</world>\n"\
+    "  <is_performer>false</is_performer>\n"\
+    "  <sdf version='1.6'>\n"\
+    "  <model name='TeamBase'>\n"\
+    "    <pose>#{_x} #{_y} #{_z} 0 0 #{_yaw}</pose>\n"\
+    "    <static>true</static>\n"\
+    "    <link name='link'>\n"\
+    "      <pose>0 0 0.05 0 0 0</pose>\n"\
+    "      <visual name='visual'>\n"\
+    "        <geometry>\n"\
+    "          <box>\n"\
+    "            <size>.1 .1 .1</size>\n"\
+    "          </box>\n"\
+    "        </geometry>\n"\
+    "      </visual>\n"\
+    "    </link>\n"\
+    "    <!-- Publish robot state information -->\n"\
+    "    <plugin filename=\"libignition-gazebo-pose-publisher-system.so\"\n"\
+    "      name=\"ignition::gazebo::systems::PosePublisher\">\n"\
+    "      <publish_link_pose>true</publish_link_pose>\n"\
+    "      <publish_sensor_pose>false</publish_sensor_pose>\n"\
+    "      <publish_collision_pose>false</publish_collision_pose>\n"\
+    "      <publish_visual_pose>false</publish_visual_pose>\n"\
+    "      <publish_nested_model_pose>false</publish_nested_model_pose>\n"\
+    "    </plugin>\n"\
+    "  </model>\n"\
+    "  </sdf>\n"\
+    "</plugin>\n"
+  end
 %>
 
 <%
@@ -1072,6 +1107,12 @@
       robotSpawned += 1
 %>
 <%=   spawnX4(name, robotConfigN, posX, posY, spawnWorldZPos, spawnWorldYaw) %>
+<%
+    elsif (name.downcase == "teambase" || name.downcase == "team_base") &&
+          (config.downcase == "teambase" || config.downcase == "team_base")
+      robotSpawned += 1
+%>
+<%=   spawnTeamBase(posX, posY, spawnWorldZPos, spawnWorldYaw) %>
 <%
     else
       # Try a team-submitted vehicle.

--- a/subt_ign/launch/competition.ign
+++ b/subt_ign/launch/competition.ign
@@ -26,6 +26,8 @@
 %>
 
 <%
+  teamBaseSpawned = false
+
   # Check if robotNameX and robotConfigX exists
   spawnRowSize = 4
   spawnColSize = 5
@@ -1019,9 +1021,12 @@
     elsif (name.downcase == "teambase" || name.downcase == "team_base") &&
           (config.downcase == "teambase" || config.downcase == "team_base")
       robotSpawned += 1
+      if !teamBaseSpawned
+        teamBaseSpawned = true
 %>
-<%=   spawnTeamBase(posX, posY, spawnWorldZPos, spawnWorldYaw) %>
+<%=     spawnTeamBase(posX, posY, spawnWorldZPos, spawnWorldYaw) %>
 <%
+      end
     else
       # Try a team-submitted vehicle.
       package = config.downcase

--- a/subt_ign/launch/competition.ign
+++ b/subt_ign/launch/competition.ign
@@ -970,15 +970,6 @@
     "        </geometry>\n"\
     "      </visual>\n"\
     "    </link>\n"\
-    "    <!-- Publish robot state information -->\n"\
-    "    <plugin filename=\"libignition-gazebo-pose-publisher-system.so\"\n"\
-    "      name=\"ignition::gazebo::systems::PosePublisher\">\n"\
-    "      <publish_link_pose>true</publish_link_pose>\n"\
-    "      <publish_sensor_pose>false</publish_sensor_pose>\n"\
-    "      <publish_collision_pose>false</publish_collision_pose>\n"\
-    "      <publish_visual_pose>false</publish_visual_pose>\n"\
-    "      <publish_nested_model_pose>false</publish_nested_model_pose>\n"\
-    "    </plugin>\n"\
     "  </model>\n"\
     "  </sdf>\n"\
     "</plugin>\n"\

--- a/subt_ign/launch/competition.ign
+++ b/subt_ign/launch/competition.ign
@@ -946,6 +946,47 @@
     "  <command>roslaunch --wait subt_ros vehicle_topics.launch world_name:=#{$worldName} name:=#{_name} uav:=#{uav} laser_scan:=#{laserScan} stereo_cam:=#{stereoCam} rgbd_cam:=#{rgbdCam}</command>\n"\
     "</executable>\n"
   end
+
+  def spawnTeamBase(_x, _y, _z, _yaw)
+    "<plugin name=\"ignition::launch::GazeboFactory\"\n"\
+    "        filename=\"libignition-launch-gazebo-factory.so\">\n"\
+    "  <name>TeamBase</name>\n"\
+    "  <allow_renaming>false</allow_renaming>\n"\
+    "  <world>#{$worldName}</world>\n"\
+    "  <is_performer>false</is_performer>\n"\
+    "  <sdf version='1.6'>\n"\
+    "  <model name='TeamBase'>\n"\
+    "    <pose>#{_x} #{_y} #{_z} 0 0 #{_yaw}</pose>\n"\
+    "    <static>true</static>\n"\
+    "    <link name='link'>\n"\
+    "      <pose>0 0 0.05 0 0 0</pose>\n"\
+    "      <visual name='visual'>\n"\
+    "        <geometry>\n"\
+    "          <box>\n"\
+    "            <size>.1 .1 .1</size>\n"\
+    "          </box>\n"\
+    "        </geometry>\n"\
+    "      </visual>\n"\
+    "    </link>\n"\
+    "    <!-- Publish robot state information -->\n"\
+    "    <plugin filename=\"libignition-gazebo-pose-publisher-system.so\"\n"\
+    "      name=\"ignition::gazebo::systems::PosePublisher\">\n"\
+    "      <publish_link_pose>true</publish_link_pose>\n"\
+    "      <publish_sensor_pose>false</publish_sensor_pose>\n"\
+    "      <publish_collision_pose>false</publish_collision_pose>\n"\
+    "      <publish_visual_pose>false</publish_visual_pose>\n"\
+    "      <publish_nested_model_pose>false</publish_nested_model_pose>\n"\
+    "    </plugin>\n"\
+    "  </model>\n"\
+    "  </sdf>\n"\
+    "</plugin>\n"\
+    "<executable name='teambase_description'>\n"\
+    "  <command>roslaunch --wait subt_ros teambase_description.launch world_name:=#{$worldName}</command>\n"\
+    "</executable>\n"\
+    "<executable name='teambase_ros_ign_bridge'>\n"\
+      "  <command>roslaunch --wait subt_ros teambase_topics.launch world_name:=#{$worldName}</command>\n"\
+    "</executable>\n"
+  end
 %>
 
 <%
@@ -974,6 +1015,12 @@
       robotSpawned += 1
 %>
 <%=   spawnX4(name, robotConfigN, posX, posY) %>
+<%
+    elsif (name.downcase == "teambase" || name.downcase == "team_base") &&
+          (config.downcase == "teambase" || config.downcase == "team_base")
+      robotSpawned += 1
+%>
+<%=   spawnTeamBase(posX, posY, spawnWorldZPos, spawnWorldYaw) %>
 <%
     else
       # Try a team-submitted vehicle.

--- a/subt_ign/launch/tunnel_circuit_practice.ign
+++ b/subt_ign/launch/tunnel_circuit_practice.ign
@@ -962,15 +962,6 @@
     "        </geometry>\n"\
     "      </visual>\n"\
     "    </link>\n"\
-    "    <!-- Publish robot state information -->\n"\
-    "    <plugin filename=\"libignition-gazebo-pose-publisher-system.so\"\n"\
-    "      name=\"ignition::gazebo::systems::PosePublisher\">\n"\
-    "      <publish_link_pose>true</publish_link_pose>\n"\
-    "      <publish_sensor_pose>false</publish_sensor_pose>\n"\
-    "      <publish_collision_pose>false</publish_collision_pose>\n"\
-    "      <publish_visual_pose>false</publish_visual_pose>\n"\
-    "      <publish_nested_model_pose>false</publish_nested_model_pose>\n"\
-    "    </plugin>\n"\
     "  </model>\n"\
     "  </sdf>\n"\
     "</plugin>\n"\

--- a/subt_ign/launch/tunnel_circuit_practice.ign
+++ b/subt_ign/launch/tunnel_circuit_practice.ign
@@ -29,6 +29,8 @@
 %>
 
 <%
+  teamBaseSpawned = false
+
   # Check if robotNameX and robotConfigX exists
   spawnRowSize = 4
   spawnColSize = 5
@@ -1011,9 +1013,12 @@
     elsif (name.downcase == "teambase" || name.downcase == "team_base") &&
           (config.downcase == "teambase" || config.downcase == "team_base")
       robotSpawned += 1
+      if !teamBaseSpawned
+        teamBaseSpawned = true
 %>
-<%=   spawnTeamBase(posX, posY, spawnWorldZPos, spawnWorldYaw) %>
+<%=     spawnTeamBase(posX, posY, spawnWorldZPos, spawnWorldYaw) %>
 <%
+      end
     else
       # Try a team-submitted vehicle.
       package = config.downcase

--- a/subt_ign/launch/tunnel_circuit_practice.ign
+++ b/subt_ign/launch/tunnel_circuit_practice.ign
@@ -938,6 +938,47 @@
     "  <command>roslaunch --wait subt_ros vehicle_topics.launch world_name:=#{$worldName} name:=#{_name} uav:=#{uav} laser_scan:=#{laserScan} stereo_cam:=#{stereoCam} rgbd_cam:=#{rgbdCam}</command>\n"\
     "</executable>\n"
   end
+
+  def spawnTeamBase(_x, _y, _z, _yaw)
+    "<plugin name=\"ignition::launch::GazeboFactory\"\n"\
+    "        filename=\"libignition-launch-gazebo-factory.so\">\n"\
+    "  <name>TeamBase</name>\n"\
+    "  <allow_renaming>false</allow_renaming>\n"\
+    "  <world>#{$worldName}</world>\n"\
+    "  <is_performer>false</is_performer>\n"\
+    "  <sdf version='1.6'>\n"\
+    "  <model name='TeamBase'>\n"\
+    "    <pose>#{_x} #{_y} #{_z} 0 0 #{_yaw}</pose>\n"\
+    "    <static>true</static>\n"\
+    "    <link name='link'>\n"\
+    "      <pose>0 0 0.05 0 0 0</pose>\n"\
+    "      <visual name='visual'>\n"\
+    "        <geometry>\n"\
+    "          <box>\n"\
+    "            <size>.1 .1 .1</size>\n"\
+    "          </box>\n"\
+    "        </geometry>\n"\
+    "      </visual>\n"\
+    "    </link>\n"\
+    "    <!-- Publish robot state information -->\n"\
+    "    <plugin filename=\"libignition-gazebo-pose-publisher-system.so\"\n"\
+    "      name=\"ignition::gazebo::systems::PosePublisher\">\n"\
+    "      <publish_link_pose>true</publish_link_pose>\n"\
+    "      <publish_sensor_pose>false</publish_sensor_pose>\n"\
+    "      <publish_collision_pose>false</publish_collision_pose>\n"\
+    "      <publish_visual_pose>false</publish_visual_pose>\n"\
+    "      <publish_nested_model_pose>false</publish_nested_model_pose>\n"\
+    "    </plugin>\n"\
+    "  </model>\n"\
+    "  </sdf>\n"\
+    "</plugin>\n"\
+    "<executable name='teambase_description'>\n"\
+    "  <command>roslaunch --wait subt_ros teambase_description.launch world_name:=#{$worldName}</command>\n"\
+    "</executable>\n"\
+    "<executable name='teambase_ros_ign_bridge'>\n"\
+      "  <command>roslaunch --wait subt_ros teambase_topics.launch world_name:=#{$worldName}</command>\n"\
+    "</executable>\n"
+  end
 %>
 
 <%
@@ -966,6 +1007,12 @@
       robotSpawned += 1
 %>
 <%=   spawnX4(name, robotConfigN, posX, posY) %>
+<%
+    elsif (name.downcase == "teambase" || name.downcase == "team_base") &&
+          (config.downcase == "teambase" || config.downcase == "team_base")
+      robotSpawned += 1
+%>
+<%=   spawnTeamBase(posX, posY, spawnWorldZPos, spawnWorldYaw) %>
 <%
     else
       # Try a team-submitted vehicle.

--- a/subt_ign/launch/urban_circuit.ign
+++ b/subt_ign/launch/urban_circuit.ign
@@ -999,6 +999,47 @@
     "  <command>roslaunch --wait subt_ros vehicle_topics.launch world_name:=#{$worldName} name:=#{_name} uav:=#{uav} laser_scan:=#{laserScan} stereo_cam:=#{stereoCam} rgbd_cam:=#{rgbdCam}</command>\n"\
     "</executable>\n"
   end
+
+  def spawnTeamBase(_x, _y, _z, _yaw)
+    "<plugin name=\"ignition::launch::GazeboFactory\"\n"\
+    "        filename=\"libignition-launch-gazebo-factory.so\">\n"\
+    "  <name>TeamBase</name>\n"\
+    "  <allow_renaming>false</allow_renaming>\n"\
+    "  <world>#{$worldName}</world>\n"\
+    "  <is_performer>false</is_performer>\n"\
+    "  <sdf version='1.6'>\n"\
+    "  <model name='TeamBase'>\n"\
+    "    <pose>#{_x} #{_y} #{_z} 0 0 #{_yaw}</pose>\n"\
+    "    <static>true</static>\n"\
+    "    <link name='link'>\n"\
+    "      <pose>0 0 0.05 0 0 0</pose>\n"\
+    "      <visual name='visual'>\n"\
+    "        <geometry>\n"\
+    "          <box>\n"\
+    "            <size>.1 .1 .1</size>\n"\
+    "          </box>\n"\
+    "        </geometry>\n"\
+    "      </visual>\n"\
+    "    </link>\n"\
+    "    <!-- Publish robot state information -->\n"\
+    "    <plugin filename=\"libignition-gazebo-pose-publisher-system.so\"\n"\
+    "      name=\"ignition::gazebo::systems::PosePublisher\">\n"\
+    "      <publish_link_pose>true</publish_link_pose>\n"\
+    "      <publish_sensor_pose>false</publish_sensor_pose>\n"\
+    "      <publish_collision_pose>false</publish_collision_pose>\n"\
+    "      <publish_visual_pose>false</publish_visual_pose>\n"\
+    "      <publish_nested_model_pose>false</publish_nested_model_pose>\n"\
+    "    </plugin>\n"\
+    "  </model>\n"\
+    "  </sdf>\n"\
+    "</plugin>\n"\
+    "<executable name='teambase_description'>\n"\
+    "  <command>roslaunch --wait subt_ros teambase_description.launch world_name:=#{$worldName}</command>\n"\
+    "</executable>\n"\
+    "<executable name='teambase_ros_ign_bridge'>\n"\
+      "  <command>roslaunch --wait subt_ros teambase_topics.launch world_name:=#{$worldName}</command>\n"\
+    "</executable>\n"
+  end
 %>
 
 <%
@@ -1033,6 +1074,12 @@
       robotSpawned += 1
 %>
 <%=   spawnX4(name, robotConfigN, posX, posY, spawnWorldZPos, spawnWorldYaw) %>
+<%
+    elsif (name.downcase == "teambase" || name.downcase == "team_base") &&
+          (config.downcase == "teambase" || config.downcase == "team_base")
+      robotSpawned += 1
+%>
+<%=   spawnTeamBase(posX, posY, spawnWorldZPos, spawnWorldYaw) %>
 <%
     else
       # Try a team-submitted vehicle.

--- a/subt_ign/launch/urban_circuit.ign
+++ b/subt_ign/launch/urban_circuit.ign
@@ -1023,15 +1023,6 @@
     "        </geometry>\n"\
     "      </visual>\n"\
     "    </link>\n"\
-    "    <!-- Publish robot state information -->\n"\
-    "    <plugin filename=\"libignition-gazebo-pose-publisher-system.so\"\n"\
-    "      name=\"ignition::gazebo::systems::PosePublisher\">\n"\
-    "      <publish_link_pose>true</publish_link_pose>\n"\
-    "      <publish_sensor_pose>false</publish_sensor_pose>\n"\
-    "      <publish_collision_pose>false</publish_collision_pose>\n"\
-    "      <publish_visual_pose>false</publish_visual_pose>\n"\
-    "      <publish_nested_model_pose>false</publish_nested_model_pose>\n"\
-    "    </plugin>\n"\
     "  </model>\n"\
     "  </sdf>\n"\
     "</plugin>\n"\

--- a/subt_ign/launch/urban_circuit.ign
+++ b/subt_ign/launch/urban_circuit.ign
@@ -35,6 +35,8 @@
   spawnWorldZPos = 7.5
   spawnWorldYaw = 0
 
+  teamBaseSpawned = false
+
   # Check if robotNameX and robotConfigX exists
   spawnRowSize = 4
   spawnColSize = 5
@@ -1078,9 +1080,12 @@
     elsif (name.downcase == "teambase" || name.downcase == "team_base") &&
           (config.downcase == "teambase" || config.downcase == "team_base")
       robotSpawned += 1
+      if !teamBaseSpawned
+        teamBaseSpawned = true
 %>
-<%=   spawnTeamBase(posX, posY, spawnWorldZPos, spawnWorldYaw) %>
+<%=     spawnTeamBase(posX, posY, spawnWorldZPos, spawnWorldYaw) %>
 <%
+      end
     else
       # Try a team-submitted vehicle.
       package = config.downcase

--- a/subt_ign/launch/virtual_stix.ign
+++ b/subt_ign/launch/virtual_stix.ign
@@ -26,6 +26,8 @@
 %>
 
 <%
+  teamBaseSpawned = false
+
   # Check if robotNameX and robotConfigX exists
   spawnRowSize = 4
   spawnColSize = 5
@@ -981,9 +983,12 @@
     elsif (name.downcase == "teambase" || name.downcase == "team_base") &&
           (config.downcase == "teambase" || config.downcase == "team_base")
       robotSpawned += 1
+      if !teamBaseSpawned
+        teamBaseSpawned = true
 %>
-<%=   spawnTeamBase(posX, posY, spawnWorldZPos, spawnWorldYaw) %>
+<%=     spawnTeamBase(posX, posY, spawnWorldZPos, spawnWorldYaw) %>
 <%
+      end
     else
       # Try a team-submitted vehicle.
       package = config.downcase

--- a/subt_ign/launch/virtual_stix.ign
+++ b/subt_ign/launch/virtual_stix.ign
@@ -908,6 +908,47 @@
     "  <command>roslaunch --wait subt_ros vehicle_topics.launch world_name:=#{$worldName} name:=#{_name} uav:=#{uav} laser_scan:=#{laserScan} stereo_cam:=#{stereoCam} rgbd_cam:=#{rgbdCam}</command>\n"\
     "</executable>\n"
   end
+
+  def spawnTeamBase(_x, _y, _z, _yaw)
+    "<plugin name=\"ignition::launch::GazeboFactory\"\n"\
+    "        filename=\"libignition-launch-gazebo-factory.so\">\n"\
+    "  <name>TeamBase</name>\n"\
+    "  <allow_renaming>false</allow_renaming>\n"\
+    "  <world>#{$worldName}</world>\n"\
+    "  <is_performer>false</is_performer>\n"\
+    "  <sdf version='1.6'>\n"\
+    "  <model name='TeamBase'>\n"\
+    "    <pose>#{_x} #{_y} #{_z} 0 0 #{_yaw}</pose>\n"\
+    "    <static>true</static>\n"\
+    "    <link name='link'>\n"\
+    "      <pose>0 0 0.05 0 0 0</pose>\n"\
+    "      <visual name='visual'>\n"\
+    "        <geometry>\n"\
+    "          <box>\n"\
+    "            <size>.1 .1 .1</size>\n"\
+    "          </box>\n"\
+    "        </geometry>\n"\
+    "      </visual>\n"\
+    "    </link>\n"\
+    "    <!-- Publish robot state information -->\n"\
+    "    <plugin filename=\"libignition-gazebo-pose-publisher-system.so\"\n"\
+    "      name=\"ignition::gazebo::systems::PosePublisher\">\n"\
+    "      <publish_link_pose>true</publish_link_pose>\n"\
+    "      <publish_sensor_pose>false</publish_sensor_pose>\n"\
+    "      <publish_collision_pose>false</publish_collision_pose>\n"\
+    "      <publish_visual_pose>false</publish_visual_pose>\n"\
+    "      <publish_nested_model_pose>false</publish_nested_model_pose>\n"\
+    "    </plugin>\n"\
+    "  </model>\n"\
+    "  </sdf>\n"\
+    "</plugin>\n"\
+    "<executable name='teambase_description'>\n"\
+    "  <command>roslaunch --wait subt_ros teambase_description.launch world_name:=#{$worldName}</command>\n"\
+    "</executable>\n"\
+    "<executable name='teambase_ros_ign_bridge'>\n"\
+      "  <command>roslaunch --wait subt_ros teambase_topics.launch world_name:=#{$worldName}</command>\n"\
+    "</executable>\n"
+  end
 %>
 
 <%
@@ -936,6 +977,12 @@
       robotSpawned += 1
 %>
 <%=   spawnX4(name, robotConfigN, posX, posY) %>
+<%
+    elsif (name.downcase == "teambase" || name.downcase == "team_base") &&
+          (config.downcase == "teambase" || config.downcase == "team_base")
+      robotSpawned += 1
+%>
+<%=   spawnTeamBase(posX, posY, spawnWorldZPos, spawnWorldYaw) %>
 <%
     else
       # Try a team-submitted vehicle.

--- a/subt_ign/launch/virtual_stix.ign
+++ b/subt_ign/launch/virtual_stix.ign
@@ -932,15 +932,6 @@
     "        </geometry>\n"\
     "      </visual>\n"\
     "    </link>\n"\
-    "    <!-- Publish robot state information -->\n"\
-    "    <plugin filename=\"libignition-gazebo-pose-publisher-system.so\"\n"\
-    "      name=\"ignition::gazebo::systems::PosePublisher\">\n"\
-    "      <publish_link_pose>true</publish_link_pose>\n"\
-    "      <publish_sensor_pose>false</publish_sensor_pose>\n"\
-    "      <publish_collision_pose>false</publish_collision_pose>\n"\
-    "      <publish_visual_pose>false</publish_visual_pose>\n"\
-    "      <publish_nested_model_pose>false</publish_nested_model_pose>\n"\
-    "    </plugin>\n"\
     "  </model>\n"\
     "  </sdf>\n"\
     "</plugin>\n"\

--- a/subt_ros/launch/teambase_description.launch
+++ b/subt_ros/launch/teambase_description.launch
@@ -1,0 +1,4 @@
+<?xml version="1.0"?>
+<launch>
+  <param name="TeamBase/robot_description" command="$(find xacro)/xacro '$(find teambase_description)/urdf/teambase.xacro'"/>
+</launch>

--- a/subt_ros/launch/teambase_topics.launch
+++ b/subt_ros/launch/teambase_topics.launch
@@ -1,19 +1,4 @@
 <?xml version="1.0"?>
 <launch>
-  <arg name="world_name"/>
-  <arg name="link_name" value="base_link"/>
-  <group ns="TeamBase">
-    <!--Create multipe bridges so that it can run in parallel-->
-    <node
-      pkg="ros_ign_bridge"
-      type="parameter_bridge"
-      name="ros_ign_bridge_pose"
-      args="/model/TeamBase/pose@geometry_msgs/TransformStamped[ignition.msgs.Pose">
-      <remap from="/model/TeamBase/pose" to="pose"/>
-    </node>
-    <node
-      pkg="subt_ros"
-      type="pose_tf_broadcaster"
-      name="pose_tf_broadcaster"/>
-  </group>
+  <node pkg="tf2_ros" type="static_transform_publisher" name="tf_teambase_static" args="0 0 0.05 0 0 0 TeamBase TeamBase/link"/>
 </launch>

--- a/subt_ros/launch/teambase_topics.launch
+++ b/subt_ros/launch/teambase_topics.launch
@@ -1,0 +1,19 @@
+<?xml version="1.0"?>
+<launch>
+  <arg name="world_name"/>
+  <arg name="link_name" value="base_link"/>
+  <group ns="TeamBase">
+    <!--Create multipe bridges so that it can run in parallel-->
+    <node
+      pkg="ros_ign_bridge"
+      type="parameter_bridge"
+      name="ros_ign_bridge_pose"
+      args="/model/TeamBase/pose@geometry_msgs/TransformStamped[ignition.msgs.Pose">
+      <remap from="/model/TeamBase/pose" to="pose"/>
+    </node>
+    <node
+      pkg="subt_ros"
+      type="pose_tf_broadcaster"
+      name="pose_tf_broadcaster"/>
+  </group>
+</launch>

--- a/teambase_description/CMakeLists.txt
+++ b/teambase_description/CMakeLists.txt
@@ -1,0 +1,11 @@
+cmake_minimum_required(VERSION 2.8.3)
+project(teambase_description)
+
+find_package(catkin REQUIRED COMPONENTS roslaunch)
+
+catkin_package()
+
+install(
+  DIRECTORY urdf
+  DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION}
+)

--- a/teambase_description/package.xml
+++ b/teambase_description/package.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0"?>
+<package format="2">
+  <name>teambase_description</name>
+  <version>0.0.1</version>
+  <description>The teambase_description package</description>
+  <author email="nate@openrobotics.org">Nate Koenig</author>
+  <maintainer email="nate@openrobotics.org">Nate Koenig</maintainer>
+  <license>Apache2</license>
+
+  <buildtool_depend>catkin</buildtool_depend>
+  <build_depend>roslaunch</build_depend>
+  <exec_depend>urdf</exec_depend>
+  <exec_depend>xacro</exec_depend>
+</package>

--- a/teambase_description/urdf/teambase.xacro
+++ b/teambase_description/urdf/teambase.xacro
@@ -2,7 +2,7 @@
 <robot name="TeamBase" xmlns:xacro="http://ros.org/wiki/xacro">
   <xacro:property name="robot_namespace" value="TeamBase"/>
 
-  <link name='${robot_namespace}/base_link'>
+  <link name='${robot_namespace}/link'>
    <visual name='visual'>
       <origin xyz='0 0 0.05' rpy='0 0 0'/>
       <geometry>

--- a/teambase_description/urdf/teambase.xacro
+++ b/teambase_description/urdf/teambase.xacro
@@ -1,0 +1,13 @@
+<?xml version='1.0' encoding='utf-8'?>
+<robot name="TeamBase" xmlns:xacro="http://ros.org/wiki/xacro">
+  <xacro:property name="robot_namespace" value="TeamBase"/>
+
+  <link name='${robot_namespace}/base_link'>
+   <visual name='visual'>
+      <origin xyz='0 0 0.05' rpy='0 0 0'/>
+      <geometry>
+        <box size="0.1 0.1 0.1"/>
+      </geometry>
+    </visual>
+  </link>
+</robot>


### PR DESCRIPTION
This adds a `teambase`. The `teambase` cannot move, an is permanently in the staging area. It's specified in the same manner as other robots, but the name and config must be "teambase" or "team_base". Capitalization doesn't matter.

**Example**

```
ign launch cave_circuit.ign worldName:=simple_cave_01 robotName1:=teambase robotConfig1:=teambase
```

You should see a small black box in the staging area. It has no collision object, just a visual.

Only 1 team base is allowed.