### PR TITLE
SubT catkin install via Docker (Also useful for breadcumbs visualization)

### DIFF
--- a/docker/catkin_install/Dockerfile
+++ b/docker/catkin_install/Dockerfile
@@ -1,0 +1,68 @@
+# Ubuntu 18.04 with nvidia-docker2 beta opengl support
+FROM nvidia/opengl:1.0-glvnd-devel-ubuntu18.04
+
+# setup timezone
+RUN echo 'Etc/UTC' > /etc/timezone && \
+  ln -s /usr/share/zoneinfo/Etc/UTC /etc/localtime && \
+  apt-get update && \
+  apt-get -q -y install --no-install-recommends tzdata && \
+  rm -rf /var/lib/apt/lists/*
+
+# install packages
+RUN apt-get update && apt-get -q -y install --no-install-recommends \
+  # dirmngr \
+  lsb-release \
+  # gnupg2 is needed for apt-key
+  gnupg2 \
+  wget \
+  && rm -rf /var/lib/apt/lists/*
+
+RUN echo "deb http://packages.ros.org/ros/ubuntu $(lsb_release -sc) main" > /etc/apt/sources.list.d/ros-latest.list
+
+RUN apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-key C1CF6E31E6BADE8868B172B4F42ED6FBAB17C654
+
+RUN echo "deb http://packages.osrfoundation.org/gazebo/ubuntu-stable `lsb_release -cs` main" > /etc/apt/sources.list.d/gazebo-stable.list
+
+RUN wget http://packages.osrfoundation.org/gazebo.key -O - | apt-key add -
+
+RUN apt-get update && apt-get -q -y install --no-install-recommends \
+  build-essential \
+  cmake \
+  ignition-blueprint \
+  libusb-dev \
+  lsb-release \
+  pkg-config python \
+  python3-colcon-common-extensions \
+  python3-vcstool \
+  ros-melodic-desktop \
+  ros-melodic-joy \
+  ros-melodic-robot-localization \
+  ros-melodic-ros-control \
+  ros-melodic-ros-ign \
+  ros-melodic-rotors-control \
+  ros-melodic-teleop-twist-keyboard \
+  ros-melodic-tf2-sensor-msgs \
+  ros-melodic-twist-mux \
+  && rm -rf /var/lib/apt/lists/*
+
+# Add new sudo user (based on https://wiki.ros.org/docker/Tutorials/GUI#The_isolated_way)
+# Requires a docker build argument `user_id`
+ARG user_id
+ENV USERNAME dev
+RUN useradd -m $USERNAME && \
+  echo "$USERNAME:$USERNAME" | chpasswd && \
+  usermod --shell /bin/bash $USERNAME && \
+  usermod -aG sudo $USERNAME && \
+  echo "$USERNAME ALL=(ALL) NOPASSWD:ALL" >> /etc/sudoers.d/$USERNAME && \
+  chmod 0440 /etc/sudoers.d/$USERNAME && \
+  usermod  --uid ${user_id} $USERNAME && \
+  groupmod --gid ${user_id} $USERNAME
+
+USER ${USERNAME}
+
+# create a workspace in the user's home directory
+# (this is where the subt repo can be mounted as a volume)
+WORKDIR /home/${USERNAME}
+RUN mkdir -p subt_ws/src
+
+CMD [ "/bin/bash" ]

--- a/docker/catkin_install/Dockerfile
+++ b/docker/catkin_install/Dockerfile
@@ -45,10 +45,6 @@ RUN apt-get update && apt-get -q -y install --no-install-recommends \
   ros-melodic-twist-mux \
   && rm -rf /var/lib/apt/lists/*
 
-# Download the public models
-COPY download_models.sh ./
-RUN ./download_models.sh
-
 # Add new sudo user (based on https://wiki.ros.org/docker/Tutorials/GUI#The_isolated_way)
 # Requires a docker build argument `user_id`
 ARG user_id
@@ -68,5 +64,9 @@ USER ${USERNAME}
 # (this is where the subt repo can be mounted as a volume)
 WORKDIR /home/${USERNAME}
 RUN mkdir -p subt_ws/src
+
+# Download the public models
+COPY download_models.sh ./
+RUN ./download_models.sh
 
 CMD [ "/bin/bash" ]

--- a/docker/catkin_install/Dockerfile
+++ b/docker/catkin_install/Dockerfile
@@ -45,6 +45,10 @@ RUN apt-get update && apt-get -q -y install --no-install-recommends \
   ros-melodic-twist-mux \
   && rm -rf /var/lib/apt/lists/*
 
+# Download the public models
+COPY download_models.sh ./
+RUN ./download_models.sh
+
 # Add new sudo user (based on https://wiki.ros.org/docker/Tutorials/GUI#The_isolated_way)
 # Requires a docker build argument `user_id`
 ARG user_id

--- a/docker/catkin_install/README.md
+++ b/docker/catkin_install/README.md
@@ -1,0 +1,86 @@
+# SubT Repo - Catkin Installation
+
+The files in this directory can be used to follow the [subt catkin install](https://github.com/osrf/subt/wiki/Catkin%20System%20Setup) instructions through a Docker image.
+
+This may be useful for doing things like [breadcrumbs visualization](https://github.com/osrf/subt/wiki/Breadcrumbs-and-communication-visualization-tutorial).
+
+## Installation
+
+```
+$ ./build_img.bash
+```
+
+## Usage
+
+First, clone the [subt](https://github.com/osrf/subt) and [ros_ign](https://github.com/ignitionrobotics/ros_ign) (optional - needed for breadcrumbs visualization) repositories in the same directory.
+This directory with these repositories will be loaded into the Docker container as a volume.
+The container's location for this volume is `~/subt_ws/src`, with `~/subt_ws` being the root of the workspace in the container.
+
+To start a container:
+
+```
+# PATH/TO/REPOS should be a directory that contains the subt and ros_ign repos
+$ ./start_container.bash PATH/TO/REPOS
+```
+
+To start another bash session in an existing container:
+
+```
+./join.bash
+```
+
+### Example Usage - Building a Workspace
+
+Once you are in the container, you may want to run something like the following commands to build the workspace:
+
+```
+$ cd ~/subt_ws
+$ . /opt/ros/melodic/setup.bash
+$ colcon build    # OR run 'catkin_make install'
+```
+
+### Example Usage - Breadcrumbs Visualization
+
+Go trough the following steps in order to perform breadcrumbs visualization:
+
+1. Clone the [subt](https://github.com/osrf/subt) and [ros_ign](https://github.com/ignitionrobotics/ros_ign) repositories into a directory, using the right branches.
+
+```
+$ cd ~
+$ mkdir repos
+$ cd repos/
+$ git clone --branch citadel https://github.com/osrf/subt.git
+$ git clone --branch melodic https://github.com/ignitionrobotics/ros_ign.git
+```
+
+2. Start a container that loads these repositories as a volume
+
+```
+$ ./start_container.bash ~/repos
+```
+
+3. In the container, remove ignition blueprint and install ignition citadel
+
+```
+$ sudo apt -y remove ignition-blueprint && sudo apt update && sudo apt -y install ignition-citadel
+```
+
+4. Build the workspace. Be sure to source ROS first
+
+```
+$ . /opt/ros/melodic/setup.bash
+$ cd ~/subt_ws/
+$ colcon build
+```
+
+5. Go to the [Deploy a breadcrumb and visualize communications](https://github.com/osrf/subt/wiki/Breadcrumbs-and-communication-visualization-tutorial#deploy-a-breadcrumb-and-visualize-communications) section of the breadcrumbs visualization tutorial and complete the remaining steps in that tutorial, performing all of the commands in the docker container (remember that you can use `join.bash` in order to access another shell in the Docker container if needed).
+
+_Calling the breadcrumbs visualization service in the tutorial can take a while, so so don't worry if the service call does not return right away._
+
+## Other Notes
+
+If you need to install new packages in the container (for example: breadcrumbs visualization requires you to install ignition citadel), be sure to run the following command first:
+
+```
+$ sudo apt update
+```

--- a/docker/catkin_install/build_img.bash
+++ b/docker/catkin_install/build_img.bash
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+
+docker build -t subt_catkin_install --build-arg user_id=$(id -u) .

--- a/docker/catkin_install/build_img.bash
+++ b/docker/catkin_install/build_img.bash
@@ -1,3 +1,3 @@
 #!/usr/bin/env bash
 
-docker build -t subt_catkin_install --build-arg user_id=$(id -u) .
+docker build -t subt_catkin_install --build-arg user_id=$(id -u) -f ./Dockerfile ./../

--- a/docker/catkin_install/join.bash
+++ b/docker/catkin_install/join.bash
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+
+docker exec -it subt_catkin_container /bin/bash

--- a/docker/catkin_install/start_container.bash
+++ b/docker/catkin_install/start_container.bash
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+
+if [ $# -ne 1 ]
+then
+  echo "Usage: $0 PATH_TO_REPOS"
+  exit 1
+fi
+
+# load repo into the workspace as a volume
+CONTAINER_WS_PATH="/home/dev/subt_ws/src/"
+WS_DIR=$1
+echo "Workspace: $WS_DIR -> $CONTAINER_WS_PATH"
+REPO_VOLUME_MOUNT="-v $WS_DIR:$CONTAINER_WS_PATH"
+
+XSOCK=/tmp/.X11-unix
+XAUTH=/tmp/.docker.xauth
+touch $XAUTH
+xauth nlist $DISPLAY | sed -e 's/^..../ffff/' | xauth -f $XAUTH nmerge -
+
+# need privileged flag or else things like rviz fail:
+# https://answers.ros.org/question/301056/ros2-rviz-in-docker-container/
+# https://github.com/moby/moby/issues/38442
+docker run -it \
+  --volume=$XSOCK:$XSOCK:rw \
+  --volume=$XAUTH:$XAUTH:rw \
+  --env="XAUTHORITY=${XAUTH}" \
+  --env="DISPLAY" \
+  --user="dev" \
+  --name subt_catkin_container \
+  --network host \
+  --privileged \
+  --rm \
+  --runtime=nvidia \
+  $REPO_VOLUME_MOUNT \
+  subt_catkin_install:latest


### PR DESCRIPTION
I've added a directory to the `docker` directory called `catkin_install`. This directory contains everything needed to use a SubT catkin installation through Docker (both simulation and source code capabilities).

This directory can also be used for breadcrumbs visualization. Take a look at the [README](https://github.com/osrf/subt/blob/catkin_install_docker/docker/catkin_install/README.md) for instructions on how to do this.

Also, I've found that the only way for me to get breadcrumbs visualization to work is by using the `citadel` branch of the `subt` repo. Would it be worth looking into merging `citadel` into `master`?

Signed-off-by: Ashton Larkin <ashton@openrobotics.org>