### PR TITLE
Absolem update

### DIFF
--- a/submitted_models/ctu_cras_norlab_absolem_sensor_config_1/config/common.sh
+++ b/submitted_models/ctu_cras_norlab_absolem_sensor_config_1/config/common.sh
@@ -9,4 +9,5 @@ config="big_collision_box_height:=0.5 big_collision_box_on_top:=1 big_collision_
   mobilicom_shift_y:=0.01 mobilicom_shift_z:=0.2 mobilicom_yaw:=3.14152 ptuxthermo_x_offset:=0.2 
   ptuxthermo_y_offset:=0.18 realsense_holder_version:=5 realsense_parent_link:=omnicam_sensor_mount 
   realsense_roll:=0.0 realsense_shift_x:=0.0 realsense_shift_y:=0.0 realsense_shift_z:=0.0 realsense_tilt:=-1.15 
-  realsense_upside_down:=0 realsense_yaw:=0.62831853 t265_parent_link:=rear_sensor_item top_box_j_x:=0.472"
+  realsense_upside_down:=0 realsense_width:=640 realsense_yaw:=0.62831853 t265_parent_link:=rear_sensor_item
+  top_box_j_x:=0.472"

--- a/submitted_models/ctu_cras_norlab_absolem_sensor_config_1/launch/vehicle_topics.launch
+++ b/submitted_models/ctu_cras_norlab_absolem_sensor_config_1/launch/vehicle_topics.launch
@@ -70,6 +70,13 @@
       args="/model/$(arg name)/joint/front_left_flipper_j/cmd_pos@std_msgs/Float64]ignition.msgs.Double">
       <remap from="/model/$(arg name)/joint/front_left_flipper_j/cmd_pos" to="flippers_cmd_pos/front_left"/>
     </node>
+    <node
+      pkg="ros_ign_bridge"
+      type="parameter_bridge"
+      name="ros_ign_bridge_front_left_flipper_pos_rel"
+      args="/model/$(arg name)/joint/front_left_flipper_j/cmd_pos_rel@std_msgs/Float64]ignition.msgs.Double">
+      <remap from="/model/$(arg name)/joint/front_left_flipper_j/cmd_pos_rel" to="flippers_cmd_pos_rel/front_left"/>
+    </node>
 
     <node
       pkg="ros_ign_bridge"
@@ -84,6 +91,13 @@
       name="ros_ign_bridge_front_right_flipper_pos"
       args="/model/$(arg name)/joint/front_right_flipper_j/cmd_pos@std_msgs/Float64]ignition.msgs.Double">
       <remap from="/model/$(arg name)/joint/front_right_flipper_j/cmd_pos" to="flippers_cmd_pos/front_right"/>
+    </node>
+    <node
+      pkg="ros_ign_bridge"
+      type="parameter_bridge"
+      name="ros_ign_bridge_front_right_flipper_pos_rel"
+      args="/model/$(arg name)/joint/front_right_flipper_j/cmd_pos_rel@std_msgs/Float64]ignition.msgs.Double">
+      <remap from="/model/$(arg name)/joint/front_right_flipper_j/cmd_pos_rel" to="flippers_cmd_pos_rel/front_right"/>
     </node>
 
     <node
@@ -100,6 +114,13 @@
       args="/model/$(arg name)/joint/rear_left_flipper_j/cmd_pos@std_msgs/Float64]ignition.msgs.Double">
       <remap from="/model/$(arg name)/joint/rear_left_flipper_j/cmd_pos" to="flippers_cmd_pos/rear_left"/>
     </node>
+    <node
+      pkg="ros_ign_bridge"
+      type="parameter_bridge"
+      name="ros_ign_bridge_rear_left_flipper_pos_rel"
+      args="/model/$(arg name)/joint/rear_left_flipper_j/cmd_pos_rel@std_msgs/Float64]ignition.msgs.Double">
+      <remap from="/model/$(arg name)/joint/rear_left_flipper_j/cmd_pos_rel" to="flippers_cmd_pos_rel/rear_left"/>
+    </node>
 
     <node
       pkg="ros_ign_bridge"
@@ -114,7 +135,15 @@
       name="ros_ign_bridge_rear_right_flipper_pos"
       args="/model/$(arg name)/joint/rear_right_flipper_j/cmd_pos@std_msgs/Float64]ignition.msgs.Double">
       <remap from="/model/$(arg name)/joint/rear_right_flipper_j/cmd_pos" to="flippers_cmd_pos/rear_right"/>
-    </node>   
+    </node>
+    <node
+      pkg="ros_ign_bridge"
+      type="parameter_bridge"
+      name="ros_ign_bridge_rear_right_flipper_pos_rel"
+      args="/model/$(arg name)/joint/rear_right_flipper_j/cmd_pos_rel@std_msgs/Float64]ignition.msgs.Double">
+      <remap from="/model/$(arg name)/joint/rear_right_flipper_j/cmd_pos_rel" to="flippers_cmd_pos_rel/rear_right"/>
+    </node>
+    
     <!-- Laser rotation control -->
     
     <node

--- a/submitted_models/ctu_cras_norlab_absolem_sensor_config_1/model.sdf
+++ b/submitted_models/ctu_cras_norlab_absolem_sensor_config_1/model.sdf
@@ -22,6 +22,14 @@
             <size>0.50017 0.24093 0.139</size>
           </box>
         </geometry>
+        <surface>
+          <contact>
+            <ode/>
+          </contact>
+          <friction>
+            <ode/>
+          </friction>
+        </surface>
       </collision>
       <collision name="base_link_collision_1">
         <pose>0.157 0 0.118 0 -0 0</pose>
@@ -30,6 +38,14 @@
             <size>0.056 0.12093 0.139</size>
           </box>
         </geometry>
+        <surface>
+          <contact>
+            <ode/>
+          </contact>
+          <friction>
+            <ode/>
+          </friction>
+        </surface>
       </collision>
       <collision name="base_link_collision_2">
         <pose>0.144 -0.076 0.118 0 -0 0.785398</pose>
@@ -38,6 +54,14 @@
             <size>0.083 0.04 0.139</size>
           </box>
         </geometry>
+        <surface>
+          <contact>
+            <ode/>
+          </contact>
+          <friction>
+            <ode/>
+          </friction>
+        </surface>
       </collision>
       <collision name="base_link_collision_3">
         <pose>0.144 0.076 0.118 0 0 -0.785398</pose>
@@ -46,6 +70,14 @@
             <size>0.083 0.04 0.139</size>
           </box>
         </geometry>
+        <surface>
+          <contact>
+            <ode/>
+          </contact>
+          <friction>
+            <ode/>
+          </friction>
+        </surface>
       </collision>
       <collision name="base_link_collision_4">
         <pose>0 0.135 0.09 0 -0 0</pose>
@@ -54,6 +86,14 @@
             <size>0.055 0.04 0.08</size>
           </box>
         </geometry>
+        <surface>
+          <contact>
+            <ode/>
+          </contact>
+          <friction>
+            <ode/>
+          </friction>
+        </surface>
       </collision>
       <collision name="base_link_collision_5">
         <pose>0 0.155 0.013 0 -0 0</pose>
@@ -62,6 +102,14 @@
             <size>0.055 0.02 0.075</size>
           </box>
         </geometry>
+        <surface>
+          <contact>
+            <ode/>
+          </contact>
+          <friction>
+            <ode/>
+          </friction>
+        </surface>
       </collision>
       <collision name="base_link_collision_6">
         <pose>0 -0.135 0.09 0 -0 0</pose>
@@ -70,6 +118,14 @@
             <size>0.055 0.04 0.08</size>
           </box>
         </geometry>
+        <surface>
+          <contact>
+            <ode/>
+          </contact>
+          <friction>
+            <ode/>
+          </friction>
+        </surface>
       </collision>
       <collision name="base_link_collision_7">
         <pose>0 -0.155 0.013 0 -0 0</pose>
@@ -78,6 +134,14 @@
             <size>0.055 0.02 0.075</size>
           </box>
         </geometry>
+        <surface>
+          <contact>
+            <ode/>
+          </contact>
+          <friction>
+            <ode/>
+          </friction>
+        </surface>
       </collision>
       <collision name="base_link_fixed_joint_lump__antenna_collision_8">
         <pose>-0.39064 0.0789 0.1551 3.1415926535897931 1.5707963267948966 3.1415926535897931</pose>
@@ -179,6 +243,14 @@
             <radius>0.068</radius>
           </cylinder>
         </geometry>
+        <surface>
+          <contact>
+            <ode/>
+          </contact>
+          <friction>
+            <ode/>
+          </friction>
+        </surface>
       </collision>
       <collision name="base_link_fixed_joint_lump__realsense_holder_part2_collision_20">
         <pose>0.111811 -0.018928 0.440133 0 0.504467 -0.000319</pose>
@@ -187,6 +259,14 @@
             <size>0.008 0.075 0.025</size>
           </box>
         </geometry>
+        <surface>
+          <contact>
+            <ode/>
+          </contact>
+          <friction>
+            <ode/>
+          </friction>
+        </surface>
       </collision>
       <collision name="base_link_fixed_joint_lump__realsense_holder_part2_collision_21">
         <pose>0.099551 -0.028924 0.4469 0 0.504467 -0.000319</pose>
@@ -195,6 +275,14 @@
             <size>0.035 0.01 0.028</size>
           </box>
         </geometry>
+        <surface>
+          <contact>
+            <ode/>
+          </contact>
+          <friction>
+            <ode/>
+          </friction>
+        </surface>
       </collision>
       <collision name="base_link_fixed_joint_lump__realsense_holder_part2_collision_22">
         <pose>0.074085 -0.043916 0.415266 -0 0.004467 -0.000319</pose>
