### PR TITLE
Absolem rgbd fov fix

### DIFF
--- a/submitted_models/ctu_cras_norlab_absolem_sensor_config_1/model.sdf
+++ b/submitted_models/ctu_cras_norlab_absolem_sensor_config_1/model.sdf
@@ -955,7 +955,7 @@
       </sensor>
       <sensor name="camera" type="rgbd_camera">
         <camera name="camera_camera">
-          <horizontal_fov>1.21126</horizontal_fov>
+          <horizontal_fov>1.5184</horizontal_fov>
           <lens>
             <intrinsics>
               <fx>337.222</fx>


### PR DESCRIPTION
The Absolem vehicle `DepthCloud` for the RGBD sensor is incorrect in the optical frame.
![Screenshot from 2020-08-07 17-05-19](https://user-images.githubusercontent.com/61025344/89698283-5c440880-d8ee-11ea-98d6-5e4b1b6ff483.png)

The issue was a FoV that did not correspond to the configured resolution leading to the `DepthCloud` being stretched while the rendered `PointCloud2` was not.  The fix is shown below:
![Screenshot from 2020-08-07 20-36-45](https://user-images.githubusercontent.com/61025344/89698285-5cdc9f00-d8ee-11ea-8933-6a9b9abe203f.png)
