### PR TITLE
Adds a competition countdown clock

### DIFF
--- a/subt_ign/src/GameLogicPlugin.cc
+++ b/subt_ign/src/GameLogicPlugin.cc
@@ -462,7 +462,7 @@ void GameLogicPlugin::Configure(const ignition::gazebo::Entity & /*_entity*/,
     this->dataPtr->node.Advertise<ignition::msgs::StringMsg>("/subt/start");
 
   this->dataPtr->competitionClockPub =
-    this->dataPtr->node.Advertise<ignition::msgs::Clock>("/subt/clock");
+    this->dataPtr->node.Advertise<ignition::msgs::Clock>("/subt/run_clock");
 
   this->dataPtr->publishThread.reset(new std::thread(
         &GameLogicPluginPrivate::PublishScore, this->dataPtr.get()));
@@ -726,10 +726,16 @@ void GameLogicPlugin::PostUpdate(
     }
     else if (!this->dataPtr->finished)
     {
-      mapData->add_value("warmup");
+      mapData->add_value("setup");
       competitionClockMsg.mutable_sim()->set_sec(
           this->dataPtr->warmupTimeSec - this->dataPtr->simTime.sec());
     }
+    else
+    {
+      // It's possible for a team to call Finish before starting.
+      mapData->add_value("finished");
+    }
+
     this->dataPtr->competitionClockPub.Publish(competitionClockMsg);
 
     ignition::msgs::StringMsg msg;

--- a/subt_ros/CMakeLists.txt
+++ b/subt_ros/CMakeLists.txt
@@ -15,6 +15,16 @@ find_package(catkin REQUIRED COMPONENTS
   subt_communication_broker
 )
 
+add_message_files(
+  FILES
+  CompetitionClock.msg
+)
+
+generate_messages(
+  DEPENDENCIES
+  std_msgs
+)
+
 find_package(ignition-common3 REQUIRED)
 find_package(ignition-math6 REQUIRED)
 find_package(ignition-msgs4 REQUIRED)
@@ -24,6 +34,7 @@ catkin_package(
   CATKIN_DEPENDS
     message_runtime
     subt_communication_broker
+    std_msgs
     topic_tools
   )
 

--- a/subt_ros/msg/CompetitionClock.msg
+++ b/subt_ros/msg/CompetitionClock.msg
@@ -1,0 +1,7 @@
+# This message represents subt competition clock.
+
+# The current phase: "warmup", "run", or "finished"
+string phase
+
+# Count down clock data for the current period.
+time data

--- a/subt_ros/msg/CompetitionClock.msg
+++ b/subt_ros/msg/CompetitionClock.msg
@@ -1,6 +1,6 @@
 # This message represents subt competition clock.
 
-# The current phase: "warmup", "run", or "finished"
+# The current phase: "setup", "run", or "finished"
 string phase
 
 # Count down clock data for the current period.

--- a/subt_ros/package.xml
+++ b/subt_ros/package.xml
@@ -24,6 +24,7 @@
   <exec_depend>compressed_image_transport</exec_depend>
   <exec_depend>message_runtime</exec_depend>
   <exec_depend>topic_tools</exec_depend>
+  <exec_depend>std_msgs</exec_depend>
 
   <export>
   </export>

--- a/subt_ros/src/SubtRosRelay.cc
+++ b/subt_ros/src/SubtRosRelay.cc
@@ -215,12 +215,13 @@ SubtRosRelay::SubtRosRelay()
 
   this->node.Subscribe("/subt/score", &SubtRosRelay::OnScore, this);
 
-  this->node.Subscribe("/subt/clock", &SubtRosRelay::OnCompetitionClock, this);
+  this->node.Subscribe("/subt/run_clock",
+      &SubtRosRelay::OnCompetitionClock, this);
 
   this->rosScorePub =
     this->rosnode->advertise<std_msgs::Int32>("score", 1000);
   this->rosCompetitionClockPub =
-    this->rosnode->advertise<subt_ros::CompetitionClock>("clock", 1000);
+    this->rosnode->advertise<subt_ros::CompetitionClock>("run_clock", 1000);
 }
 
 //////////////////////////////////////////////////

--- a/subt_ros/src/SubtRosRelay.cc
+++ b/subt_ros/src/SubtRosRelay.cc
@@ -18,6 +18,7 @@
 #include <ros/ros.h>
 #include <std_srvs/SetBool.h>
 #include <std_msgs/Int32.h>
