### PR TITLE
Add theora_image_transport to package.xml in subt_ros

### DIFF
--- a/subt_ros/package.xml
+++ b/subt_ros/package.xml
@@ -14,6 +14,7 @@
   <depend>ignition-math6</depend>
   <depend>ignition-msgs4</depend>
   <depend>ignition-transport7</depend>
+  <depend>theora_image_transport</depend>
   <depend>tf2</depend>
   <depend>tf2_ros</depend>
   <depend>urdf</depend>


### PR DESCRIPTION
Being used at `subt_ros/src/BridgeLogger.cc:#include <theora_image_transport/Packet.h>`