@@ -203,6 +291,14 @@
             <size>0.035 0.045 0.073</size>
           </box>
         </geometry>
+        <surface>
+          <contact>
+            <ode/>
+          </contact>
+          <friction>
+            <ode/>
+          </friction>
+        </surface>
       </collision>
       <collision name="base_link_fixed_joint_lump__camera_link_collision_23">
         <pose>0.125348 -0.010971 0.43571 0.015 0.499467 -0.000319</pose>
@@ -211,10 +307,20 @@
             <size>0.02505 0.09 0.025</size>
           </box>
         </geometry>
+        <surface>
+          <contact>
+            <ode/>
+          </contact>
+          <friction>
+            <ode/>
+          </friction>
+        </surface>
       </collision>
       <visual name="base_link_visual">
+        <pose>0 0 0 0 -0 0</pose>
         <geometry>
           <mesh>
+            <scale>1 1 1</scale>
             <uri>meshes/body.dae</uri>
           </mesh>
         </geometry>
@@ -223,6 +329,7 @@
         <pose>-0.372 0.0789 0.1551 0 -0 0</pose>
         <geometry>
           <mesh>
+            <scale>1 1 1</scale>
             <uri>meshes/antenna.dae</uri>
           </mesh>
         </geometry>
@@ -231,6 +338,7 @@
         <pose>-0.2836 -0.0221 0.0722 0 -0 0</pose>
         <geometry>
           <mesh>
+            <scale>1 1 1</scale>
             <uri>meshes/battery.dae</uri>
           </mesh>
         </geometry>
@@ -440,7 +548,7 @@
         </geometry>
       </visual>
       <visual name="base_link_fixed_joint_lump__realsense_holder_part2_visual_28">
-        <pose>0.088894 -0.073921 0.3871 -5e-06 -0.002418 1.57486</pose>
+        <pose>0.084785 -0.073919 0.387078 -5e-06 -0.002418 1.57486</pose>
         <geometry>
           <mesh>
             <scale>0.001 0.001 0.001</scale>
@@ -448,23 +556,10 @@
           </mesh>
         </geometry>
         <material>
-          <diffuse>.5 0.5 0.5 1</diffuse>
-          <ambient>.1 0.1 0.1 1</ambient>
+          <diffuse>0.5 0.5 0.5 1</diffuse>
+          <ambient>0.1 0.1 0.1 1</ambient>
         </material>
       </visual>
-      <visual name="base_link_fixed_joint_lump__realsense_visual">
-        <pose>0.133882 -0.000937 0.420959 2.07031 -0.013169 1.5633</pose>
-        <geometry>
-          <mesh>
-            <uri>meshes/realsense_d435.dae</uri>
-          </mesh>
-        </geometry>
-        <material>
-          <diffuse>.5 0.5 0.5 1</diffuse>
-          <ambient>.1 0.1 0.1 1</ambient>
-        </material>
-      </visual>
-
       <visual name="base_link_fixed_joint_lump__camera_back_mounting_plane_visual_29">
         <pose>0.115312 -0.018929 0.4382 0.015 0.499467 -0.000319</pose>
         <geometry>
@@ -489,7 +584,20 @@
           </box>
         </geometry>
       </visual>
-      <visual name="base_link_fixed_joint_lump__camera_depth_frame_visual_32">
+      <visual name="base_link_fixed_joint_lump__camera_link_visual_32">
+        <pose>0.138428 -0.010975 0.428574 2.07031 -0.013168 1.56329</pose>
+        <geometry>
+          <mesh>
+            <scale>1 1 1</scale>
+            <uri>meshes/realsense_d435.dae</uri>
+          </mesh>
+        </geometry>
+        <material>
+          <diffuse>0.5 0.5 0.5 1</diffuse>
+          <ambient>0.1 0.1 0.1 1</ambient>
+        </material>
+      </visual>
+      <visual name="base_link_fixed_joint_lump__camera_depth_frame_visual_33">
         <pose>0.125479 0.006527 0.435941 0.015 0.499467 -0.000319</pose>
         <geometry>
           <box>
@@ -497,7 +605,7 @@
           </box>
         </geometry>
       </visual>
-      <visual name="base_link_fixed_joint_lump__camera_color_frame_visual_33">
+      <visual name="base_link_fixed_joint_lump__camera_color_frame_visual_34">
         <pose>0.125592 0.021526 0.436138 0.015 0.499467 -0.000319</pose>
         <geometry>
           <box>
@@ -505,7 +613,7 @@
           </box>
         </geometry>
       </visual>
-      <visual name="base_link_fixed_joint_lump__camera_color_optical_frame_visual_34">
+      <visual name="base_link_fixed_joint_lump__camera_color_optical_frame_visual_35">
         <pose>0.125592 0.021526 0.436138 -2.07031 0.013167 -1.5783</pose>
         <geometry>
           <box>
@@ -513,7 +621,7 @@
           </box>
         </geometry>
       </visual>
-      <visual name="base_link_fixed_joint_lump__camera_depth_optical_frame_visual_35">
+      <visual name="base_link_fixed_joint_lump__camera_depth_optical_frame_visual_36">
         <pose>0.125479 0.006527 0.435941 -2.07031 0.013167 -1.5783</pose>
         <geometry>
           <box>
@@ -521,7 +629,7 @@
           </box>
         </geometry>
       </visual>
-      <visual name="base_link_fixed_joint_lump__camera_left_ir_frame_visual_36">
+      <visual name="base_link_fixed_joint_lump__camera_left_ir_frame_visual_37">
         <pose>0.125479 0.006527 0.435941 0.015 0.499467 -0.000319</pose>
         <geometry>
           <box>
@@ -529,7 +637,7 @@
           </box>
         </geometry>
       </visual>
-      <visual name="base_link_fixed_joint_lump__camera_left_ir_optical_frame_visual_37">
+      <visual name="base_link_fixed_joint_lump__camera_left_ir_optical_frame_visual_38">
         <pose>0.125479 0.006527 0.435941 -2.07031 0.013167 -1.5783</pose>
         <geometry>
           <box>
@@ -537,7 +645,7 @@
           </box>
         </geometry>
       </visual>
-      <visual name="base_link_fixed_joint_lump__camera_right_ir_frame_visual_38">
+      <visual name="base_link_fixed_joint_lump__camera_right_ir_frame_visual_39">
         <pose>0.125104 -0.043467 0.435282 0.015 0.499467 -0.000319</pose>
         <geometry>
           <box>
@@ -545,7 +653,7 @@
           </box>
         </geometry>
       </visual>
-      <visual name="base_link_fixed_joint_lump__camera_right_ir_optical_frame_visual_39">
+      <visual name="base_link_fixed_joint_lump__camera_right_ir_optical_frame_visual_40">
         <pose>0.125104 -0.043467 0.435282 -2.07031 0.013167 -1.5783</pose>
         <geometry>
           <box>
@@ -710,6 +818,8 @@
               </noise>
             </z>
           </linear_acceleration>
+          <angular_velocity/>
+          <linear_acceleration/>
         </imu>
         <pose>0 0 0.15 -3.1415926535897931 -0 0</pose>
       </sensor>
@@ -875,6 +985,7 @@
         </camera>
         <pose>0.012561 -0.017068 0.314417 -0.000579 0.005611 0.313689</pose>
       </sensor>
+      <velocity_decay/>
       <sensor name="omnicam_sensor4" type="camera">
         <update_rate>6</update_rate>
         <camera name="camera_4">
@@ -914,6 +1025,7 @@
         </camera>
         <pose>0.058951 -0.03438 0.313899 -0.010815 0.001034 -0.943109</pose>
       </sensor>
+      <velocity_decay/>
       <sensor name="omnicam_sensor5" type="camera">
         <update_rate>6</update_rate>
         <camera name="camera_5">
@@ -953,6 +1065,8 @@
         </camera>
         <pose>0.024083 -0.058382 0.376328 3.1415926535897931 -1.5707963267948966 0.945143</pose>
       </sensor>
+      <velocity_decay/>
+      <velocity_decay/>
       <sensor name="camera" type="rgbd_camera">
         <camera name="camera_camera">
           <horizontal_fov>1.21126</horizontal_fov>
@@ -981,7 +1095,7 @@
             <format>RGB_INT8</format>
           </image>
           <clip>
-            <near>0.01</near>
+            <near>0.1</near>
             <far>100</far>
           </clip>
           <depth_camera>
@@ -999,8 +1113,10 @@
         </camera>
         <always_on>1</always_on>
         <update_rate>6</update_rate>
-        <pose>0.136479 -0.016527 0.419441 0.015 0.499467 -0.000319</pose>
+        <pose>0.125479 0.006527 0.435941 0.015 0.499467 -0.000319</pose>
       </sensor>
+      <gravity>1</gravity>
+      <velocity_decay/>
     </link>
     <link name="laser">
       <pose>0.2502 0 0.1407 -3.1415926535897931 -0 0</pose>
@@ -1120,18 +1236,22 @@
           </box>
         </geometry>
         <surface>
+          <contact>
+            <ode>
+              <kp>1e+07</kp>
+              <kd>1</kd>
+            </ode>
+          </contact>
           <friction>
             <ode>
               <mu>0.7</mu>
               <mu2>150</mu2>
+              <slip1>0.035</slip1>
+              <slip2>0</slip2>
               <fdir1>0 0 1</fdir1>
             </ode>
           </friction>
-          <contact>
-            <ode/>
-          </contact>
         </surface>
-        <max_contacts>20</max_contacts>
       </collision>
       <visual name="left_track_visual">
         <pose>0 0 -0.0705 1.5707963267948966 -0 1.5707963267948966</pose>
