### PR TITLE
Add level generator

### DIFF
--- a/subt_ign/CMakeLists.txt
+++ b/subt_ign/CMakeLists.txt
@@ -277,7 +277,7 @@ target_link_libraries(log_checker
 install(TARGETS log_checker
   RUNTIME DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION})
 
-add_executable(dot_generator src/dot_generator.cc src/ConnectionHelper.cc)
+add_executable(dot_generator src/dot_generator.cc src/ConnectionHelper.cc src/SdfParser.cc)
 target_link_libraries(dot_generator
   ignition-math6::ignition-math6
   ignition-common3::ignition-common3
@@ -286,6 +286,17 @@ target_include_directories(dot_generator
   PRIVATE ${CATKIN_DEVEL_PREFIX}/include)
 install(TARGETS dot_generator
   DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION})
+
+add_executable(level_generator src/level_generator.cc src/ConnectionHelper.cc src/SdfParser.cc)
+target_link_libraries(level_generator
+  ignition-math6::ignition-math6
+  ignition-common3::ignition-common3
+  sdformat8::sdformat8)
+target_include_directories(level_generator
+  PRIVATE ${CATKIN_DEVEL_PREFIX}/include)
+install(TARGETS level_generator
+  DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION})
+
 
 ###########
 ## Tests ##

--- a/subt_ign/src/SdfParser.cc
+++ b/subt_ign/src/SdfParser.cc
@@ -1,0 +1,100 @@
+/*
+ * Copyright (C) 2020 Open Source Robotics Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+*/
+
+#include "ConnectionHelper.hh"
+#include "SdfParser.hh"
+
+using namespace ignition;
+using namespace subt;
+
+//////////////////////////////////////////////////
+std::string SdfParser::Parse(const std::string &_key, const std::string &_str,
+     size_t &_endPos)
+{
+  std::string elemStartStr = "<" + _key + ">";
+  std::string elemEndStr = "</" + _key + ">";
+
+  size_t start = _str.find(elemStartStr);
+  if (start == std::string::npos)
+    return std::string();
+  size_t startIdx = start + elemStartStr.size();
+  size_t end = _str.find(elemEndStr, startIdx);
+  if (end == std::string::npos)
+    return std::string();
+
+  _endPos = end + elemEndStr.size();
+  std::string result = _str.substr(startIdx, end - startIdx);
+  return result;
+}
+
+//////////////////////////////////////////////////
+std::string SdfParser::Parse(const std::string &_key, const std::string &_str)
+{
+  size_t endPos;
+  return Parse(_key, _str, endPos);
+}
+
+//////////////////////////////////////////////////
+bool SdfParser::FillVertexData(const std::string &_includeStr, VertexData &_vd,
+  std::function<bool(const std::string &, const std::string &)> &_filter)
+{
+  // parse name
+  std::string name = Parse("name", _includeStr);
+
+  // parse pose
+  std::string poseStr = Parse("pose", _includeStr);
+  math::Pose3d pose;
+  std::stringstream ss(poseStr);
+  ss >> pose;
+
+  // parse uri and get model type
+  std::string uri = Parse("uri", _includeStr);
+  std::string fuelStr =
+      "https://fuel.ignitionrobotics.org/1.0/openrobotics/models/";
+  size_t fuelIdx = uri.find(fuelStr);
+  std::string modelType;
+  if (fuelIdx == std::string::npos)
+    return false;
+  modelType = uri.substr(fuelIdx + fuelStr.size());
+
+  // check if model type is recognized
+  if (_filter && _filter(name, modelType))
+    return false;
+  sdf::Model modelSdf;
+  modelSdf.SetName(name);
+  modelSdf.SetPose(pose);
+
+  static int tileId = 0;
+  // Try getting the tile id from the tile name first.
+  try
+  {
+    int numIndex = name.rfind("_");
+    _vd.id = std::stoi(name.substr(numIndex+1));
+  }
+  catch (...)
+  {
+    _vd.id = tileId++;
+  }
+  _vd.tileType = modelType;
+  _vd.tileName = name;
+  _vd.model = modelSdf;
+
+  return true;
+}
+
+
+

