### PR TITLE
Limit joint state publication

### DIFF
--- a/submitted_models/marble_hd2_sensor_config_1/model.sdf
+++ b/submitted_models/marble_hd2_sensor_config_1/model.sdf
@@ -1100,7 +1100,10 @@
             <plugin filename="libignition-gazebo-apply-joint-force-system.so" name="ignition::gazebo::systems::ApplyJointForce">
               <joint_name>tilt_gimbal_joint</joint_name>
             </plugin>
-            <plugin filename="libignition-gazebo-joint-state-publisher-system.so" name="ignition::gazebo::systems::JointStatePublisher"/>
+            <plugin filename="libignition-gazebo-joint-state-publisher-system.so" name="ignition::gazebo::systems::JointStatePublisher">
+              <joint_name>pan_gimbal_joint</joint_name>
+              <joint_name>tilt_gimbal_joint</joint_name>
+            </plugin>
             <static>0</static>
           </model>
         </sdf>

--- a/submitted_models/marble_husky_sensor_config_1/model.sdf
+++ b/submitted_models/marble_husky_sensor_config_1/model.sdf
@@ -1024,6 +1024,8 @@
     <plugin
       filename="libignition-gazebo-joint-state-publisher-system.so"
       name="ignition::gazebo::systems::JointStatePublisher">
+      <joint_name>pan_gimbal_joint</joint_name>
+      <joint_name>tilt_gimbal_joint</joint_name>
     </plugin>
     <static>0</static>
   </model>


### PR DESCRIPTION
Limit joint state publication to the gimbal joints in two of the Marble robots.

Signed-off-by: Nate Koenig <nate@openrobotics.org>