### PR TITLE
Use github actions to build and push images to dockerhub

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -28,7 +28,7 @@ jobs:
       - name: Tag image
         run: docker tag ${{ matrix.image_name }}:latest ${{ env.registry }}:${{ matrix.image_name }}_latest
 
-      # only reserverd for subt_sim_entry
+      # only reserved for subt_sim_entry
       - name: Tag latest image
         run: docker tag ${{ matrix.image_name }}:latest ${{ env.registry }}/subt:latest
         if: matrix.image_name == 'subt_sim_entry'

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -42,7 +42,6 @@ jobs:
       - name: Push to docker
         uses: actions-hub/docker@master
         env:
-          NAME: ${{ matrix.image_name }}
           TAG: ${{ env.registry }}:${{ matrix.image_name }}_latest
         with:
           args: push ${IMAGE_TAG}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,4 +1,4 @@
-name: Relase to dockerhub
+name: Release to dockerhub
 on:
   push:
     tags:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,62 @@
+name: Relase to dockerhub
+on:
+  push:
+    tags:
+      - dockerhub_release_*  # Launch dockerhub push on dockerhub_release_* tags
+jobs:
+  build_docker_image:
+    runs-on: ubuntu-latest
+    env:
+      registry: osrf/subt-virtual-testbed
+    strategy:
+      matrix:
+        image_name: ['cloudsim_sim', 'cloudsim_bridge', 'subt_shell', 'subt_sim_entry']
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v2
+
+      - name: Install base dependencies
+        if: ${{ success() }}
+        run: |
+          sudo apt update;
+          sudo apt-get install -y docker
+
+      - name: Run build script
+        if: ${{ success() }}
+        run: |
+            cd docker
+            bash +xe ./build.bash ${{ matrix.image_name }}
+
+      - name: Tag image
+        if: ${{ success() }}
+        run: docker tag ${{ matrix.image_name }}:latest ${{ env.registry }}:${{ matrix.image_name }}_latest
+
+      # only reserverd for subt_sim_entry
+      - name: Tag latest image
+        run: docker tag ${{ matrix.image_name }}:latest ${{ env.registry }}/subt:latest
+        if: matrix.image_name == 'subt_sim_entry'
+
+      - name: Login to docker hub
+        if: ${{ success() }}
+        uses: actions-hub/docker/login@master
+        env:
+          DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
+          DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
+
+      - name: Push to docker
+        if: ${{ success() }}
+        uses: actions-hub/docker@master
+        env:
+          NAME: ${{ matrix.image_name }}
+          TAG: ${{ env.registry }}:${{ matrix.image_name }}_latest
+        with:
+          args: push ${IMAGE_TAG}
+
+      - name: Push latest to docker
+        uses: actions-hub/docker@master
+        env:
+          NAME: ${{ matrix.image_name }}
+          TAG: ${{ env.registry }}:latest
+        with:
+          args: push ${IMAGE_TAG}
+        if: matrix.image_name == 'subt_sim_entry'

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -16,19 +16,16 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Install base dependencies
-        if: ${{ success() }}
         run: |
           sudo apt update;
           sudo apt-get install -y docker
 
       - name: Run build script
-        if: ${{ success() }}
         run: |
             cd docker
             bash +xe ./build.bash ${{ matrix.image_name }}
 
       - name: Tag image
-        if: ${{ success() }}
         run: docker tag ${{ matrix.image_name }}:latest ${{ env.registry }}:${{ matrix.image_name }}_latest
 
       # only reserverd for subt_sim_entry
@@ -37,14 +34,12 @@ jobs:
         if: matrix.image_name == 'subt_sim_entry'
 
       - name: Login to docker hub
-        if: ${{ success() }}
         uses: actions-hub/docker/login@master
         env:
           DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
           DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
 
       - name: Push to docker
-        if: ${{ success() }}
         uses: actions-hub/docker@master
         env:
           NAME: ${{ matrix.image_name }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -55,7 +55,6 @@ jobs:
       - name: Push latest to docker
         uses: actions-hub/docker@master
         env:
-          NAME: ${{ matrix.image_name }}
           TAG: ${{ env.registry }}:latest
         with:
           args: push ${IMAGE_TAG}


### PR DESCRIPTION
The PR implements an auto-mechanism to generate the docker images and push them into the dockerhub. The way it currently works:

 * Requires credentials setup in subt repository (dockerhub user + token)
 * Trigger the build when someone push a tag with the name `dockerhub_release_*` (we can use any other interaction to trigger the build, tag seemed to me flexible enough but we could also consider the `releases` mechanism in github)
 * The job will trigger four different builds, one per docker image, define in `image_name` (see [my testing repo](https://github.com/j-rivero/subt/actions/runs/136258747))
 * It uses the docker/build.sh script
 * There is a special threatment for `subt_sim_entry` which seems to be the one producing the `latest` image (see how actions [are ignoring these steps for other images](https://github.com/j-rivero/subt/runs/767112433?check_suite_focus=true)).

Please be sure that [the images in my dockerhub ](https://hub.docker.com/r/jlrivero/subt/tags)matches the one in subt. 

TODO: I did not implement anything related to `-private` repository. Please let me know if we need to do it.