--- a/subt_ign/src/SdfParser.hh
+++ b/subt_ign/src/SdfParser.hh
@@ -1,0 +1,48 @@
+/*
+ * Copyright (C) 2020 Open Source Robotics Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+*/
+
+#include "ConnectionHelper.hh"
+
+namespace subt
+{
+
+class SdfParser
+{
+  /// \brief Parse contents of an sdf element
+  /// \param[in] _key SDF element key
+  /// \param[in] _str String content of the sdf element
+  /// \param[out] _endPos end position of the sdf element string
+  /// \return Value for the input key
+  public: static std::string Parse(const std::string &_key, const std::string &_str,
+       size_t &_endPos);
+
+  /// \brief Parse contents of an sdf element
+  /// \param[in] _key SDF element key
+  /// \param[in] _str String content of the sdf element
+  /// \return Value for the input key
+  public: static std::string Parse(const std::string &_key,
+      const std::string &_str);
+
+  /// \brief Fill VertexData from string
+  /// \param[in] _includeStr input <include> string
+  /// \param[out] _vd Vertex data to be filled
+  /// \return True if vertex data is successfully filled, false otherwise
+  public: static bool FillVertexData(const std::string &_includeStr,
+    VertexData &_vd,
+    std::function<bool(const std::string &, const std::string &)> &_filter);
+};
+}

--- a/subt_ign/src/dot_generator.cc
+++ b/subt_ign/src/dot_generator.cc
@@ -17,43 +17,10 @@
 
 #include <ignition/common/Console.hh>
 #include "ConnectionHelper.hh"
+#include "SdfParser.hh"
 
-using namespace ignition;
 using namespace subt;
-
-/// \brief Parse contents of an sdf element
-/// \param[in] _key SDF element key
-/// \param[in] _str String content of the sdf element
-/// \param[out] _endPos end position of the sdf element string
-/// \return Value for the input key
-std::string parse(const std::string &_key, const std::string &_str,
-     size_t &_endPos)
-{
-  std::string elemStartStr = "<" + _key + ">";
-  std::string elemEndStr = "</" + _key + ">";
-
-  size_t start = _str.find(elemStartStr);
-  if (start == std::string::npos)
-    return std::string();
-  size_t startIdx = start + elemStartStr.size();
-  size_t end = _str.find(elemEndStr, startIdx);
-  if (end == std::string::npos)
-    return std::string();
-
-  _endPos = end + elemEndStr.size();
-  std::string result = _str.substr(startIdx, end - startIdx);
-  return result;
-}
-
-/// \brief Parse contents of an sdf element
-/// \param[in] _key SDF element key
-/// \param[in] _str String content of the sdf element
-/// \return Value for the input key
-std::string parse(const std::string &_key, const std::string &_str)
-{
-  size_t endPos;
-  return parse(_key, _str, endPos);
-}
+using namespace ignition;
 
 /// \brief Print the DOT file
 /// \param[in] _vertexData vector of vertex data containing
@@ -140,57 +107,7 @@ void printGraph(std::vector<VertexData> &_vertexData)
   std::cout << out.str() << std::endl;
 }
 
