### PR TITLE
Support aws cli version 2

### DIFF
--- a/subt_ign/scripts/subt_docker.bash
+++ b/subt_ign/scripts/subt_docker.bash
@@ -28,7 +28,15 @@ fi
 
 # Log into docker
 echo "Logging into docker"
-$(aws ecr get-login --no-include-email --region us-east-1)
+awsVersion=`aws --version`
+if [[ "$awsVersion" == *"aws-cli/1"* ]]; then
+  $(aws ecr get-login --no-include-email --region us-east-1)
+elif [[ "$awsVersion" == *"aws-cli/2"* ]]; then
+  $(aws ecr get-login-password --region us-east-1 | docker login --username AWS --password-stdin 200670743174.dkr.ecr.us-east-1.amazonaws.com)
+else
+  echo "Unsupported aws cli version $awsVersion"
+  exit
+fi
 
 if [ $? != 0 ]; then
   echo "Failed to log into docker. Check your AWS credentials."


### PR DESCRIPTION
AWS ECR login has changed in version 2 of the `aws` cli tool.

Signed-off-by: Nate Koenig <nate@openrobotics.org>