### PR TITLE
Comms broadcast behavior testing files

### DIFF
--- a/comms_broadcast_test/CMakeLists.txt
+++ b/comms_broadcast_test/CMakeLists.txt
@@ -1,0 +1,34 @@
+cmake_minimum_required(VERSION 3.0.2)
+project(comms_broadcast_test)
+
+find_package(catkin REQUIRED COMPONENTS
+  roscpp
+  subt_communication_broker
+)
+
+catkin_package(
+)
+
+include_directories(
+# include
+  ${catkin_INCLUDE_DIRS}
+)
+
+add_executable(${PROJECT_NAME}_node
+  src/test_node.cc
+)
+
+target_link_libraries(${PROJECT_NAME}_node
+  ${catkin_LIBRARIES}
+)
+
+install(TARGETS ${PROJECT_NAME}_node
+  RUNTIME DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}
+)
+
+## Mark cpp header files for installation
+# install(DIRECTORY include/${PROJECT_NAME}/
+#   DESTINATION ${CATKIN_PACKAGE_INCLUDE_DESTINATION}
+#   FILES_MATCHING PATTERN "*.h"
+#   PATTERN ".svn" EXCLUDE
+# )

--- a/comms_broadcast_test/package.xml
+++ b/comms_broadcast_test/package.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0"?>
+<package format="2">
+  <name>comms_broadcast_test</name>
+  <version>0.0.0</version>
+  <description>The comms_broadcast_test package</description>
+
+  <maintainer email="ashton@openrobotics.org">Ashton Larkin</maintainer>
+
+  <license>Apache 2.0</license>
+
+  <buildtool_depend>catkin</buildtool_depend>
+
+  <depend>roscpp</depend>
+  <depend>subt_communication_broker</depend>
+</package>

--- a/comms_broadcast_test/src/test_node.cc
+++ b/comms_broadcast_test/src/test_node.cc
@@ -1,0 +1,58 @@
+#include <string>
+
+#include <ros/ros.h>
+#include <subt_communication_broker/subt_communication_client.h>
+
+const int port = 5000;
+subt::CommsClient *x1_commsClient;
+
+void X2_IncomingMsgCallback(const std::string & srcAddress,
+                            const std::string & dstAddress,
+                            const uint32_t dstPort,
+                            const std::string & data);
+
+void TimerCallback(const ros::TimerEvent &);
+
+int main(int argc, char *argv[])
+{
+  ros::init(argc, argv, "comms_broadcast_test_node");
+  ros::NodeHandle nh;
+
+  // CommsClient for robot X1
+  // This CommsClient will send msgs to X2
+  std::string robot_X1 = "X1";
+  x1_commsClient = new subt::CommsClient(robot_X1);
+
+  // CommsClient for robot X2
+  // This CommsClient will receive msgs from X1
+  std::string robot_X2 = "X2";
+  subt::CommsClient x2_commsClient(robot_X2);
+  x2_commsClient.Bind(&X2_IncomingMsgCallback,
+                      robot_X2,
+                      port);
+
+  auto timer = nh.createTimer(ros::Duration(1.0), &TimerCallback, true);
+
+  ros::spin();
+}
+
+void X2_IncomingMsgCallback(const std::string & srcAddress,
+                            const std::string & dstAddress,
+                            const uint32_t dstPort,
+                            const std::string & data)
+{
+  ROS_INFO_STREAM("Received a message from "
+                  << srcAddress
+                  << " intended for "
+                  << dstAddress
+                  << " on port "
+                  << dstPort);
+
+  // TODO do something with "data" here
+}
+
+void TimerCallback(const ros::TimerEvent &)
+{
+  ROS_INFO("Sending message...\n");
+  x1_commsClient->SendTo("hello", subt::communication_broker::kBroadcast, port);
+}


### PR DESCRIPTION
Here is a package you can use to test the `broadcast` functionality for communications. Here is how you can use this package:

1. Start a simulator with two robots (they must be named `X1` and `X2`):
`ign launch -v 4 cave_circuit.ign worldName:=cave_qual robotName1:=X1 robotConfig1:=X1_SENSOR_CONFIG_1 robotName2:=X2 robotConfig2:=X1_SENSOR_CONFIG_1`

2. Run the comms test node:
`rosrun comms_broadcast_test comms_broadcast_test_node`

_However, after I tested this setup, I found that I did not have the duplicate message reception/callback trigger issue I mentioned to you earlier, so I am starting to wonder if it's actually an issue on my end..._