### PR TITLE
Log robot position and elevation data

### DIFF
--- a/subt_ign/src/GameLogicPlugin.cc
+++ b/subt_ign/src/GameLogicPlugin.cc
@@ -1530,6 +1530,13 @@ void GameLogicPluginPrivate::LogRobotPosData()
 {
   std::string path = common::joinPaths(this->logPath, "pos-data");
 
+  // remove previous pos data on start
+  if (this->lastUpdateScoresTime.time_since_epoch().count() == 0u)
+  {
+    common::removeAll(path);
+    common::createDirectory(path);
+  }
+
   // log robot pos data
   for (auto &it : this->robotPoseData)
   {


### PR DESCRIPTION
Robot position data are streamed to individual log files in `/tmp/ign/logs/pos-data` directory, named as `<robot_name>-pos.data`. The positions samples are taken when the robot has moved for more than 1m. Each entry in the position data log file consists of space delimited numbers in the format of `<second> <nanosecond> <x> <y> <z>`

Robot elevation data are logged to `run.yml`. The data are:

 17. Greatest cumulative elevation gain by a robot on the team
 18. Greatest cumulative elevation loss by a robot on the team
 19. Total cumulative elevation gain by all the robots.
 20. Total cumulative elevation loss by all the robots.
 21. Max elevation reached by a robot
 22. Min elevation reached by a robot

Both the robot position and elevation logs are updated at 30 sec (real time) intervals or when start/finish is triggered.