@@ -1182,6 +1302,7 @@
     <link name="front_left_flipper">
       <pose>0.25 0.272 0.0195 0 0.193732 0</pose>
       <inertial>
+        <pose>0 0 0 0 -0 0</pose>
         <mass>1e-05</mass>
         <inertia>
           <ixx>0.001</ixx>
@@ -1193,16 +1314,25 @@
         </inertia>
       </inertial>
       <collision name="front_left_flipper_collision">
+        <pose>0 0 0 0 -0 0</pose>
         <geometry>
           <box>
             <size>0.01 0.01 0.01</size>
           </box>
         </geometry>
         <surface>
+          <contact>
+            <ode>
+              <kp>1e+07</kp>
+              <kd>1</kd>
+            </ode>
+          </contact>
           <friction>
             <ode>
               <mu>0.7</mu>
               <mu2>150</mu2>
+              <slip1>0.035</slip1>
+              <slip2>0</slip2>
               <fdir1>0 0 1</fdir1>
             </ode>
           </friction>
@@ -1212,10 +1342,15 @@
         <pose>0 0 0 -2.95744 0 1.5707963267948966</pose>
         <geometry>
           <mesh>
+            <scale>1 1 1</scale>
             <uri>meshes/flipper.dae</uri>
           </mesh>
         </geometry>
       </visual>
+      <gravity>1</gravity>
+      <velocity_decay/>
+      <self_collide>1</self_collide>
+      <kinematic>0</kinematic>
     </link>
     <joint name="front_left_flipper_j" type="revolute">
       <child>front_left_flipper</child>
@@ -1257,7 +1392,7 @@
           <izz>0.010941</izz>
         </inertia>
       </inertial>
-      <collision name="front_left_flipper_wheel1_fixed_joint_lump__front_left_flipper_collision_wheel1_collision">
+      <collision name="front_left_flipper_wheel1_collision_collision">
         <pose>0 0 0 1.5707963267948966 -0 0</pose>
         <geometry>
           <cylinder>
@@ -1274,8 +1409,8 @@
           </contact>
           <friction>
             <ode>
-              <mu>1</mu>
-              <mu2>1</mu2>
+              <mu>0.7</mu>
+              <mu2>150</mu2>
               <slip1>0.035</slip1>
               <slip2>0</slip2>
               <fdir1>0 0 1</fdir1>
@@ -1283,6 +1418,10 @@
           </friction>
         </surface>
       </collision>
+      <gravity>1</gravity>
+      <velocity_decay/>
+      <self_collide>1</self_collide>
+      <kinematic>0</kinematic>
     </link>
     <joint name="front_left_flipper_wheel1_j" type="revolute">
       <child>front_left_flipper_wheel1</child>
@@ -1314,7 +1453,7 @@
           <izz>0.010941</izz>
         </inertia>
       </inertial>
-      <collision name="front_left_flipper_wheel2_fixed_joint_lump__front_left_flipper_collision_wheel2_collision">
+      <collision name="front_left_flipper_wheel2_collision_collision">
         <pose>0 0 0 1.5707963267948966 -0 0</pose>
         <geometry>
           <cylinder>
@@ -1331,16 +1470,19 @@
           </contact>
           <friction>
             <ode>
-              <mu>1</mu>
-              <mu2>1</mu2>
+              <mu>0.7</mu>
+              <mu2>150</mu2>
               <slip1>0.035</slip1>
               <slip2>0</slip2>
               <fdir1>0 0 1</fdir1>
             </ode>
           </friction>
         </surface>
-
       </collision>
+      <gravity>1</gravity>
+      <velocity_decay/>
+      <self_collide>1</self_collide>
+      <kinematic>0</kinematic>
     </link>
     <joint name="front_left_flipper_wheel2_j" type="revolute">
       <child>front_left_flipper_wheel2</child>
@@ -1372,7 +1514,7 @@
           <izz>0.010941</izz>
         </inertia>
       </inertial>
-      <collision name="front_left_flipper_wheel3_fixed_joint_lump__front_left_flipper_collision_wheel3_collision">
+      <collision name="front_left_flipper_wheel3_collision_collision">
         <pose>0 0 0 1.5707963267948966 -0 0</pose>
         <geometry>
           <cylinder>
@@ -1389,16 +1531,19 @@
           </contact>
           <friction>
             <ode>
-              <mu>1</mu>
-              <mu2>1</mu2>
+              <mu>0.7</mu>
+              <mu2>150</mu2>
               <slip1>0.035</slip1>
               <slip2>0</slip2>
               <fdir1>0 0 1</fdir1>
             </ode>
           </friction>
         </surface>
-
       </collision>
+      <gravity>1</gravity>
+      <velocity_decay/>
+      <self_collide>1</self_collide>
+      <kinematic>0</kinematic>
     </link>
     <joint name="front_left_flipper_wheel3_j" type="revolute">
       <child>front_left_flipper_wheel3</child>
@@ -1430,7 +1575,7 @@
           <izz>0.010941</izz>
         </inertia>
       </inertial>
-      <collision name="front_left_flipper_wheel4_fixed_joint_lump__front_left_flipper_collision_wheel4_collision">
+      <collision name="front_left_flipper_wheel4_collision_collision">
         <pose>0 0 0 1.5707963267948966 -0 0</pose>
         <geometry>
           <cylinder>
@@ -1447,16 +1592,19 @@
           </contact>
           <friction>
             <ode>
-              <mu>1</mu>
-              <mu2>1</mu2>
+              <mu>0.7</mu>
+              <mu2>150</mu2>
               <slip1>0.035</slip1>
               <slip2>0</slip2>
               <fdir1>0 0 1</fdir1>
             </ode>
           </friction>
         </surface>
-
       </collision>
+      <gravity>1</gravity>
+      <velocity_decay/>
+      <self_collide>1</self_collide>
+      <kinematic>0</kinematic>
     </link>
     <joint name="front_left_flipper_wheel4_j" type="revolute">
       <child>front_left_flipper_wheel4</child>
@@ -1488,7 +1636,7 @@
           <izz>0.010941</izz>
         </inertia>
       </inertial>
-      <collision name="front_left_flipper_wheel5_fixed_joint_lump__front_left_flipper_collision_wheel5_collision">
+      <collision name="front_left_flipper_wheel5_collision_collision">
         <pose>0 0 0 1.5707963267948966 -0 0</pose>
         <geometry>
           <cylinder>
@@ -1505,16 +1653,19 @@
           </contact>
           <friction>
             <ode>
-              <mu>1</mu>
-              <mu2>1</mu2>
+              <mu>0.7</mu>
+              <mu2>150</mu2>
               <slip1>0.035</slip1>
               <slip2>0</slip2>
               <fdir1>0 0 1</fdir1>
             </ode>
           </friction>
         </surface>
-
       </collision>
+      <gravity>1</gravity>
+      <velocity_decay/>
+      <self_collide>1</self_collide>
+      <kinematic>0</kinematic>
     </link>
     <joint name="front_left_flipper_wheel5_j" type="revolute">
       <child>front_left_flipper_wheel5</child>
@@ -1563,16 +1714,18 @@
           </contact>
           <friction>
             <ode>
-              <mu>1</mu>
-              <mu2>1</mu2>
+              <mu>0.7</mu>
+              <mu2>150</mu2>
               <slip1>0.035</slip1>
               <slip2>0</slip2>
               <fdir1>0 0 1</fdir1>
             </ode>
           </friction>
         </surface>
-
       </collision>
+      <gravity>1</gravity>
+      <velocity_decay/>
+      <kinematic>0</kinematic>
     </link>
     <joint name="left_track_wheel1_j" type="revolute">
       <child>left_track_wheel1</child>
@@ -1621,16 +1774,18 @@
           </contact>
           <friction>
             <ode>
-              <mu>1</mu>
-              <mu2>1</mu2>
+              <mu>0.7</mu>
+              <mu2>150</mu2>
               <slip1>0.035</slip1>
               <slip2>0</slip2>
               <fdir1>0 0 1</fdir1>
             </ode>
           </friction>
         </surface>
-
       </collision>
+      <gravity>1</gravity>
+      <velocity_decay/>
+      <kinematic>0</kinematic>
     </link>
     <joint name="left_track_wheel2_j" type="revolute">
       <child>left_track_wheel2</child>
@@ -1679,16 +1834,18 @@
           </contact>
           <friction>
             <ode>
-              <mu>1</mu>
-              <mu2>1</mu2>
+              <mu>0.7</mu>
+              <mu2>150</mu2>
               <slip1>0.035</slip1>
               <slip2>0</slip2>
               <fdir1>0 0 1</fdir1>
             </ode>
           </friction>
         </surface>
-
       </collision>
+      <gravity>1</gravity>
+      <velocity_decay/>
+      <kinematic>0</kinematic>
     </link>
     <joint name="left_track_wheel3_j" type="revolute">
       <child>left_track_wheel3</child>
@@ -1737,16 +1894,18 @@
           </contact>
           <friction>
             <ode>
-              <mu>1</mu>
-              <mu2>1</mu2>
+              <mu>0.7</mu>
+              <mu2>150</mu2>
               <slip1>0.035</slip1>
               <slip2>0</slip2>
               <fdir1>0 0 1</fdir1>
             </ode>
           </friction>
         </surface>
-
       </collision>
+      <gravity>1</gravity>
+      <velocity_decay/>
+      <kinematic>0</kinematic>
     </link>
     <joint name="left_track_wheel4_j" type="revolute">
       <child>left_track_wheel4</child>
@@ -1795,16 +1954,18 @@
           </contact>
           <friction>
             <ode>
-              <mu>1</mu>
-              <mu2>1</mu2>
+              <mu>0.7</mu>
+              <mu2>150</mu2>
               <slip1>0.035</slip1>
               <slip2>0</slip2>
               <fdir1>0 0 1</fdir1>
             </ode>
           </friction>
         </surface>
