### PR TITLE
Remove std::regex from CommsBrokerPlugin

### DIFF
--- a/subt_ign/src/CommsBrokerPlugin.cc
+++ b/subt_ign/src/CommsBrokerPlugin.cc
@@ -19,7 +19,6 @@
 
 #include <functional>
 #include <mutex>
-#include <regex>
 
 #include <ignition/common/Console.hh>
 #include <ignition/common/Util.hh>
@@ -312,8 +311,8 @@ void CommsBrokerPlugin::UpdateIfNewBreadcrumbs()
   {
     // New breadcrumb found.
     // A static model is spawned when the breadcrumb is made static
-    if (std::regex_match(name,
-        std::regex(".*__breadcrumb___(\\d+)__static__")) &&
+    if (name.find("__breadcrumb__") != std::string::npos &&
+        name.find("__static__") != std::string::npos &&
         this->breadcrumbs.find(name) == this->breadcrumbs.end())
     {
       this->breadcrumbs[name] = pose;


### PR DESCRIPTION
`std::regex` is painfully slow and causes a very slow callback in `OnPose()` processing Ignition poses. This is generating a huge queue of incoming messages and a major delay processing them.

How to test?

Replace the `for` loop in `CommsBrokerPlugin.cc::OnPose()` with this one:

```
// Update all the published poses
for (int i = 0; i < _msg.pose_size(); ++i)
{
  this->poses[_msg.pose(i).name()] = ignition::msgs::Convert(_msg.pose(i));
  if (_msg.pose(i).name() == "X1")
    std::cout << "X1 pose: " << this->poses[_msg.pose(i).name()] << std::endl;
}
```

Now launch your world:

```
ign launch cave_circuit.ign worldName:=cave_circuit_practice_02 robotName1:=X1 robotConfig1:=X1_SENSOR_CONFIG_1
```

And teleoperate your robot:

```
roslaunch subt_example teleop.launch
```

Without this patch you should observe that changes in the position of your robot take a while until are noticed by the callback. This issue should be fixed with this patch.