-/// \brief Fill VertexData from string
-/// \param[in] _includeStr input <include> string
-/// \param[out] _vd Vertex data to be filled
-/// \return True if vertex data is successfully filled, false otherwise
-bool fillVertexData(const std::string &_includeStr, VertexData &_vd)
-{
-  // parse name
-  std::string name = parse("name", _includeStr);
-
-  // parse pose
-  std::string poseStr = parse("pose", _includeStr);
-  math::Pose3d pose;
-  std::stringstream ss(poseStr);
-  ss >> pose;
-
-  // parse uri and get model type
-  std::string uri = parse("uri", _includeStr);
-  std::string fuelStr =
-      "https://fuel.ignitionrobotics.org/1.0/openrobotics/models/";
-  size_t fuelIdx = uri.find(fuelStr);
-  std::string modelType;
-  if (fuelIdx == std::string::npos)
-    return false;
-  modelType = uri.substr(fuelIdx + fuelStr.size());
-
-  // check if model type is recognized
-  if (subt::ConnectionHelper::connectionPoints.count(modelType) <= 0)
-    return false;
-  sdf::Model modelSdf;
-  modelSdf.SetName(name);
-  modelSdf.SetPose(pose);
-
-  static int tileId = 0;
-  // Try getting the tile id from the tile name first.
-  try
-  {
-    int numIndex = name.rfind("_");
-    _vd.id = std::stoi(name.substr(numIndex+1));
-  }
-  catch (...)
-  {
-    _vd.id = tileId++;
-  }
-  _vd.tileType = modelType;
-  _vd.tileName = name;
-  _vd.model = modelSdf;
-
-  return true;
-}
-
-/// \brief Main function to generat DOT from input sdf file
+/// \brief Main function to generate DOT from input sdf file
 /// \param[in] _sdfFile Input sdf file.
 void generateDOT(const std::string &_sdfFile)
 {
@@ -203,16 +120,24 @@ void generateDOT(const std::string &_sdfFile)
   std::string str((std::istreambuf_iterator<char>(file)),
       std::istreambuf_iterator<char>());
 
+  // filter tiles that do not have connections
+  std::function<bool(const std::string &, const std::string &)>
+      filter = [](const std::string &/*_name*/,
+      const std::string &_type)
+  {
+    return subt::ConnectionHelper::connectionPoints.count(_type) <= 0;
+  };
+
   std::vector<VertexData> vertexData;
   while (!str.empty())
   {
     size_t result = std::string::npos;
-    std::string includeStr = parse("include", str, result);
+    std::string includeStr = SdfParser::Parse("include", str, result);
     if (result == std::string::npos || result > str.size())
       break;
 
     VertexData vd;
-    bool filled = fillVertexData(includeStr, vd);
+    bool filled = SdfParser::FillVertexData(includeStr, vd, filter);
     if (filled)
       vertexData.push_back(vd);
 

--- a/subt_ign/src/level_generator.cc
+++ b/subt_ign/src/level_generator.cc
@@ -119,56 +119,32 @@ std::string levelsStr(const std::map<double, Level> &_levels)
 
 /// \brief Print the level sdf elements
 /// \param[in] _vertexData vector of model info
-///\ param[in[ _size Tile size
-///\ param[in[ _buffer Level bfufer size
+/// \param[in] _size Tile size, which is used to compute the size of levels
+/// At minimum this should be the size of largest tile in the world but larger
+/// values can be specified to increase the size of each level.
+/// tile in the world.
+/// \param[in] _buffer Level buffer size
 void printLevels(std::vector<VertexData> &_vertexData,
     const math::Vector3d &_size, double _buffer)
 {
   std::map<double, Level> levelX;
   std::map<double, Level> levelY;
 
-  double minX = std::numeric_limits<double>::max();
-  double minY = minX;
-  double minZ = minX;
-  double maxX = -std::numeric_limits<double>::max();
-  double maxY = maxX;
-  double maxZ = maxX;
+  math::Vector3d min(math::MAX_D, math::MAX_D, math::MAX_D);
+  math::Vector3d max(-math::MAX_D, -math::MAX_D, -math::MAX_D);
 
-  // get min max of xyz of models
+  // get min & max model position values
   for (const auto &vd : _vertexData)
   {
-    double x = vd.model.Pose().Pos().X();
-    double y = vd.model.Pose().Pos().Y();
-    double z = vd.model.Pose().Pos().Z();
-
-    if (x < minX)
-      minX = x;
-    if (y < minY)
-      minY = y;
-    if (z < minZ)
-      minZ = z;
-
-    if (x > maxX)
-      maxX = x;
-    if (y > maxY)
-      maxY = y;
-    if (z > maxZ)
-      maxZ = z;
+    min.Min(vd.model.Pose().Pos());
+    max.Max(vd.model.Pose().Pos());
   }
 
   // compute level size and position
-  double lsx = maxX - minX;
-  double lx = minX + lsx * 0.5;
+  math::Vector3d ls = max - min;
+  math::Vector3d l = min + ls * 0.5;
 
-  double lsy = maxY - minY;
-  double ly = minY + lsy * 0.5;
-
-  double lsz = maxZ - minZ;
-  double lz = minZ + lsz * 0.5;
-
-  lsx += _size.X() * 2.0;
-  lsy += _size.Y() * 2.0;
-  lsz += _size.Z() * 2.0;
+  ls += _size * 2.0;
 
   double levelSizeFactor = 1.875;
 
@@ -183,12 +159,12 @@ void printLevels(std::vector<VertexData> &_vertexData,
     if (levelX.find(x) == levelX.end())
     {
       double rx = x;
-      double ry = ly;
-      double rz = lz;
+      double ry = l.Y();
+      double rz = l.Z();
 
       double rsx = _size.X() * levelSizeFactor;
-      double rsy = lsy;
-      double rsz = lsz;
+      double rsy = ls.Y();
+      double rsz = ls.Z();
 
       Level level;
       level.x = rx;
@@ -205,13 +181,13 @@ void printLevels(std::vector<VertexData> &_vertexData,
     // Create a new level for each unique y
     if (levelY.find(y) == levelY.end())
     {
-      double cx = lx;
+      double cx = l.X();
       double cy = y;
-      double cz = lz;
+      double cz = l.Z();
 
-      double csx = lsx;
+      double csx = ls.X();
       double csy = _size.Y() * levelSizeFactor;
-      double csz = lsz;
+      double csz = ls.Z();
 
       Level level;
       level.x = cx;
@@ -247,7 +223,10 @@ void printLevels(std::vector<VertexData> &_vertexData,
 
 /// \brief Main function to generate levels from input sdf file
 /// \param[in] _sdfFile Input sdf file.
-/// \param[in] _size Tile size
+/// \param[in] _size Tile size, which is used to compute the size of levels
+/// At minimum this should be the size of largest tile in the world but larger
+/// values can be specified to increase the size of each level.
+/// tile in the world.
 /// \param[in] _buffer Buffer of level
 void generateLevel(const std::string &_sdfFile, const math::Vector3d &_size,
     double _buffer)

--- a/subt_ign/src/level_generator.cc
+++ b/subt_ign/src/level_generator.cc
@@ -295,7 +295,7 @@ int main(int argc, char **argv)
 {
   if (argc != 7)
   {
-    std::cerr << "Usage: dot_generator <path_to_world_sdf_file> "
+    std::cerr << "Usage: level_generator <path_to_world_sdf_file> "
               << "<size_x> <size_y> <size_z> <buffer> <output_file>"
               << std::endl;
     return -1;

--- a/subt_ign/src/level_generator.cc
+++ b/subt_ign/src/level_generator.cc
@@ -1,0 +1,313 @@
+/*
+ * Copyright (C) 2020 Open Source Robotics Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+*/
+
+#include <ignition/common/Console.hh>
+#include "ConnectionHelper.hh"
+#include "SdfParser.hh"
+
+using namespace ignition;
+using namespace subt;
+
+/// \brief Data structure containing properties of a level
+struct Level
+{
+  /// \brief Position X
+  double x;
+
+  /// \brief Position Y
+  double y;
+
+  /// \brief Position Z
+  double z;
+
+  /// \brief Size x
+  double sx;
+
+  /// \brief Size y
+  double sy;
+
+  /// \brief Size z
+  double sz;
+
+  /// \brief Buffer of a level
+  double buffer;
+
+  /// \brief A list of models referenced by this level
+  std::vector<std::string> refs;
+};
+
+/// \brief A list of models to ignore when generating levels
+const std::set<std::string> modelsToIgnore =
+{
+  "staging_area", "base_station", "artifact_origin"
+};
+
+/// \brief Set to true to print debug visuals
+bool debugLevels = false;
+
+/// \brief Print debug visuals the levels sdf string
+/// \param[in] _levels List of levels to debug
+void printDebugVisuals(const std::map<double, Level> &_levels)
+{
+  std::stringstream out;
+  static int debugCounter = 0;
+
+  for (const auto &lIt : _levels)
+  {
+    auto l = lIt.second;
+    out << "    <model name=\"level_debug_" << std::to_string(debugCounter++)
+        << "\">\n";
+    out << "      <pose>" << l.x << " " << l.y << " " << l.z
+                          << " 0 0 0</pose>\n";
+    out << "      <link name=\"level_debug_link\">\n";
+    out << "        <visual name=\"level_debug_visual\">\n";
+    out << "          <transparency>0.2</transparency>\n";
+    out << "          <geometry><box><size>\n";
+    out << "            " << l.sx << " " << l.sy << " " << l.sz << "\n";
+    out << "          </size></box></geometry>\n";
+    out << "          <material><diffuse>1 0 0</diffuse></material>\n";
+    out << "          <cast_shadows>false</cast_shadows>\n";
+    out << "        </visual>\n";
+    out << "      </link>\n";
+    out << "      <static>true</static>\n";
+    out << "    </model>\n";
+  }
+  std::cout << out.str() << std::endl;
+}
+
+/// \brief Get the levels sdf string
+/// \param[in] _level input map of levels
+std::string levelsStr(const std::map<double, Level> &_levels)
+{
+  static int levelCounter = 0;
+  std::stringstream out;
+  for (const auto &lIt : _levels)
+  {
+    auto l = lIt.second;
+    out << "      <level name=\"level" << std::to_string(levelCounter++)
+        << "\">\n";
+
+    for (const auto &r : l.refs)
+    {
+      out << "        <ref>" << r << "</ref>\n";
+    }
+    out << "        <pose>" << l.x << " " << l.y << " " << l.z
+                            << " 0 0 0</pose>\n";
+    out << "        <geometry><box><size>" << l.sx << " " << l.sy << " " << l.sz
+                            << "</size></box></geometry>\n";
+    out << "        <buffer>" << l.buffer << "</buffer>\n";
+
+    out << "      </level>\n";
+  }
+  return out.str();
+}
+
+
+/// \brief Print the level sdf elements
+/// \param[in] _vertexData vector of model info
+///\ param[in[ _size Tile size
+///\ param[in[ _buffer Level bfufer size
+void printLevels(std::vector<VertexData> &_vertexData,
+    const math::Vector3d &_size, double _buffer)
+{
+  std::map<double, Level> levelX;
+  std::map<double, Level> levelY;
+
+  double minX = std::numeric_limits<double>::max();
+  double minY = minX;
+  double minZ = minX;
+  double maxX = -std::numeric_limits<double>::max();
+  double maxY = maxX;
+  double maxZ = maxX;
+
+  // get min max of xyz of models
+  for (const auto &vd : _vertexData)
+  {
+    double x = vd.model.Pose().Pos().X();
+    double y = vd.model.Pose().Pos().Y();
+    double z = vd.model.Pose().Pos().Z();
+
+    if (x < minX)
+      minX = x;
+    if (y < minY)
+      minY = y;
+    if (z < minZ)
+      minZ = z;
+
+    if (x > maxX)
+      maxX = x;
+    if (y > maxY)
+      maxY = y;
+    if (z > maxZ)
+      maxZ = z;
+  }
+
+  // compute level size and position
+  double lsx = maxX - minX;
+  double lx = minX + lsx * 0.5;
+
+  double lsy = maxY - minY;
+  double ly = minY + lsy * 0.5;
+
+  double lsz = maxZ - minZ;
+  double lz = minZ + lsz * 0.5;
+
+  lsx += _size.X() * 2.0;
+  lsy += _size.Y() * 2.0;
+  lsz += _size.Z() * 2.0;
+
+  double levelSizeFactor = 1.875;
+
+  for (const auto &vd : _vertexData)
+  {
+    std::string name = vd.tileName;
+
+    double x = vd.model.Pose().Pos().X();
+    double y = vd.model.Pose().Pos().Y();
+
+    // Create a new level for each unique x
+    if (levelX.find(x) == levelX.end())
+    {
+      double rx = x;
+      double ry = ly;
+      double rz = lz;
+
+      double rsx = _size.X() * levelSizeFactor;
+      double rsy = lsy;
+      double rsz = lsz;
+
+      Level level;
+      level.x = rx;
+      level.y = ry;
+      level.z = rz;
+      level.sx = rsx;
+      level.sy = rsy;
+      level.sz = rsz;
+      level.buffer = _buffer;
+      levelX[x] = level;
+    }
+    levelX[x].refs.push_back(name);
+
+    // Create a new level for each unique y
+    if (levelY.find(y) == levelY.end())
+    {
+      double cx = lx;
+      double cy = y;
+      double cz = lz;
+
+      double csx = lsx;
+      double csy = _size.Y() * levelSizeFactor;
+      double csz = lsz;
+
+      Level level;
+      level.x = cx;
+      level.y = cy;
+      level.z = cz;
+      level.sx = csx;
+      level.sy = csy;
+      level.sz = csz;
+      level.buffer = _buffer;
+      levelY[y] = level;
+    }
+    levelY[y].refs.push_back(name);
+  }
+
+  // print out plugin with all the levels
+  std::stringstream out;
+  out << "    <!-- Auto generated: level_generator "
+      << _size << " " << _buffer << " -->\n";
+  out << "    <plugin name=\"ignition::gazebo\" filename=\"dummy\">\n";
+  out << levelsStr(levelX);
+  out << levelsStr(levelY);
+  out << "    </plugin>";
+  std::cout << out.str() << std::endl;
+
+
+  // print debug visuals
+  if (debugLevels)
+  {
+    printDebugVisuals(levelX);
+    printDebugVisuals(levelY);
+  }
+}
+
+/// \brief Main function to generate levels from input sdf file
+/// \param[in] _sdfFile Input sdf file.
+/// \param[in] _size Tile size
+/// \param[in] _buffer Buffer of level
+void generateLevel(const std::string &_sdfFile, const math::Vector3d &_size,
+    double _buffer)
+{
+  std::ifstream file(_sdfFile);
+  if (!file.is_open())
+  {
+    std::cerr << "Failed to read file " << _sdfFile << std::endl;
+    return;
+  }
+  std::string str((std::istreambuf_iterator<char>(file)),
+      std::istreambuf_iterator<char>());
+
+  // filter models that are in the staging area
+  std::function<bool(const std::string &, const std::string &)>
+      filter = [](const std::string &_name,
+      const std::string &/*_type*/)
+  {
+    return modelsToIgnore.count(_name) > 0;
+  };
+
+  std::vector<VertexData> vertexData;
+  while (!str.empty())
+  {
+    size_t result = std::string::npos;
+    std::string includeStr = SdfParser::Parse("include", str, result);
+    if (result == std::string::npos || result > str.size())
+      break;
+
+    VertexData vd;
+    bool filled = SdfParser::FillVertexData(includeStr, vd, filter);
+    if (filled)
+      vertexData.push_back(vd);
+
+    str = str.substr(result);
+  }
+
+  printLevels(vertexData, _size, _buffer);
+
+  file.close();
+}
+
+//////////////////////////////////////////////////
+int main(int argc, char **argv)
+{
+  if (argc != 6)
+  {
+    std::cerr << "Usage: dot_generator <path_to_world_sdf_file> "
+              << "<size_x> <size_y> <size_z> <buffer>"
+              << std::endl;
+    return -1;
+  }
+  std::string sdfFile = argv[1];
+
+  double sx = std::stod(argv[2]);
+  double sy = std::stod(argv[3]);
+  double sz = std::stod(argv[4]);
+  double buffer = std::stod(argv[5]);
+
+  generateLevel(sdfFile, math::Vector3d(sx, sy, sz), buffer);
+
+  return 0;
+}


### PR DESCRIPTION
There are two methods for level generation in the origin tile_tsv.py script: 1) row and col method, and 2) single tile (distance based) method. This PR ports the row and col level generation method to a program called `level_generator`  

The code for parsing sdf file from the `dot_generator` was refactored and reused in the `level_generator`

usage:

```
./level_generator <path_to_sdf> <size_x> <size_y> <size_z> <buffer> <output_file>
```

example:

```
./level_generator simple_cave_01.sdf 25 25 25 5 simple_cave_01.sdf
```

**Note** remove the existing levels before running the `level_generator` to avoid adding duplicate levels to the sdf

I checked the results against the levels in urban practice worlds. The order of `<level>` SDF params and names do not match due to differences in how tiles and artifacts are read and stored. So manually compared the level positions and geometry size and they seem to be correct. One key difference is that the z pos and size of level in the original script are hardcoded but the new `level_generator` computes these z values. This is because the vertical depth of the cave worlds can be much larger than previous circuits..

For testing, you can set [debugLevels](https://github.com/osrf/subt/compare/cave_feature_release1...level_generator?expand=1#diff-0630163bb4dab92293c50c7c7b2397fbR60) to `true` to also print out a list of visuals representing the levels. There will be quite a bit of overlap (and z fighting) between visuals so it may be easier to select and highlight these debug levels by using the `EntityTree` gui plugin.

Signed-off-by: Ian Chen <ichen@osrfoundation.org>