-
       </collision>
+      <gravity>1</gravity>
+      <velocity_decay/>
+      <kinematic>0</kinematic>
     </link>
     <joint name="left_track_wheel5_j" type="revolute">
       <child>left_track_wheel5</child>
@@ -1853,16 +2014,18 @@
           </contact>
           <friction>
             <ode>
-              <mu>1</mu>
-              <mu2>1</mu2>
+              <mu>0.7</mu>
+              <mu2>150</mu2>
               <slip1>0.035</slip1>
               <slip2>0</slip2>
               <fdir1>0 0 1</fdir1>
             </ode>
           </friction>
         </surface>
-
       </collision>
+      <gravity>1</gravity>
+      <velocity_decay/>
+      <kinematic>0</kinematic>
     </link>
     <joint name="left_track_wheel6_j" type="revolute">
       <child>left_track_wheel6</child>
@@ -1911,16 +2074,18 @@
           </contact>
           <friction>
             <ode>
-              <mu>1</mu>
-              <mu2>1</mu2>
+              <mu>0.7</mu>
+              <mu2>150</mu2>
               <slip1>0.035</slip1>
               <slip2>0</slip2>
               <fdir1>0 0 1</fdir1>
             </ode>
           </friction>
         </surface>
-
       </collision>
+      <gravity>1</gravity>
+      <velocity_decay/>
+      <kinematic>0</kinematic>
     </link>
     <joint name="left_track_wheel7_j" type="revolute">
       <child>left_track_wheel7</child>
@@ -1969,17 +2134,18 @@
           </contact>
           <friction>
             <ode>
-              <mu>1</mu>
-              <mu2>1</mu2>
+              <mu>0.7</mu>
+              <mu2>150</mu2>
               <slip1>0.035</slip1>
               <slip2>0</slip2>
               <fdir1>0 0 1</fdir1>
             </ode>
           </friction>
         </surface>
-
       </collision>
-
+      <gravity>1</gravity>
+      <velocity_decay/>
+      <kinematic>0</kinematic>
     </link>
     <joint name="left_track_wheel8_j" type="revolute">
       <child>left_track_wheel8</child>
@@ -2019,18 +2185,22 @@
           </box>
         </geometry>
         <surface>
+          <contact>
+            <ode>
+              <kp>1e+07</kp>
+              <kd>1</kd>
+            </ode>
+          </contact>
           <friction>
             <ode>
               <mu>0.7</mu>
               <mu2>150</mu2>
+              <slip1>0.035</slip1>
+              <slip2>0</slip2>
               <fdir1>0 0 1</fdir1>
             </ode>
           </friction>
-          <contact>
-            <ode/>
-          </contact>
         </surface>
-        <max_contacts>20</max_contacts>
       </collision>
       <visual name="rear_left_flipper_visual">
         <pose>0 0 0 -2.95744 0 1.5707963267948966</pose>
@@ -2086,7 +2256,7 @@
           <izz>0.010941</izz>
         </inertia>
       </inertial>
-      <collision name="rear_left_flipper_wheel1_fixed_joint_lump__rear_left_flipper_collision_wheel1_collision">
+      <collision name="rear_left_flipper_wheel1_collision_collision">
         <pose>0 0 0 1.5707963267948966 -0 0</pose>
         <geometry>
           <cylinder>
@@ -2103,16 +2273,19 @@
           </contact>
           <friction>
             <ode>
-              <mu>1</mu>
-              <mu2>1</mu2>
+              <mu>0.7</mu>
+              <mu2>150</mu2>
               <slip1>0.035</slip1>
               <slip2>0</slip2>
               <fdir1>0 0 1</fdir1>
             </ode>
           </friction>
         </surface>
-
       </collision>
+      <gravity>1</gravity>
+      <velocity_decay/>
+      <self_collide>1</self_collide>
+      <kinematic>0</kinematic>
     </link>
     <joint name="rear_left_flipper_wheel1_j" type="revolute">
       <child>rear_left_flipper_wheel1</child>
@@ -2144,7 +2317,7 @@
           <izz>0.010941</izz>
         </inertia>
       </inertial>
-      <collision name="rear_left_flipper_wheel2_fixed_joint_lump__rear_left_flipper_collision_wheel2_collision">
+      <collision name="rear_left_flipper_wheel2_collision_collision">
         <pose>0 0 0 1.5707963267948966 -0 0</pose>
         <geometry>
           <cylinder>
@@ -2161,16 +2334,19 @@
           </contact>
           <friction>
             <ode>
-              <mu>1</mu>
-              <mu2>1</mu2>
+              <mu>0.7</mu>
+              <mu2>150</mu2>
               <slip1>0.035</slip1>
               <slip2>0</slip2>
               <fdir1>0 0 1</fdir1>
             </ode>
           </friction>
         </surface>
-
       </collision>
+      <gravity>1</gravity>
+      <velocity_decay/>
+      <self_collide>1</self_collide>
+      <kinematic>0</kinematic>
     </link>
     <joint name="rear_left_flipper_wheel2_j" type="revolute">
       <child>rear_left_flipper_wheel2</child>
@@ -2202,7 +2378,7 @@
           <izz>0.010941</izz>
         </inertia>
       </inertial>
-      <collision name="rear_left_flipper_wheel3_fixed_joint_lump__rear_left_flipper_collision_wheel3_collision">
+      <collision name="rear_left_flipper_wheel3_collision_collision">
         <pose>0 0 0 1.5707963267948966 -0 0</pose>
         <geometry>
           <cylinder>
@@ -2219,16 +2395,19 @@
           </contact>
           <friction>
             <ode>
-              <mu>1</mu>
-              <mu2>1</mu2>
+              <mu>0.7</mu>
+              <mu2>150</mu2>
               <slip1>0.035</slip1>
               <slip2>0</slip2>
               <fdir1>0 0 1</fdir1>
             </ode>
           </friction>
         </surface>
-
       </collision>
+      <gravity>1</gravity>
+      <velocity_decay/>
+      <self_collide>1</self_collide>
+      <kinematic>0</kinematic>
     </link>
     <joint name="rear_left_flipper_wheel3_j" type="revolute">
       <child>rear_left_flipper_wheel3</child>
@@ -2260,7 +2439,7 @@
           <izz>0.010941</izz>
         </inertia>
       </inertial>
-      <collision name="rear_left_flipper_wheel4_fixed_joint_lump__rear_left_flipper_collision_wheel4_collision">
+      <collision name="rear_left_flipper_wheel4_collision_collision">
         <pose>0 0 0 1.5707963267948966 -0 0</pose>
         <geometry>
           <cylinder>
@@ -2277,16 +2456,19 @@
           </contact>
           <friction>
             <ode>
-              <mu>1</mu>
-              <mu2>1</mu2>
+              <mu>0.7</mu>
+              <mu2>150</mu2>
               <slip1>0.035</slip1>
               <slip2>0</slip2>
               <fdir1>0 0 1</fdir1>
             </ode>
           </friction>
         </surface>
-
       </collision>
+      <gravity>1</gravity>
+      <velocity_decay/>
+      <self_collide>1</self_collide>
+      <kinematic>0</kinematic>
     </link>
     <joint name="rear_left_flipper_wheel4_j" type="revolute">
       <child>rear_left_flipper_wheel4</child>
@@ -2318,7 +2500,7 @@
           <izz>0.010941</izz>
         </inertia>
       </inertial>
-      <collision name="rear_left_flipper_wheel5_fixed_joint_lump__rear_left_flipper_collision_wheel5_collision">
+      <collision name="rear_left_flipper_wheel5_collision_collision">
         <pose>0 0 0 1.5707963267948966 -0 0</pose>
         <geometry>
           <cylinder>
@@ -2335,16 +2517,19 @@
           </contact>
           <friction>
             <ode>
-              <mu>1</mu>
-              <mu2>1</mu2>
+              <mu>0.7</mu>
+              <mu2>150</mu2>
               <slip1>0.035</slip1>
               <slip2>0</slip2>
               <fdir1>0 0 1</fdir1>
             </ode>
           </friction>
         </surface>
-
       </collision>
+      <gravity>1</gravity>
+      <velocity_decay/>
+      <self_collide>1</self_collide>
+      <kinematic>0</kinematic>
     </link>
     <joint name="rear_left_flipper_wheel5_j" type="revolute">
       <child>rear_left_flipper_wheel5</child>
@@ -2384,18 +2569,22 @@
           </box>
         </geometry>
         <surface>
+          <contact>
+            <ode>
+              <kp>1e+07</kp>
+              <kd>1</kd>
+            </ode>
+          </contact>
           <friction>
             <ode>
               <mu>0.7</mu>
               <mu2>150</mu2>
+              <slip1>0.035</slip1>
+              <slip2>0</slip2>
               <fdir1>0 0 1</fdir1>
             </ode>
           </friction>
-          <contact>
-            <ode/>
-          </contact>
         </surface>
-        <max_contacts>20</max_contacts>
       </collision>
       <visual name="right_track_visual">
         <pose>0 0 -0.0705 1.5707963267948966 0 -1.5707963267948966</pose>
@@ -2465,18 +2654,22 @@
           </box>
         </geometry>
         <surface>
+          <contact>
+            <ode>
+              <kp>1e+07</kp>
+              <kd>1</kd>
+            </ode>
+          </contact>
           <friction>
             <ode>
               <mu>0.7</mu>
               <mu2>150</mu2>
+              <slip1>0.035</slip1>
+              <slip2>0</slip2>
               <fdir1>0 0 1</fdir1>
             </ode>
           </friction>
-          <contact>
-            <ode/>
-          </contact>
         </surface>
