### PR TITLE
Add example world showing dynamic obstacles

### DIFF
--- a/subt_ign/worlds/dynamic_rocks_test.sdf
+++ b/subt_ign/worlds/dynamic_rocks_test.sdf
@@ -1,0 +1,121 @@
+<?xml version="1.0" ?>
+<!--
+World for testing out dynamic obstacles. To launch, run:
+
+```
+ign launch -v 4 cave_circuit.ign  robotName1:=Xa robotConfig1:=X1_SENSOR_CONFIG_1  worldName:=dynamic_rocks_test
+```
+
+Then send a velocity command to the X1 to move it toward the entrance of the cave.
+When the vehicle reaches the entrance, dynamic rocks will be deployed
+
+```
+rostopic pub /Xa/cmd_vel geometry_msgs/Twist "{x: 0.5}" "{z: -0.05}" 
+```
+-->
+<sdf version="1.6">
+  <world name="dynamic_rocks_test">
+
+    <physics name="1ms" type="ode">
+      <max_step_size>0.004</max_step_size>
+      <real_time_factor>1.0</real_time_factor>
+    </physics>
+
+    <scene>
+      <ambient>0.1 0.1 0.1 1.0</ambient>
+      <background>0 0 0 1.0</background>
+      <grid>false</grid>
+      <origin_visual>false</origin_visual>
+    </scene>
+
+    <!-- The staging area -->
+    <include>
+      <static>true</static>
+      <name>staging_area</name>
+      <pose>0 0 0 0 0 0</pose>
+      <uri>https://fuel.ignitionrobotics.org/1.0/OpenRobotics/models/Cave Starting Area Type B</uri>
+    </include>
+
+
+    <!-- The base station -->
+    <include>
+      <static>true</static>
+      <name>base_station</name>
+      <pose>-8 0 0 0 0 -1.5708</pose>
+      <uri>https://fuel.ignitionrobotics.org/1.0/OpenRobotics/models/Base Station</uri>
+    </include>
+
+    <!-- Fiducial marking the origin for artifacts reports -->
+    <include>
+      <name>artifact_origin</name>
+      <pose>10.0 0.0 0.0 0 0 0</pose>
+      <uri>https://fuel.ignitionrobotics.org/1.0/OpenRobotics/models/Fiducial</uri>
+    </include>
+
+
+    <!--Dynamic obstacles -->
+    <include>
+      <name>dynamic_rocks_1</name>
+      <uri>https://fuel.ignitionrobotics.org/1.0/azeey/models/Dynamic Rocks Test</uri>
+      <pose>1.0 0.800000 7.0 0 0 0</pose>
+    </include>
+
+    <!--Performer detector at cave entrance-->
+    <model name="performer_detector_1">
+      <static>true</static>
+      <pose>15.5 -0.9 5 0 0 0</pose>
+      <link name='body'>
+        <visual name="v1">
+          <transparency>1.0</transparency>
+          <geometry>
+            <box>
+              <size>10 10 10</size>
+            </box>
+          </geometry>
+        </visual>
+        <material>
+          <ambient>0.0 1.0 0.0 1</ambient>
+          <diffuse>0.0 1.0 0.0 1</diffuse>
+          <specular>0.5 0.5 0.5 1</specular>
+        </material>
+        <cast_shadows>false</cast_shadows>
+      </link>
+      <plugin filename="libignition-gazebo-performer-detector-system.so"
+        name="ignition::gazebo::systems::PerformerDetector">
+      <topic>/subt_performer_detector</topic>
+      <geometry>
+        <box>
+          <size>10 10 10</size>
+        </box>
+      </geometry>
+    </plugin>
+
+    <!--TriggeredPublisher that publishes on the "deploy" topic of dynamic_rocks_1 when a performer enters the region defined in performer_detector_1-->
+    <plugin name="ignition::gazebo::systems::TriggeredPublisher" filename="libignition-gazebo-triggered-publisher-system.so">
+      <input type="ignition.msgs.Pose" topic="/subt_performer_detector">
+        <match field="header.data">
+            {
+              key: "frame_id"
+              value: "performer_detector_1"
+            }
+        </match>
+        <match field="header.data">
+            {
+              key: "state"
+              value: "1"
+            }
+        </match>
+      </input>
+      <output type="ignition.msgs.Empty" topic="/model/dynamic_rocks_1/breadcrumbs/Rock/deploy"/>
+    </plugin>
+
+  </model>
+
+    <include>
+      <name>tile_30</name>
+      <uri>https://fuel.ignitionrobotics.org/1.0/OpenRobotics/models/Cave Straight 05 Type B</uri>
+      <pose>25.000000 0.000000 0.000000 0 0 1.570796</pose>
+    </include>
+
+  </world>
+</sdf>


### PR DESCRIPTION
**This PR is only for visibility. Once all the relevant PRs are merged and we validate this approach, we can add the dynamic obstacles to the circuit world files**

-----------------------

This PR adds a world for testing out dynamic obstacles. To launch, run:
```
ign launch -v 4 cave_circuit.ign  robotName1:=Xa robotConfig1:=X1_SENSOR_CONFIG_1  worldName:=dynamic_rocks_test
```
Then send a velocity command to the X1 to move it toward the entrance of the cave.
When the vehicle reaches the entrance, dynamic rocks will be deployed
```
rostopic pub /Xa/cmd_vel geometry_msgs/Twist "{x: 0.5}" "{z: -0.05}" 
```

I have uploaded Fuel models for individual rocks to the OpenRobotics org, but I put the `Dynamic Rocks` model in my personal account because I wasn't sure if we are going to have only one `Dynamic Rocks` model.

Requires:
* PerformerDetector: ignitionrobotics/ign-gazebo#125 
* TriggeredPublisher: ignitionrobotics/ign-gazebo#139 
* Breadcrumb renaming: ignitionrobotics/ign-gazebo#155 