### PR TITLE
Remove extra topics and joint states from Absolem model

### DIFF
--- a/submitted_models/ctu_cras_norlab_absolem_sensor_config_1/launch/vehicle_topics.launch
+++ b/submitted_models/ctu_cras_norlab_absolem_sensor_config_1/launch/vehicle_topics.launch
@@ -122,7 +122,7 @@
       type="parameter_bridge"
       name="ros_ign_bridge_laser"
       args="/model/$(arg name)/joint/laser_j/cmd_vel@std_msgs/Float64]ignition.msgs.Double">
-      <remap from="/model/$(arg name)/joint/laser_j/cmd_vel" to="scanning_speed_cmd"/>
+      <remap from="/model/$(arg name)/joint/laser_j/cmd_vel" to="lidar_gimbal/roll_rate_cmd_double"/>
     </node>
     
     <!-- Joint Publisher (Publishes to topic but doesn't control...)-->

--- a/submitted_models/ctu_cras_norlab_absolem_sensor_config_1/launch/vehicle_topics.launch
+++ b/submitted_models/ctu_cras_norlab_absolem_sensor_config_1/launch/vehicle_topics.launch
@@ -131,7 +131,7 @@
       type="parameter_bridge"
       name="ros_ign_bridge_joint_state_publisher"
       args="/world/$(arg world_name)/model/$(arg name)/joint_state@sensor_msgs/JointState[ignition.msgs.Model">
-      <remap from="/world/$(arg world_name)/model/$(arg name)/joint_state" to="joint_states"/>
+      <remap from="/world/$(arg world_name)/model/$(arg name)/joint_state" to="joint_state"/>
     </node>
     
     <!-- Slightly downward looking RGBD camera -->

--- a/submitted_models/ctu_cras_norlab_absolem_sensor_config_1/launch/vehicle_topics.launch
+++ b/submitted_models/ctu_cras_norlab_absolem_sensor_config_1/launch/vehicle_topics.launch
@@ -382,10 +382,4 @@
     </group>
   </group>
   
-    <!-- As URDF->SDF conversion "swallows" all fixed joints (and thus static transforms), we need to re-create them from the URDF  -->
-    <!-- Due to an internal limitation of robot_state_publisher, it has to be created in the global namespace. -->
-    <node name="$(anon robot_state_publisher)" pkg="robot_state_publisher" type="robot_state_publisher">
-      <remap from="/tf" to="/nonexistent" /> <!-- published by ign_ros bridge -->
-      <remap from="robot_description" to="/$(arg name)/robot_description" />
-    </node>
 </launch>

--- a/submitted_models/ctu_cras_norlab_absolem_sensor_config_1/launch/vehicle_topics.launch
+++ b/submitted_models/ctu_cras_norlab_absolem_sensor_config_1/launch/vehicle_topics.launch
@@ -199,7 +199,7 @@
       type="parameter_bridge"
       name="ros_ign_bridge_omnicam0"
       args="$(arg link_prefix)/base_link/sensor/omnicam_sensor0/camera_info@sensor_msgs/CameraInfo[ignition.msgs.CameraInfo">
-      <remap from="$(arg link_prefix)/base_link/sensor/omnicam_sensor0/camera_info" to="viz/camera_0/camera_info"/>
+      <remap from="$(arg link_prefix)/base_link/sensor/omnicam_sensor0/camera_info" to="omni/camera_0/camera_info"/>
     </node>
     <node
       pkg="ros_ign_image"
@@ -207,16 +207,16 @@
       name="ros_ign_image_omnicam0"
       respawn="true"
       args="$(arg link_prefix)/base_link/sensor/omnicam_sensor0/image">
-      <remap from="$(arg link_prefix)/base_link/sensor/omnicam_sensor0/image" to="viz/camera_0/image_raw"/>
+      <remap from="$(arg link_prefix)/base_link/sensor/omnicam_sensor0/image" to="omni/camera_0/image_raw"/>
     </node>
     <node
       pkg="subt_ros"
       type="optical_frame_publisher"
       name="optical_frame_publisher_omnicam0">
-      <remap from="input/image" to="viz/camera_0/image_raw" />
-      <remap from="output/image" to="viz/camera_0/optical/image_raw" />
-      <remap from="input/camera_info" to="viz/camera_0/camera_info" />
-      <remap from="output/camera_info" to="viz/camera_0/optical/camera_info" />
+      <remap from="input/image" to="omni/camera_0/image_raw" />
+      <remap from="output/image" to="omni/camera_0/optical/image_raw" />
+      <remap from="input/camera_info" to="omni/camera_0/camera_info" />
+      <remap from="output/camera_info" to="omni/camera_0/optical/camera_info" />
     </node>
     
     <node
@@ -224,7 +224,7 @@
       type="parameter_bridge"
       name="ros_ign_bridge_omnicam1"
       args="$(arg link_prefix)/base_link/sensor/omnicam_sensor1/camera_info@sensor_msgs/CameraInfo[ignition.msgs.CameraInfo">
-      <remap from="$(arg link_prefix)/base_link/sensor/omnicam_sensor1/camera_info" to="viz/camera_1/camera_info"/>
+      <remap from="$(arg link_prefix)/base_link/sensor/omnicam_sensor1/camera_info" to="omni/camera_1/camera_info"/>
     </node>
     <node
       pkg="ros_ign_image"
@@ -232,16 +232,16 @@
       name="ros_ign_image_omnicam1"
       respawn="true"
       args="$(arg link_prefix)/base_link/sensor/omnicam_sensor1/image">
-      <remap from="$(arg link_prefix)/base_link/sensor/omnicam_sensor1/image" to="viz/camera_1/image_raw"/>
+      <remap from="$(arg link_prefix)/base_link/sensor/omnicam_sensor1/image" to="omni/camera_1/image_raw"/>
     </node>
     <node
       pkg="subt_ros"
       type="optical_frame_publisher"
       name="optical_frame_publisher_omnicam1">
-      <remap from="input/image" to="viz/camera_1/image_raw" />
-      <remap from="output/image" to="viz/camera_1/optical/image_raw" />
-      <remap from="input/camera_info" to="viz/camera_1/camera_info" />
-      <remap from="output/camera_info" to="viz/camera_1/optical/camera_info" />
+      <remap from="input/image" to="omni/camera_1/image_raw" />
+      <remap from="output/image" to="omni/camera_1/optical/image_raw" />
+      <remap from="input/camera_info" to="omni/camera_1/camera_info" />
+      <remap from="output/camera_info" to="omni/camera_1/optical/camera_info" />
     </node>
 
     <node
@@ -249,7 +249,7 @@
       type="parameter_bridge"
       name="ros_ign_bridge_omnicam2"
       args="$(arg link_prefix)/base_link/sensor/omnicam_sensor2/camera_info@sensor_msgs/CameraInfo[ignition.msgs.CameraInfo">
-      <remap from="$(arg link_prefix)/base_link/sensor/omnicam_sensor2/camera_info" to="viz/camera_2/camera_info"/>
+      <remap from="$(arg link_prefix)/base_link/sensor/omnicam_sensor2/camera_info" to="omni/camera_2/camera_info"/>
     </node>
     <node
       pkg="ros_ign_image"
@@ -257,16 +257,16 @@
       name="ros_ign_image_omnicam2"
       respawn="true"
       args="$(arg link_prefix)/base_link/sensor/omnicam_sensor2/image">
-      <remap from="$(arg link_prefix)/base_link/sensor/omnicam_sensor2/image" to="viz/camera_2/image_raw"/>
+      <remap from="$(arg link_prefix)/base_link/sensor/omnicam_sensor2/image" to="omni/camera_2/image_raw"/>
     </node>
     <node
       pkg="subt_ros"
       type="optical_frame_publisher"
       name="optical_frame_publisher_omnicam2">
-      <remap from="input/image" to="viz/camera_2/image_raw" />
-      <remap from="output/image" to="viz/camera_2/optical/image_raw" />
-      <remap from="input/camera_info" to="viz/camera_2/camera_info" />
-      <remap from="output/camera_info" to="viz/camera_2/optical/camera_info" />
+      <remap from="input/image" to="omni/camera_2/image_raw" />
+      <remap from="output/image" to="omni/camera_2/optical/image_raw" />
+      <remap from="input/camera_info" to="omni/camera_2/camera_info" />
+      <remap from="output/camera_info" to="omni/camera_2/optical/camera_info" />
     </node>
 
     <node
@@ -275,23 +275,23 @@
       name="ros_ign_bridge_omnicam3"
       respawn="true"
       args="$(arg link_prefix)/base_link/sensor/omnicam_sensor3/camera_info@sensor_msgs/CameraInfo[ignition.msgs.CameraInfo">
-      <remap from="$(arg link_prefix)/base_link/sensor/omnicam_sensor3/camera_info" to="viz/camera_3/camera_info"/>
+      <remap from="$(arg link_prefix)/base_link/sensor/omnicam_sensor3/camera_info" to="omni/camera_3/camera_info"/>
     </node>
     <node
       pkg="ros_ign_image"
       type="image_bridge"
       name="ros_ign_image_omnicam3"
       args="$(arg link_prefix)/base_link/sensor/omnicam_sensor3/image">
-      <remap from="$(arg link_prefix)/base_link/sensor/omnicam_sensor3/image" to="viz/camera_3/image_raw"/>
+      <remap from="$(arg link_prefix)/base_link/sensor/omnicam_sensor3/image" to="omni/camera_3/image_raw"/>
     </node>
     <node
       pkg="subt_ros"
       type="optical_frame_publisher"
       name="optical_frame_publisher_omnicam3">
-      <remap from="input/image" to="viz/camera_3/image_raw" />
-      <remap from="output/image" to="viz/camera_3/optical/image_raw" />
-      <remap from="input/camera_info" to="viz/camera_3/camera_info" />
-      <remap from="output/camera_info" to="viz/camera_3/optical/camera_info" />
+      <remap from="input/image" to="omni/camera_3/image_raw" />
+      <remap from="output/image" to="omni/camera_3/optical/image_raw" />
+      <remap from="input/camera_info" to="omni/camera_3/camera_info" />
+      <remap from="output/camera_info" to="omni/camera_3/optical/camera_info" />
     </node>
 
     <node
@@ -299,7 +299,7 @@
       type="parameter_bridge"
       name="ros_ign_bridge_omnicam4"
       args="$(arg link_prefix)/base_link/sensor/omnicam_sensor4/camera_info@sensor_msgs/CameraInfo[ignition.msgs.CameraInfo">
-      <remap from="$(arg link_prefix)/base_link/sensor/omnicam_sensor4/camera_info" to="viz/camera_4/camera_info"/>
+      <remap from="$(arg link_prefix)/base_link/sensor/omnicam_sensor4/camera_info" to="omni/camera_4/camera_info"/>
     </node>
     <node
       pkg="ros_ign_image"
@@ -307,16 +307,16 @@
       name="ros_ign_image_omnicam4"
       respawn="true"
       args="$(arg link_prefix)/base_link/sensor/omnicam_sensor4/image">
-      <remap from="$(arg link_prefix)/base_link/sensor/omnicam_sensor4/image" to="viz/camera_4/image_raw"/>
+      <remap from="$(arg link_prefix)/base_link/sensor/omnicam_sensor4/image" to="omni/camera_4/image_raw"/>
     </node>
     <node
       pkg="subt_ros"
       type="optical_frame_publisher"
       name="optical_frame_publisher_omnicam4">
-      <remap from="input/image" to="viz/camera_4/image_raw" />
-      <remap from="output/image" to="viz/camera_4/optical/image_raw" />
-      <remap from="input/camera_info" to="viz/camera_4/camera_info" />
-      <remap from="output/camera_info" to="viz/camera_4/optical/camera_info" />
+      <remap from="input/image" to="omni/camera_4/image_raw" />
+      <remap from="output/image" to="omni/camera_4/optical/image_raw" />
+      <remap from="input/camera_info" to="omni/camera_4/camera_info" />
+      <remap from="output/camera_info" to="omni/camera_4/optical/camera_info" />
     </node>
 
     <node
@@ -324,7 +324,7 @@
       type="parameter_bridge"
       name="ros_ign_bridge_omnicam5"
       args="$(arg link_prefix)/base_link/sensor/omnicam_sensor5/camera_info@sensor_msgs/CameraInfo[ignition.msgs.CameraInfo">
-      <remap from="$(arg link_prefix)/base_link/sensor/omnicam_sensor5/camera_info" to="viz/camera_5/camera_info"/>
+      <remap from="$(arg link_prefix)/base_link/sensor/omnicam_sensor5/camera_info" to="omni/camera_5/camera_info"/>
     </node>
     <node
       pkg="ros_ign_image"
@@ -332,16 +332,16 @@
       name="ros_ign_image_omnicam5"
       respawn="true"
       args="$(arg link_prefix)/base_link/sensor/omnicam_sensor5/image">
-      <remap from="$(arg link_prefix)/base_link/sensor/omnicam_sensor5/image" to="viz/camera_5/image_raw"/>
+      <remap from="$(arg link_prefix)/base_link/sensor/omnicam_sensor5/image" to="omni/camera_5/image_raw"/>
     </node>
     <node
       pkg="subt_ros"
       type="optical_frame_publisher"
       name="optical_frame_publisher_omnicam5">
-      <remap from="input/image" to="viz/camera_5/image_raw" />
-      <remap from="output/image" to="viz/camera_5/optical/image_raw" />
-      <remap from="input/camera_info" to="viz/camera_5/camera_info" />
-      <remap from="output/camera_info" to="viz/camera_5/optical/camera_info" />
+      <remap from="input/image" to="omni/camera_5/image_raw" />
+      <remap from="output/image" to="omni/camera_5/optical/image_raw" />
+      <remap from="input/camera_info" to="omni/camera_5/camera_info" />
+      <remap from="output/camera_info" to="omni/camera_5/optical/camera_info" />
     </node>
 
     <!--IMU-->

--- a/submitted_models/ctu_cras_norlab_absolem_sensor_config_1/model.sdf
+++ b/submitted_models/ctu_cras_norlab_absolem_sensor_config_1/model.sdf
@@ -3640,15 +3640,19 @@
     </joint>
     <plugin name="cras::FlipperControlPlugin" filename="libflipper_control_plugin.so">
       <joint_name>front_left_flipper_j</joint_name>
+      <max_velocity>0.8</max_velocity>
     </plugin>
     <plugin name="cras::FlipperControlPlugin" filename="libflipper_control_plugin.so">
       <joint_name>front_right_flipper_j</joint_name>
+      <max_velocity>0.8</max_velocity>
     </plugin>
     <plugin name="cras::FlipperControlPlugin" filename="libflipper_control_plugin.so">
       <joint_name>rear_left_flipper_j</joint_name>
+      <max_velocity>0.8</max_velocity>
     </plugin>
     <plugin name="cras::FlipperControlPlugin" filename="libflipper_control_plugin.so">
       <joint_name>rear_right_flipper_j</joint_name>
+      <max_velocity>0.8</max_velocity>
     </plugin>
 
     <!--

--- a/submitted_models/ctu_cras_norlab_absolem_sensor_config_1/model.sdf
+++ b/submitted_models/ctu_cras_norlab_absolem_sensor_config_1/model.sdf
@@ -3680,8 +3680,6 @@
       <rotation_angular_limit>1.618994</rotation_angular_limit>
     </plugin>
     <plugin name="ignition::gazebo::systems::JointStatePublisher" filename="libignition-gazebo-joint-state-publisher-system.so">
-      <joint_name>left_track_j</joint_name>
-      <joint_name>right_track_j</joint_name>
       <joint_name>front_left_flipper_j</joint_name>
       <joint_name>front_right_flipper_j</joint_name>
       <joint_name>rear_left_flipper_j</joint_name>

--- a/submitted_models/ctu_cras_norlab_absolem_sensor_config_1/model.sdf
+++ b/submitted_models/ctu_cras_norlab_absolem_sensor_config_1/model.sdf
@@ -3641,6 +3641,17 @@
     <plugin name="cras::FlipperControlPlugin" filename="libflipper_control_plugin.so">
       <joint_name>front_left_flipper_j</joint_name>
     </plugin>
+    <plugin name="cras::FlipperControlPlugin" filename="libflipper_control_plugin.so">
+      <joint_name>front_right_flipper_j</joint_name>
+    </plugin>
+    <plugin name="cras::FlipperControlPlugin" filename="libflipper_control_plugin.so">
+      <joint_name>rear_left_flipper_j</joint_name>
+    </plugin>
+    <plugin name="cras::FlipperControlPlugin" filename="libflipper_control_plugin.so">
+      <joint_name>rear_right_flipper_j</joint_name>
+    </plugin>
+
+    <!--
     <plugin name="ignition::gazebo::systems::JointController" filename="libignition-gazebo-joint-controller-system.so">
       <joint_name>front_right_flipper_j</joint_name>
       <use_force_commands>1</use_force_commands>

--- a/submitted_models/ctu_cras_norlab_absolem_sensor_config_1/model.sdf
+++ b/submitted_models/ctu_cras_norlab_absolem_sensor_config_1/model.sdf
@@ -3685,6 +3685,7 @@
       <cmd_max>100</cmd_max>
       <cmd_min>-100</cmd_min>
     </plugin>
+-->
     <plugin name="cras::LaserRotatePlugin" filename="liblaser_rotate_plugin.so">
       <joint_name>laser_j</joint_name>
       <initial_velocity>0.0</initial_velocity>

--- a/submitted_models/ctu_cras_norlab_absolem_sensor_config_1/src/flipper_control_plugin.cpp
+++ b/submitted_models/ctu_cras_norlab_absolem_sensor_config_1/src/flipper_control_plugin.cpp
@@ -132,7 +132,8 @@ class FlipperControlPlugin : public System, public ISystemConfigure, public ISys
             this->staticAngle = pos->Data()[0];
           }
         }
-        this->angularSpeed = velocity;
+        const auto sanitizedVelocity = math::clamp(velocity, -this->maxAngularVelocity, this->maxAngularVelocity);
+        this->angularSpeed = sanitizedVelocity;
       }
       this->cmdVel.reset();
     } else if (this->cmdPos.has_value()) {


### PR DESCRIPTION
I think the `left_track_j` and `right_track_j` joint state information should not be published.

Also removed the `/nonexistent` and `/joint_states` topics.

Signed-off-by: Nate Koenig <nate@openrobotics.org>