-        <max_contacts>20</max_contacts>
       </collision>
       <visual name="front_right_flipper_visual">
         <pose>0 0 0 -2.95744 -0 -1.5707963267948966</pose>
@@ -2532,7 +2725,7 @@
           <izz>0.010941</izz>
         </inertia>
       </inertial>
-      <collision name="front_right_flipper_wheel1_fixed_joint_lump__front_right_flipper_collision_wheel1_collision">
+      <collision name="front_right_flipper_wheel1_collision_collision">
         <pose>0 0 0 1.5707963267948966 -0 0</pose>
         <geometry>
           <cylinder>
@@ -2549,16 +2742,19 @@
           </contact>
           <friction>
             <ode>
-              <mu>1</mu>
-              <mu2>1</mu2>
+              <mu>0.7</mu>
+              <mu2>150</mu2>
               <slip1>0.035</slip1>
               <slip2>0</slip2>
               <fdir1>0 0 1</fdir1>
             </ode>
           </friction>
         </surface>
-
       </collision>
+      <gravity>1</gravity>
+      <velocity_decay/>
+      <self_collide>1</self_collide>
+      <kinematic>0</kinematic>
     </link>
     <joint name="front_right_flipper_wheel1_j" type="revolute">
       <child>front_right_flipper_wheel1</child>
@@ -2590,14 +2786,13 @@
           <izz>0.010941</izz>
         </inertia>
       </inertial>
-      <collision name="front_right_flipper_wheel2_fixed_joint_lump__front_right_flipper_collision_wheel2_collision">
+      <collision name="front_right_flipper_wheel2_collision_collision">
         <pose>0 0 0 1.5707963267948966 -0 0</pose>
         <geometry>
           <cylinder>
             <length>0.04981</length>
             <radius>0.074</radius>
           </cylinder>
-
         </geometry>
         <surface>
           <contact>
@@ -2608,16 +2803,19 @@
           </contact>
           <friction>
             <ode>
-              <mu>1</mu>
-              <mu2>1</mu2>
+              <mu>0.7</mu>
+              <mu2>150</mu2>
               <slip1>0.035</slip1>
               <slip2>0</slip2>
               <fdir1>0 0 1</fdir1>
             </ode>
           </friction>
         </surface>
-
       </collision>
+      <gravity>1</gravity>
+      <velocity_decay/>
+      <self_collide>1</self_collide>
+      <kinematic>0</kinematic>
     </link>
     <joint name="front_right_flipper_wheel2_j" type="revolute">
       <child>front_right_flipper_wheel2</child>
@@ -2649,7 +2847,7 @@
           <izz>0.010941</izz>
         </inertia>
       </inertial>
-      <collision name="front_right_flipper_wheel3_fixed_joint_lump__front_right_flipper_collision_wheel3_collision">
+      <collision name="front_right_flipper_wheel3_collision_collision">
         <pose>0 0 0 1.5707963267948966 -0 0</pose>
         <geometry>
           <cylinder>
@@ -2666,16 +2864,19 @@
           </contact>
           <friction>
             <ode>
-              <mu>1</mu>
-              <mu2>1</mu2>
+              <mu>0.7</mu>
+              <mu2>150</mu2>
               <slip1>0.035</slip1>
               <slip2>0</slip2>
               <fdir1>0 0 1</fdir1>
             </ode>
           </friction>
         </surface>
-
       </collision>
+      <gravity>1</gravity>
+      <velocity_decay/>
+      <self_collide>1</self_collide>
+      <kinematic>0</kinematic>
     </link>
     <joint name="front_right_flipper_wheel3_j" type="revolute">
       <child>front_right_flipper_wheel3</child>
@@ -2707,7 +2908,7 @@
           <izz>0.010941</izz>
         </inertia>
       </inertial>
-      <collision name="front_right_flipper_wheel4_fixed_joint_lump__front_right_flipper_collision_wheel4_collision">
+      <collision name="front_right_flipper_wheel4_collision_collision">
         <pose>0 0 0 1.5707963267948966 -0 0</pose>
         <geometry>
           <cylinder>
@@ -2724,16 +2925,19 @@
           </contact>
           <friction>
             <ode>
-              <mu>1</mu>
-              <mu2>1</mu2>
+              <mu>0.7</mu>
+              <mu2>150</mu2>
               <slip1>0.035</slip1>
               <slip2>0</slip2>
               <fdir1>0 0 1</fdir1>
             </ode>
           </friction>
         </surface>
-
       </collision>
+      <gravity>1</gravity>
+      <velocity_decay/>
+      <self_collide>1</self_collide>
+      <kinematic>0</kinematic>
     </link>
     <joint name="front_right_flipper_wheel4_j" type="revolute">
       <child>front_right_flipper_wheel4</child>
@@ -2765,7 +2969,7 @@
           <izz>0.010941</izz>
         </inertia>
       </inertial>
-      <collision name="front_right_flipper_wheel5_fixed_joint_lump__front_right_flipper_collision_wheel5_collision">
+      <collision name="front_right_flipper_wheel5_collision_collision">
         <pose>0 0 0 1.5707963267948966 -0 0</pose>
         <geometry>
           <cylinder>
@@ -2782,16 +2986,19 @@
           </contact>
           <friction>
             <ode>
-              <mu>1</mu>
-              <mu2>1</mu2>
+              <mu>0.7</mu>
+              <mu2>150</mu2>
               <slip1>0.035</slip1>
               <slip2>0</slip2>
               <fdir1>0 0 1</fdir1>
             </ode>
           </friction>
         </surface>
-
       </collision>
+      <gravity>1</gravity>
+      <velocity_decay/>
+      <self_collide>1</self_collide>
+      <kinematic>0</kinematic>
     </link>
     <joint name="front_right_flipper_wheel5_j" type="revolute">
       <child>front_right_flipper_wheel5</child>
@@ -2831,18 +3038,22 @@
           </box>
         </geometry>
         <surface>
+          <contact>
+            <ode>
+              <kp>1e+07</kp>
+              <kd>1</kd>
+            </ode>
+          </contact>
           <friction>
             <ode>
               <mu>0.7</mu>
               <mu2>150</mu2>
+              <slip1>0.035</slip1>
+              <slip2>0</slip2>
               <fdir1>0 0 1</fdir1>
             </ode>
           </friction>
-          <contact>
-            <ode/>
-          </contact>
         </surface>
-        <max_contacts>20</max_contacts>
       </collision>
       <visual name="rear_right_flipper_visual">
         <pose>0 0 0 -2.95744 -0 -1.5707963267948966</pose>
@@ -2898,7 +3109,7 @@
           <izz>0.010941</izz>
         </inertia>
       </inertial>
-      <collision name="rear_right_flipper_wheel1_fixed_joint_lump__rear_right_flipper_collision_wheel1_collision">
+      <collision name="rear_right_flipper_wheel1_collision_collision">
         <pose>0 0 0 1.5707963267948966 -0 0</pose>
         <geometry>
           <cylinder>
@@ -2915,16 +3126,19 @@
           </contact>
           <friction>
             <ode>
-              <mu>1</mu>
-              <mu2>1</mu2>
+              <mu>0.7</mu>
+              <mu2>150</mu2>
               <slip1>0.035</slip1>
               <slip2>0</slip2>
               <fdir1>0 0 1</fdir1>
             </ode>
           </friction>
         </surface>
-
       </collision>
+      <gravity>1</gravity>
+      <velocity_decay/>
+      <self_collide>1</self_collide>
+      <kinematic>0</kinematic>
     </link>
     <joint name="rear_right_flipper_wheel1_j" type="revolute">
       <child>rear_right_flipper_wheel1</child>
@@ -2956,7 +3170,7 @@
           <izz>0.010941</izz>
         </inertia>
       </inertial>
-      <collision name="rear_right_flipper_wheel2_fixed_joint_lump__rear_right_flipper_collision_wheel2_collision">
+      <collision name="rear_right_flipper_wheel2_collision_collision">
         <pose>0 0 0 1.5707963267948966 -0 0</pose>
         <geometry>
           <cylinder>
@@ -2973,16 +3187,19 @@
           </contact>
           <friction>
             <ode>
-              <mu>1</mu>
-              <mu2>1</mu2>
+              <mu>0.7</mu>
+              <mu2>150</mu2>
               <slip1>0.035</slip1>
               <slip2>0</slip2>
               <fdir1>0 0 1</fdir1>
             </ode>
           </friction>
         </surface>
-
       </collision>
+      <gravity>1</gravity>
+      <velocity_decay/>
+      <self_collide>1</self_collide>
+      <kinematic>0</kinematic>
     </link>
     <joint name="rear_right_flipper_wheel2_j" type="revolute">
       <child>rear_right_flipper_wheel2</child>
@@ -3014,7 +3231,7 @@
           <izz>0.010941</izz>
         </inertia>
       </inertial>
-      <collision name="rear_right_flipper_wheel3_fixed_joint_lump__rear_right_flipper_collision_wheel3_collision">
+      <collision name="rear_right_flipper_wheel3_collision_collision">
         <pose>0 0 0 1.5707963267948966 -0 0</pose>
         <geometry>
           <cylinder>
@@ -3031,16 +3248,19 @@
           </contact>
           <friction>
             <ode>
-              <mu>1</mu>
-              <mu2>1</mu2>
+              <mu>0.7</mu>
+              <mu2>150</mu2>
               <slip1>0.035</slip1>
               <slip2>0</slip2>
               <fdir1>0 0 1</fdir1>
             </ode>
           </friction>
         </surface>
-
       </collision>
+      <gravity>1</gravity>
+      <velocity_decay/>
+      <self_collide>1</self_collide>
+      <kinematic>0</kinematic>
     </link>
     <joint name="rear_right_flipper_wheel3_j" type="revolute">
       <child>rear_right_flipper_wheel3</child>