+#include <std_msgs/Time.h>
 #include <ignition/common/Util.hh>
 #include <ignition/msgs/boolean.pb.h>
 #include <ignition/msgs/float.pb.h>
@@ -43,6 +44,16 @@ class SubtRosRelay
   /// \brief Ign callback for score topic and the data is republished to ROS
   /// \param[in] _msg Score msg
   public: void OnScore(const ignition::msgs::Float &_msg);
+
+  /// \brief Ign callback for competition clock and the data is republished
+  /// to ROS
+  /// \param[in] _msg Time msg
+  public: void OnCompetitionClock(const ignition::msgs::Time &_msg);
+
+  /// \brief Ign callback for warmup clock and the data is republished
+  /// to ROS
+  /// \param[in] _msg Time msg
+  public: void OnWarmupClock(const ignition::msgs::Time &_msg);
 
   /// \brief ROS service callback triggered when the service is called.
   /// \param[in]  _req The message containing a flag telling if the game
@@ -134,6 +145,12 @@ class SubtRosRelay
   /// \brief ROS publisher to publish score data
   public: ros::Publisher rosScorePub;
 
+  /// \brief ROS publisher for competition clock data.
+  public: ros::Publisher rosCompetitionClockPub;
+
+  /// \brief ROS publisher for warmup clock data.
+  public: ros::Publisher rosWarmupClockPub;
+
   /// \brief ROS service server to receive the location of a robot relative to
   /// the origin artifact.
   public: ros::ServiceServer poseFromArtifactService;
@@ -205,8 +222,18 @@ SubtRosRelay::SubtRosRelay()
 
   this->node.Subscribe("/subt/score", &SubtRosRelay::OnScore, this);
 
+  this->node.Subscribe("/subt/clock/competition",
+      &SubtRosRelay::OnCompetitionClock, this);
+
+  this->node.Subscribe("/subt/clock/warmup",
+      &SubtRosRelay::OnWarmupClock, this);
+
   this->rosScorePub =
     this->rosnode->advertise<std_msgs::Int32>("score", 1000);
+  this->rosCompetitionClockPub =
+    this->rosnode->advertise<std_msgs::Time>("clock/competition", 1000);
+  this->rosWarmupClockPub =
+    this->rosnode->advertise<std_msgs::Time>("clock/warmup", 1000);
 }
 
 //////////////////////////////////////////////////
@@ -220,6 +247,24 @@ void SubtRosRelay::OnScore(const ignition::msgs::Float &_msg)
   std_msgs::Int32 rosMsg;
   rosMsg.data = _msg.data();
   this->rosScorePub.publish(rosMsg);
+}
+
+/////////////////////////////////////////////////
+void SubtRosRelay::OnCompetitionClock(const ignition::msgs::Time &_msg)
+{
+  std_msgs::Time timeMsg;
+  timeMsg.data.sec = _msg.sec();
+  timeMsg.data.nsec = _msg.nsec();
+  this->rosCompetitionClockPub.publish(timeMsg);
+}
+
+/////////////////////////////////////////////////
+void SubtRosRelay::OnWarmupClock(const ignition::msgs::Time &_msg)
+{
+  std_msgs::Time timeMsg;
+  timeMsg.data.sec = _msg.sec();
+  timeMsg.data.nsec = _msg.nsec();
+  this->rosWarmupClockPub.publish(timeMsg);
 }
 
 /////////////////////////////////////////////////


### PR DESCRIPTION
Introduces a `/subt/clock` topic on both Ignition and ROS.

The Ignition message look like:

```
header {
  data {
    key: "phase"
    value: "run"
  }
}
sim {
  sec: 5
}
```

The ROS message looks like:

```
phase: "run"
data: 
  secs: 5
  nsecs:         0
```

The phases are: `warmup`, `run`, `finished`. 

The clock counts down the time left in a phase.

## To test

1. `ign launch cave_circuit.ign worldName:=simple_cave_01 robotName1:=X1 robotConfig1:=X1_SENSOR_CONFIG_1 durationSec:=10`

2. `ign topic -et /subt/clock`

3. `rostopic echo /subt/clock`

4. Teleop the robot into the tunnel using: `roslaunch subt_example teleop.launch`

5. The duration is set to 10seconds, so you should see all three phases.