@@ -3072,7 +3292,7 @@
           <izz>0.010941</izz>
         </inertia>
       </inertial>
-      <collision name="rear_right_flipper_wheel4_fixed_joint_lump__rear_right_flipper_collision_wheel4_collision">
+      <collision name="rear_right_flipper_wheel4_collision_collision">
         <pose>0 0 0 1.5707963267948966 -0 0</pose>
         <geometry>
           <cylinder>
@@ -3089,16 +3309,19 @@
           </contact>
           <friction>
             <ode>
-              <mu>1</mu>
-              <mu2>1</mu2>
+              <mu>0.7</mu>
+              <mu2>150</mu2>
               <slip1>0.035</slip1>
               <slip2>0</slip2>
               <fdir1>0 0 1</fdir1>
             </ode>
           </friction>
         </surface>
-
       </collision>
+      <gravity>1</gravity>
+      <velocity_decay/>
+      <self_collide>1</self_collide>
+      <kinematic>0</kinematic>
     </link>
     <joint name="rear_right_flipper_wheel4_j" type="revolute">
       <child>rear_right_flipper_wheel4</child>
@@ -3130,7 +3353,7 @@
           <izz>0.010941</izz>
         </inertia>
       </inertial>
-      <collision name="rear_right_flipper_wheel5_fixed_joint_lump__rear_right_flipper_collision_wheel5_collision">
+      <collision name="rear_right_flipper_wheel5_collision_collision">
         <pose>0 0 0 1.5707963267948966 -0 0</pose>
         <geometry>
           <cylinder>
@@ -3147,16 +3370,19 @@
           </contact>
           <friction>
             <ode>
-              <mu>1</mu>
-              <mu2>1</mu2>
+              <mu>0.7</mu>
+              <mu2>150</mu2>
               <slip1>0.035</slip1>
               <slip2>0</slip2>
               <fdir1>0 0 1</fdir1>
             </ode>
           </friction>
         </surface>
-
       </collision>
+      <gravity>1</gravity>
+      <velocity_decay/>
+      <self_collide>1</self_collide>
+      <kinematic>0</kinematic>
     </link>
     <joint name="rear_right_flipper_wheel5_j" type="revolute">
       <child>rear_right_flipper_wheel5</child>
@@ -3205,16 +3431,18 @@
           </contact>
           <friction>
             <ode>
-              <mu>1</mu>
-              <mu2>1</mu2>
+              <mu>0.7</mu>
+              <mu2>150</mu2>
               <slip1>0.035</slip1>
               <slip2>0</slip2>
               <fdir1>0 0 1</fdir1>
             </ode>
           </friction>
         </surface>
-
       </collision>
+      <gravity>1</gravity>
+      <velocity_decay/>
+      <kinematic>0</kinematic>
     </link>
     <joint name="right_track_wheel1_j" type="revolute">
       <child>right_track_wheel1</child>
@@ -3263,16 +3491,18 @@
           </contact>
           <friction>
             <ode>
-              <mu>1</mu>
-              <mu2>1</mu2>
+              <mu>0.7</mu>
+              <mu2>150</mu2>
               <slip1>0.035</slip1>
               <slip2>0</slip2>
               <fdir1>0 0 1</fdir1>
             </ode>
           </friction>
         </surface>
-
       </collision>
+      <gravity>1</gravity>
+      <velocity_decay/>
+      <kinematic>0</kinematic>
     </link>
     <joint name="right_track_wheel2_j" type="revolute">
       <child>right_track_wheel2</child>
@@ -3321,16 +3551,18 @@
           </contact>
           <friction>
             <ode>
-              <mu>1</mu>
-              <mu2>1</mu2>
+              <mu>0.7</mu>
+              <mu2>150</mu2>
               <slip1>0.035</slip1>
               <slip2>0</slip2>
               <fdir1>0 0 1</fdir1>
             </ode>
           </friction>
         </surface>
-
       </collision>
+      <gravity>1</gravity>
+      <velocity_decay/>
+      <kinematic>0</kinematic>
     </link>
     <joint name="right_track_wheel3_j" type="revolute">
       <child>right_track_wheel3</child>
@@ -3379,16 +3611,18 @@
           </contact>
           <friction>
             <ode>
-              <mu>1</mu>
-              <mu2>1</mu2>
+              <mu>0.7</mu>
+              <mu2>150</mu2>
               <slip1>0.035</slip1>
               <slip2>0</slip2>
               <fdir1>0 0 1</fdir1>
             </ode>
           </friction>
         </surface>
-
       </collision>
+      <gravity>1</gravity>
+      <velocity_decay/>
+      <kinematic>0</kinematic>
     </link>
     <joint name="right_track_wheel4_j" type="revolute">
       <child>right_track_wheel4</child>
@@ -3437,16 +3671,18 @@
           </contact>
           <friction>
             <ode>
-              <mu>1</mu>
-              <mu2>1</mu2>
+              <mu>0.7</mu>
+              <mu2>150</mu2>
               <slip1>0.035</slip1>
               <slip2>0</slip2>
               <fdir1>0 0 1</fdir1>
             </ode>
           </friction>
         </surface>
-
       </collision>
+      <gravity>1</gravity>
+      <velocity_decay/>
+      <kinematic>0</kinematic>
     </link>
     <joint name="right_track_wheel5_j" type="revolute">
       <child>right_track_wheel5</child>
@@ -3495,16 +3731,18 @@
           </contact>
           <friction>
             <ode>
-              <mu>1</mu>
-              <mu2>1</mu2>
+              <mu>0.7</mu>
+              <mu2>150</mu2>
               <slip1>0.035</slip1>
               <slip2>0</slip2>
               <fdir1>0 0 1</fdir1>
             </ode>
           </friction>
         </surface>
-
       </collision>
+      <gravity>1</gravity>
+      <velocity_decay/>
+      <kinematic>0</kinematic>
     </link>
     <joint name="right_track_wheel6_j" type="revolute">
       <child>right_track_wheel6</child>
@@ -3553,16 +3791,18 @@
           </contact>
           <friction>
             <ode>
-              <mu>1</mu>
-              <mu2>1</mu2>
+              <mu>0.7</mu>
+              <mu2>150</mu2>
               <slip1>0.035</slip1>
               <slip2>0</slip2>
               <fdir1>0 0 1</fdir1>
             </ode>
           </friction>
         </surface>
-
       </collision>
+      <gravity>1</gravity>
+      <velocity_decay/>
+      <kinematic>0</kinematic>
     </link>
     <joint name="right_track_wheel7_j" type="revolute">
       <child>right_track_wheel7</child>
@@ -3611,16 +3851,18 @@
           </contact>
           <friction>
             <ode>
-              <mu>1</mu>
-              <mu2>1</mu2>
+              <mu>0.7</mu>
+              <mu2>150</mu2>
               <slip1>0.035</slip1>
               <slip2>0</slip2>
               <fdir1>0 0 1</fdir1>
             </ode>
           </friction>
         </surface>
-
       </collision>
+      <gravity>1</gravity>
+      <velocity_decay/>
+      <kinematic>0</kinematic>
     </link>
     <joint name="right_track_wheel8_j" type="revolute">
       <child>right_track_wheel8</child>
@@ -3638,16 +3880,17 @@
         <use_parent_model_frame>0</use_parent_model_frame>
       </axis>
     </joint>
+    <static>0</static>
     <plugin name="cras::FlipperControlPlugin" filename="libflipper_control_plugin.so">
       <joint_name>front_left_flipper_j</joint_name>
     </plugin>
-    <plugin filename="libflipper_control_plugin.so" name="cras::FlipperControlPlugin">
+    <plugin name="cras::FlipperControlPlugin" filename="libflipper_control_plugin.so">
       <joint_name>front_right_flipper_j</joint_name>
     </plugin>
-    <plugin filename="libflipper_control_plugin.so" name="cras::FlipperControlPlugin">
+    <plugin name="cras::FlipperControlPlugin" filename="libflipper_control_plugin.so">
       <joint_name>rear_left_flipper_j</joint_name>
     </plugin>
-    <plugin filename="libflipper_control_plugin.so" name="cras::FlipperControlPlugin">
+    <plugin name="cras::FlipperControlPlugin" filename="libflipper_control_plugin.so">
       <joint_name>rear_right_flipper_j</joint_name>
     </plugin>
     <plugin name="cras::LaserRotatePlugin" filename="liblaser_rotate_plugin.so">

--- a/submitted_models/ctu_cras_norlab_absolem_sensor_config_1/model.sdf
+++ b/submitted_models/ctu_cras_norlab_absolem_sensor_config_1/model.sdf
@@ -3641,38 +3641,14 @@
     <plugin name="cras::FlipperControlPlugin" filename="libflipper_control_plugin.so">
       <joint_name>front_left_flipper_j</joint_name>
     </plugin>
-    <plugin name="ignition::gazebo::systems::JointController" filename="libignition-gazebo-joint-controller-system.so">
+    <plugin filename="libflipper_control_plugin.so" name="cras::FlipperControlPlugin">
       <joint_name>front_right_flipper_j</joint_name>
-      <use_force_commands>1</use_force_commands>
-      <p_gain>30.0</p_gain>
-      <i_gain>0.1</i_gain>
-      <d_gain>0.01</d_gain>
-      <i_max>10</i_max>
-      <i_min>-10</i_min>
-      <cmd_max>100</cmd_max>
-      <cmd_min>-100</cmd_min>
     </plugin>
-    <plugin name="ignition::gazebo::systems::JointController" filename="libignition-gazebo-joint-controller-system.so">
+    <plugin filename="libflipper_control_plugin.so" name="cras::FlipperControlPlugin">
       <joint_name>rear_left_flipper_j</joint_name>
-      <use_force_commands>1</use_force_commands>
-      <p_gain>30.0</p_gain>
-      <i_gain>0.1</i_gain>
-      <d_gain>0.01</d_gain>
-      <i_max>10</i_max>
-      <i_min>-10</i_min>
-      <cmd_max>100</cmd_max>
-      <cmd_min>-100</cmd_min>
     </plugin>
-    <plugin name="ignition::gazebo::systems::JointController" filename="libignition-gazebo-joint-controller-system.so">
+    <plugin filename="libflipper_control_plugin.so" name="cras::FlipperControlPlugin">
       <joint_name>rear_right_flipper_j</joint_name>
-      <use_force_commands>1</use_force_commands>
-      <p_gain>30.0</p_gain>
-      <i_gain>0.1</i_gain>
-      <d_gain>0.01</d_gain>
-      <i_max>10</i_max>
-      <i_min>-10</i_min>
-      <cmd_max>100</cmd_max>
-      <cmd_min>-100</cmd_min>
     </plugin>
     <plugin name="cras::LaserRotatePlugin" filename="liblaser_rotate_plugin.so">
       <joint_name>laser_j</joint_name>

--- a/submitted_models/ctu_cras_norlab_absolem_sensor_config_1/urdf/_d435.xacro
+++ b/submitted_models/ctu_cras_norlab_absolem_sensor_config_1/urdf/_d435.xacro
@@ -56,18 +56,16 @@ aluminum peripherial evaluation case.
 
         <link name="$(arg prefix)${name}_link">
             <!-- For some reason, Gazebo sees the camera itself, which is bad... -->
-            <xacro:if value="${'$(arg rendering_target)' == 'urdf'}">
-                <visual>
-                    <origin xyz="${d435_cam_mount_from_center_offset} ${-d435_cam_depth_py} 0" rpy="${M_PI/2} 0 ${M_PI/2}"/>
-                    <geometry>
-                        <!-- <box size="${d435_cam_width} ${d435_cam_height} ${d435_cam_depth}"/> -->
-                        <mesh filename="package://ctu_cras_norlab_absolem_sensor_config_1/meshes/realsense_d435.dae" />
-                        <!--<mesh filename="package://realsense2_description/meshes/d435/d435.dae" />-->
-    
-                    </geometry>
-                    <material name="${name}_aluminum"/>
-                </visual>
-            </xacro:if>
+            <visual>
+                <origin xyz="${d435_cam_mount_from_center_offset} ${-d435_cam_depth_py} 0" rpy="${M_PI/2} 0 ${M_PI/2}"/>
+                <geometry>
+                    <!-- <box size="${d435_cam_width} ${d435_cam_height} ${d435_cam_depth}"/> -->
+                    <mesh filename="package://ctu_cras_norlab_absolem_sensor_config_1/meshes/realsense_d435.dae" />
+                    <!--<mesh filename="package://realsense2_description/meshes/d435/d435.dae" />-->
+
+                </geometry>
+                <material name="${name}_aluminum"/>
+            </visual>
             <collision>
                 <origin xyz="0 ${-d435_cam_depth_py} 0" rpy="0 0 0"/>
                 <geometry>

--- a/submitted_models/ctu_cras_norlab_absolem_sensor_config_1/urdf/nifti_robot.xacro
+++ b/submitted_models/ctu_cras_norlab_absolem_sensor_config_1/urdf/nifti_robot.xacro
@@ -866,7 +866,7 @@
 	
 	<xacro:macro name="flipper_fake_wheel" params="prefix1 prefix2 reflect_y do_inward_enlargement num_wheels wheel_num">
 			<link name="$(arg prefix)${prefix1}_${prefix2}_flipper_wheel${wheel_num}">
-					<collision name="${prefix1}_${prefix2}_flipper_collision_wheel${wheel_num}">
+					<collision name="${prefix1}_${prefix2}_flipper_wheel${wheel_num}_collision">
 							<origin rpy="${pi/2} 0 0" xyz="0 0 0"/>
 							<geometry>
 									<cylinder length="${$(arg rover_flipperWidth)+$(arg flipper_inward_enlargement)*do_inward_enlargement}" radius="${(0.029+($(arg rover_trackWheelRadius)-0.029)*(num_wheels-wheel_num)/(num_wheels-1)) * (1 + ($(arg flipper_inflation_ratio)-1)*do_inward_enlargement)}" />
@@ -1159,21 +1159,25 @@
         <kinematic>false</kinematic>
     </xacro:macro>
 
-    <xacro:macro name="gazebo_flipper_tags">
-        <selfCollide>true</selfCollide>
-    </xacro:macro>
-
     <xacro:macro name="track_base_surface">
         <surface>
-            <friction>
-                <ode>
-                    <mu>$(arg track_mu)</mu>
-                    <mu2>$(arg track_mu2)</mu2>
-                    <fdir1>0 1 0</fdir1> <!-- is overridden by the plugin -->
-                </ode>
-            </friction>
+			<contact>
+				<ode>
+					<kp>1e+07</kp>
+					<kd>1</kd>
+				</ode>
+			</contact>
+			<friction>
+				<ode>
+					<mu>$(arg track_mu)</mu>
+					<mu2>$(arg track_mu2)</mu2>
+					<slip1>0.035</slip1>
+					<slip2>0</slip2>
+					<fdir1>0 0 1</fdir1>
+				</ode>
+			</friction>
         </surface>
-        <max_contacts>20</max_contacts>
+<!--        <max_contacts>20</max_contacts>-->
     </xacro:macro>
 
     <xacro:macro name="flipper_surface">
@@ -1182,54 +1186,69 @@
     <xacro:macro name="track_surface">
     </xacro:macro>
 
-    <gazebo reference="$(arg prefix)left_track">
+	<xacro:macro name="gazebo_track_tags">
 		<xacro:gazebo_default_tags />
-        <collision>
-            <xacro:track_base_surface />
-            <xacro:track_surface />
-        </collision>
-	</gazebo>
-    <gazebo reference="$(arg prefix)right_track">
+		<collision>
+			<xacro:track_base_surface />
+			<xacro:track_surface />
+		</collision>
+	</xacro:macro>
+
+	<xacro:macro name="gazebo_flipper_tags">
 		<xacro:gazebo_default_tags />
-        <collision>
-            <xacro:track_base_surface />
-            <xacro:track_surface />
-        </collision>
-    </gazebo>
+		<selfCollide>true</selfCollide>
+		<collision>
+			<xacro:track_base_surface />
+			<xacro:flipper_surface />
+		</collision>
+	</xacro:macro>
+
+    <gazebo reference="$(arg prefix)left_track"><xacro:gazebo_track_tags /></gazebo>
+    <gazebo reference="$(arg prefix)right_track"><xacro:gazebo_track_tags /></gazebo>
+
+    <gazebo reference="$(arg prefix)left_track_wheel1"><xacro:gazebo_track_tags /></gazebo>
+    <gazebo reference="$(arg prefix)right_track_wheel1"><xacro:gazebo_track_tags /></gazebo>
+    <gazebo reference="$(arg prefix)left_track_wheel2"><xacro:gazebo_track_tags /></gazebo>
+    <gazebo reference="$(arg prefix)right_track_wheel2"><xacro:gazebo_track_tags /></gazebo>
+    <gazebo reference="$(arg prefix)left_track_wheel3"><xacro:gazebo_track_tags /></gazebo>
+    <gazebo reference="$(arg prefix)right_track_wheel3"><xacro:gazebo_track_tags /></gazebo>
+    <gazebo reference="$(arg prefix)left_track_wheel4"><xacro:gazebo_track_tags /></gazebo>
+    <gazebo reference="$(arg prefix)right_track_wheel4"><xacro:gazebo_track_tags /></gazebo>
+    <gazebo reference="$(arg prefix)left_track_wheel5"><xacro:gazebo_track_tags /></gazebo>
+    <gazebo reference="$(arg prefix)right_track_wheel5"><xacro:gazebo_track_tags /></gazebo>
+    <gazebo reference="$(arg prefix)left_track_wheel6"><xacro:gazebo_track_tags /></gazebo>
+    <gazebo reference="$(arg prefix)right_track_wheel6"><xacro:gazebo_track_tags /></gazebo>
+    <gazebo reference="$(arg prefix)left_track_wheel7"><xacro:gazebo_track_tags /></gazebo>
+    <gazebo reference="$(arg prefix)right_track_wheel7"><xacro:gazebo_track_tags /></gazebo>
+    <gazebo reference="$(arg prefix)left_track_wheel8"><xacro:gazebo_track_tags /></gazebo>
+    <gazebo reference="$(arg prefix)right_track_wheel8"><xacro:gazebo_track_tags /></gazebo>
 
     <xacro:if value="$(arg has_flippers)">
-        <gazebo reference="$(arg prefix)front_left_flipper">
-            <xacro:gazebo_default_tags />
-            <xacro:gazebo_flipper_tags />
-            <collision>
-                <xacro:track_base_surface />
-                <xacro:flipper_surface />
-            </collision>
-        </gazebo>
-        <gazebo reference="$(arg prefix)front_right_flipper">
-            <xacro:gazebo_default_tags />
-            <xacro:gazebo_flipper_tags />
-            <collision>
-                <xacro:track_base_surface />
-                <xacro:flipper_surface />
-            </collision>
-        </gazebo>
-        <gazebo reference="$(arg prefix)rear_left_flipper">
-            <xacro:gazebo_default_tags />
-            <xacro:gazebo_flipper_tags />
-            <collision>
-                <xacro:track_base_surface />
-                <xacro:flipper_surface />
-            </collision>
-        </gazebo>
-        <gazebo reference="$(arg prefix)rear_right_flipper">
-            <xacro:gazebo_default_tags />
-            <xacro:gazebo_flipper_tags />
-            <collision>
-                <xacro:track_base_surface />
-                <xacro:flipper_surface />
-            </collision>
-        </gazebo>
+        <gazebo reference="$(arg prefix)front_left_flipper"><xacro:gazebo_flipper_tags /></gazebo>
+        <gazebo reference="$(arg prefix)front_right_flipper"><xacro:gazebo_flipper_tags /></gazebo>
+        <gazebo reference="$(arg prefix)rear_left_flipper"><xacro:gazebo_flipper_tags /></gazebo>
+        <gazebo reference="$(arg prefix)rear_right_flipper"><xacro:gazebo_flipper_tags /></gazebo>
+
+        <gazebo reference="$(arg prefix)front_left_flipper_wheel1"><xacro:gazebo_flipper_tags /></gazebo>
+        <gazebo reference="$(arg prefix)front_right_flipper_wheel1"><xacro:gazebo_flipper_tags /></gazebo>
+        <gazebo reference="$(arg prefix)rear_left_flipper_wheel1"><xacro:gazebo_flipper_tags /></gazebo>
+        <gazebo reference="$(arg prefix)rear_right_flipper_wheel1"><xacro:gazebo_flipper_tags /></gazebo>
+        <gazebo reference="$(arg prefix)front_left_flipper_wheel2"><xacro:gazebo_flipper_tags /></gazebo>
+        <gazebo reference="$(arg prefix)front_right_flipper_wheel2"><xacro:gazebo_flipper_tags /></gazebo>
+        <gazebo reference="$(arg prefix)rear_left_flipper_wheel2"><xacro:gazebo_flipper_tags /></gazebo>
+        <gazebo reference="$(arg prefix)rear_right_flipper_wheel2"><xacro:gazebo_flipper_tags /></gazebo>
+        <gazebo reference="$(arg prefix)front_left_flipper_wheel3"><xacro:gazebo_flipper_tags /></gazebo>
+        <gazebo reference="$(arg prefix)front_right_flipper_wheel3"><xacro:gazebo_flipper_tags /></gazebo>
+        <gazebo reference="$(arg prefix)rear_left_flipper_wheel3"><xacro:gazebo_flipper_tags /></gazebo>
+        <gazebo reference="$(arg prefix)rear_right_flipper_wheel3"><xacro:gazebo_flipper_tags /></gazebo>
+        <gazebo reference="$(arg prefix)front_left_flipper_wheel4"><xacro:gazebo_flipper_tags /></gazebo>
+        <gazebo reference="$(arg prefix)front_right_flipper_wheel4"><xacro:gazebo_flipper_tags /></gazebo>
+        <gazebo reference="$(arg prefix)rear_left_flipper_wheel4"><xacro:gazebo_flipper_tags /></gazebo>
+        <gazebo reference="$(arg prefix)rear_right_flipper_wheel4"><xacro:gazebo_flipper_tags /></gazebo>
+        <gazebo reference="$(arg prefix)front_left_flipper_wheel5"><xacro:gazebo_flipper_tags /></gazebo>
+        <gazebo reference="$(arg prefix)front_right_flipper_wheel5"><xacro:gazebo_flipper_tags /></gazebo>
+        <gazebo reference="$(arg prefix)rear_left_flipper_wheel5"><xacro:gazebo_flipper_tags /></gazebo>
+        <gazebo reference="$(arg prefix)rear_right_flipper_wheel5"><xacro:gazebo_flipper_tags /></gazebo>
     </xacro:if>
 
     <xacro:if value="$(arg has_sick_lidar)">
@@ -1263,7 +1282,6 @@
 									  <!-- TODO -->
 <!--                <time_increment>2.77777780866e-05</time_increment>-->
 <!--                <scan_time>0.019999999553</scan_time>-->
-<!--                <angle_increment>0.00872664619237</angle_increment>-->
                 </sensor>
             </xacro:if>
         </gazebo>

--- a/submitted_models/ctu_cras_norlab_absolem_sensor_config_1/urdf/nifti_robot.xacro
+++ b/submitted_models/ctu_cras_norlab_absolem_sensor_config_1/urdf/nifti_robot.xacro
@@ -1115,38 +1115,14 @@
 						<plugin filename="libflipper_control_plugin.so" name="cras::FlipperControlPlugin">
 							<joint_name>front_left_flipper_j</joint_name>
 						</plugin>
-						<plugin filename="libignition-gazebo-joint-controller-system.so" name="ignition::gazebo::systems::JointController">
+						<plugin filename="libflipper_control_plugin.so" name="cras::FlipperControlPlugin">
 							<joint_name>front_right_flipper_j</joint_name>
-							<use_force_commands>true</use_force_commands>
-							<p_gain>30.0</p_gain>
-							<i_gain>0.1</i_gain>
-							<d_gain>0.01</d_gain>
-							<i_max>10</i_max>
-							<i_min>-10</i_min>
-							<cmd_max>100</cmd_max>
-							<cmd_min>-100</cmd_min>
 						</plugin>
-						<plugin filename="libignition-gazebo-joint-controller-system.so" name="ignition::gazebo::systems::JointController">
+						<plugin filename="libflipper_control_plugin.so" name="cras::FlipperControlPlugin">
 							<joint_name>rear_left_flipper_j</joint_name>
-							<use_force_commands>true</use_force_commands>
-							<p_gain>30.0</p_gain>
-							<i_gain>0.1</i_gain>
-							<d_gain>0.01</d_gain>
-							<i_max>10</i_max>
-							<i_min>-10</i_min>
-							<cmd_max>100</cmd_max>
-							<cmd_min>-100</cmd_min>
 						</plugin>
-						<plugin filename="libignition-gazebo-joint-controller-system.so" name="ignition::gazebo::systems::JointController">
+						<plugin filename="libflipper_control_plugin.so" name="cras::FlipperControlPlugin">
 							<joint_name>rear_right_flipper_j</joint_name>
-							<use_force_commands>true</use_force_commands>
-							<p_gain>30.0</p_gain>
-							<i_gain>0.1</i_gain>
-							<d_gain>0.01</d_gain>
-							<i_max>10</i_max>
-							<i_min>-10</i_min>
-							<cmd_max>100</cmd_max>
-							<cmd_min>-100</cmd_min>
 						</plugin>
         </xacro:if>
 

--- a/submitted_models/ctu_cras_norlab_absolem_sensor_config_1/urdf/realsense.gazebo.xacro
+++ b/submitted_models/ctu_cras_norlab_absolem_sensor_config_1/urdf/realsense.gazebo.xacro
@@ -42,12 +42,12 @@ This is the Gazebo URDF model for the Intel RealSense D435 camera
               <format>RGB_INT8</format>
             </image>
             <clip>
-              <near>0.01</near>
+              <near>0.1</near> <!-- not less, the image would be obstructed-->
               <far>100</far>
             </clip>
             <depth_camera>
               <clip>
-                <near>0.1</near>
+                <near>0.1</near> <!-- not less, the image would be obstructed-->
                 <far>10</far>
               </clip>
             </depth_camera>
@@ -61,5 +61,23 @@ This is the Gazebo URDF model for the Intel RealSense D435 camera
           <update_rate>$(arg realsense_fps)</update_rate>
           <pose frame="">0.0 0 0.0 0 0.0 0</pose>
         </sensor>
+    </gazebo>
+
+    <gazebo reference="$(arg prefix)realsense_holder_part2">
+      <visual>
+        <material>
+          <diffuse>.5 0.5 0.5 1</diffuse>
+          <ambient>.1 0.1 0.1 1</ambient>
+        </material>
+      </visual>
+    </gazebo>
+
+    <gazebo reference="$(arg prefix)$(arg realsense_name)_link">
+      <visual>
+        <material>
+          <diffuse>.5 0.5 0.5 1</diffuse>
+          <ambient>.1 0.1 0.1 1</ambient>
+        </material>
+      </visual>
     </gazebo>
 </robot>

--- a/submitted_models/ctu_cras_norlab_absolem_sensor_config_1/urdf/realsense_d435_with_holder.xacro
+++ b/submitted_models/ctu_cras_norlab_absolem_sensor_config_1/urdf/realsense_d435_with_holder.xacro
@@ -170,7 +170,7 @@
     <xacro:if value="${holder_version>=5}">
         <link name="$(arg prefix)realsense_holder_part2">
             <visual>
-                <origin rpy="-0.504467 0 1.5758" xyz="-0.002 -0.055 -0.051"/>
+                <origin rpy="-0.504467 0 1.5758" xyz="-0.002 -0.055 -0.0595"/>
                 <geometry>
                     <mesh scale="0.001 0.001 0.001"
                           filename="package://ctu_cras_norlab_absolem_sensor_config_1/meshes/d435_holder_combined.stl"/>


### PR DESCRIPTION
Followup of #528 and #520. Thanks for pushing this forward.

I fixed the flipper control (plugin names were wrong, and I fixed the problem with positional commands only reacting after zero velocity command).

Realsense sensor was moved back and the image rendering issue was fixed by setting min clipping plane to 10 cm. It seems more proper to me than moving the sensor origin. I've also noticed a weird bug - if I set the clipping plane to 5 cm, both RGB and D images get blank when the robot is rotated too much from any world axis (e.g. at 45°, the RGB image is black and Depth image is white).

I improved the flipper control plugin so that it also allows relative positional commands (this is useful for teleoperation).

I also incorporated all of the SDF-only changes back to the Xacro file, as that one is the "source" for the robot model. The empty tags in SDF are automatically created by `ign sdf` and they have no effect, so I'd like to keep them (otherwise there'd need to be extra logic to remove them).