### PR TITLE
Path tracer

### DIFF
--- a/submitted_models/ctu_cras_norlab_absolem_sensor_config_1/CMakeLists.txt
+++ b/submitted_models/ctu_cras_norlab_absolem_sensor_config_1/CMakeLists.txt
@@ -3,7 +3,7 @@ project(ctu_cras_norlab_absolem_sensor_config_1)
 
 set(CMAKE_CXX_STANDARD 17)
 
-find_package(ignition-gazebo2 REQUIRED)
+find_package(ignition-gazebo3 REQUIRED)
 find_package(ignition-common3 REQUIRED)
 
 find_package(catkin REQUIRED)
@@ -11,10 +11,10 @@ find_package(catkin REQUIRED)
 catkin_package()
 
 add_library(laser_rotate_plugin src/laser_rotate_plugin.cpp)
-target_link_libraries(laser_rotate_plugin PRIVATE ignition-gazebo2::core ignition-common3::ignition-common3)
+target_link_libraries(laser_rotate_plugin PRIVATE ignition-gazebo3::core ignition-common3::ignition-common3)
 
 add_library(flipper_control_plugin src/flipper_control_plugin.cpp)
-target_link_libraries(flipper_control_plugin PRIVATE ignition-gazebo2::core ignition-common3::ignition-common3)
+target_link_libraries(flipper_control_plugin PRIVATE ignition-gazebo3::core ignition-common3::ignition-common3)
 
 install(TARGETS laser_rotate_plugin flipper_control_plugin
         ARCHIVE DESTINATION lib

--- a/subt_ign/CMakeLists.txt
+++ b/subt_ign/CMakeLists.txt
@@ -178,6 +178,19 @@ install(TARGETS validate_connections
   LIBRARY DESTINATION lib
   RUNTIME DESTINATION bin)
 
+add_executable(path_tracer
+  src/path_tracer.cc)
+target_link_libraries(path_tracer
+  PRIVATE
+    ignition-gazebo${IGN_GAZEBO_VER}::core
+    ${catkin_LIBRARIES} 
+    ${YAML_CPP_LIBRARIES}
+)
+install(TARGETS path_tracer
+  ARCHIVE DESTINATION lib
+  LIBRARY DESTINATION lib
+  RUNTIME DESTINATION bin)
+
 
 # Create the libCommsBrokerPlugin.so library.
 set(comms_broker_plugin_name CommsBrokerPlugin)

--- a/subt_ign/launch/path_tracer.ign
+++ b/subt_ign/launch/path_tracer.ign
@@ -1,0 +1,197 @@
+<?xml version="1.0"?>
+<!-- This launch file is used by CloudSim to run Ignition Gazebo and the
+     plugins needed by SubT. It does not run ROS. A separete launch file,
+     cloudsim_bridge.ign, starts a ROS master and the ROS1-Ignition bridge.
+
+     For more information, please refer to
+         https://github.com/osrf/subt/wiki/tutorials/cloudsim
+
+    Usage: ign launch cloudsim_sim.ign
+            [worldName:=<worldName>
+             robotName1:=<robotName> robotConfig1:=<robotConfig>
+             robotName2:=<robotName> robotConfig2:=<robotConfig>
+             ... ]
+
+    The [worldName] command line argument is optional,
+          defaults to tunnel_circuit_practice_01 if not specified
+    The [robotNameX] command line argument is optional, where X can be 1 to 20
+
+    Example that loads tunnel circuit practice world with an X2 robot with configuration 3
+
+      ign launch cloudsim_sim.ign worldName:=tunnel_circuit_practice_01
+          robotName1:=X2_3 robotConfig1:=X2_SENSOR_CONFIG_3
+-->
+
+<%
+  # Check if worldName is not defined or is empty/nil
+  if !defined?(worldName) || worldName == nil || worldName.empty?
+    $worldName = 'tunnel_circuit_practice_01'
+  else
+    $worldName = worldName
+  end
+
+  worldNumber = $worldName.split('_').last
+%>
+
+
+<ignition version='1.0'>
+  <env>
+    <name>IGN_GAZEBO_SYSTEM_PLUGIN_PATH</name>
+    <value>$LD_LIBRARY_PATH</value>
+  </env>
+
+  <plugin name="ignition::launch::GazeboServer"
+          filename="libignition-launch-gazebo.so">
+    <% if $worldName.include?('tunnel_circuit_') &&
+          !$worldName.include?('practice') %>
+      <world_file>tunnel_circuit/<%= worldNumber %>/<%= $worldName %>.sdf</world_file>
+    <% elsif $worldName.include?('urban_circuit_') &&
+          !$worldName.include?('practice') %>
+      <world_file>urban_circuit/<%= worldNumber %>/<%= $worldName %>.sdf</world_file>
+    <% else %>
+      <world_file><%= $worldName %>.sdf</world_file>
+    <% end %>
+   <%if defined?(updateRate) && updateRate != nil && !updateRate.empty?%>
+    <update_rate><%= updateRate %></update_rate>
+    <%end%>
+    <run>true</run>
+    <levels>false</levels>
+    <record>
+      <enabled>true</enabled>
+      <!-- This path is used by cloudsim, please do not change -->
+      <path>/tmp/ign/logs</path>
+    </record>
+    <%if defined?(seed) && seed != nil && !seed.empty?%>
+    <seed><%= seed %></seed>
+    <%end%>
+
+    <plugin entity_name="<%= $worldName %>"
+            entity_type="world"
+            filename="libignition-gazebo-physics-system.so"
+            name="ignition::gazebo::systems::Physics">
+    </plugin>
+    <!--
+    <plugin entity_name="<%= $worldName %>"
+            entity_type="world"
+            filename="libignition-gazebo-sensors-system.so"
+            name="ignition::gazebo::systems::Sensors">
+            <render_engine>ogre2</render_engine>
+    </plugin>
+-->
+    <plugin entity_name="<%= $worldName %>"
+            entity_type="world"
+            filename="libignition-gazebo-user-commands-system.so"
+            name="ignition::gazebo::systems::UserCommands">
+    </plugin>
+    <plugin entity_name="<%= $worldName %>"
+            entity_type="world"
+            filename="libignition-gazebo-scene-broadcaster-system.so"
+            name="ignition::gazebo::systems::SceneBroadcaster">
+    </plugin>
+
+    <!--<plugin entity_name="<%= $worldName %>"
+            entity_type="world"
+            filename="libignition-gazebo-imu-system.so"
+            name="ignition::gazebo::systems::Imu">
+    </plugin>
+
+    <plugin entity_name="<%= $worldName %>"
+            entity_type="world"
+            filename="libignition-gazebo-magnetometer-system.so"
+            name="ignition::gazebo::systems::Magnetometer">
+    </plugin>
+
+    <plugin entity_name="<%= $worldName %>"
+            entity_type="world"
+            filename="libignition-gazebo-air-pressure-system.so"
+            name="ignition::gazebo::systems::AirPressure">
+    </plugin>
+-->
+    </plugin>
+
+
+  <executable_wrapper>
+    <plugin name="ignition::launch::GazeboGui"
+          filename="libignition-launch-gazebogui.so">
+      <world_name><%= $worldName %></world_name>
+      <window_title>SubT Simulator</window_title>
+      <window_icon><%= ENV['SUBT_IMAGES_PATH'] %>/SubT_logo.svg</window_icon>
+      <plugin filename="GzScene3D" name="3D View">
+        <ignition-gui>
+          <title>3D View</title>
+          <property type="bool" key="showTitleBar">false</property>
+          <property type="string" key="state">docked</property>
+        </ignition-gui>
+
+        <engine>ogre2</engine>
+        <scene>scene</scene>
+        <ambient_light>1.0 1.0 1.0</ambient_light>
+        <background_color>1.0 1.0 1.0</background_color>
+
+        <!-- Perspective -->
+        <!-- <camera_pose>-120 70 70 0 0.568 -1.0</camera_pose> -->
+
+        <!-- Top down -->
+        <camera_pose>-40 -80 190 0 1.5708 1.5708</camera_pose>
+      </plugin>
+      <plugin filename="WorldControl" name="World control">
+        <ignition-gui>
+          <title>World control</title>
+          <property type="bool" key="showTitleBar">false</property>
+          <property type="bool" key="resizable">false</property>
+          <property type="double" key="height">72</property>
+          <property type="double" key="width">121</property>
+          <property type="double" key="z">1</property>
+
+          <property type="string" key="state">floating</property>
+          <anchors target="3D View">
+            <line own="left" target="left"/>
+            <line own="bottom" target="bottom"/>
+          </anchors>
+        </ignition-gui>
+
+        <play_pause>true</play_pause>
+        <step>true</step>
+        <start_paused>true</start_paused>
+        <service>/world/<%= $worldName %>/control</service>
+        <stats_topic>/world/<%= $worldName %>/stats</stats_topic>
+
+      </plugin>
+
+      <plugin filename="WorldStats" name="World stats">
+        <ignition-gui>
+          <title>World stats</title>
+          <property type="bool" key="showTitleBar">false</property>
+          <property type="bool" key="resizable">false</property>
+          <property type="double" key="height">110</property>
+          <property type="double" key="width">290</property>
+          <property type="double" key="z">1</property>
+
+          <property type="string" key="state">floating</property>
+          <anchors target="3D View">
+            <line own="right" target="right"/>
+            <line own="bottom" target="bottom"/>
+          </anchors>
+        </ignition-gui>
+
+        <sim_time>true</sim_time>
+        <real_time>true</real_time>
+        <real_time_factor>true</real_time_factor>
+        <iterations>true</iterations>
+        <topic>/world/<%= $worldName %>/stats</topic>
+      </plugin>
+      <!-- Entity tree -->
+      <!-- <plugin filename="EntityTree" name="Entity tree">
+        <ignition-gui>
+          <title>Entity tree</title>
+        </ignition-gui>
+      </plugin> -->
+
+      <!-- Transform Control -->
+      <!-- <plugin filename="TransformControl" name="Transform Control">
+        <service>/world/<%= $worldName %>/gui/transform_mode</service>
+      </plugin> -->
+    </plugin>
+  </executable_wrapper>
+
+</ignition>

--- a/subt_ign/src/GameLogicPlugin.cc
+++ b/subt_ign/src/GameLogicPlugin.cc
@@ -1193,14 +1193,6 @@ bool GameLogicPluginPrivate::OnNewArtifact(const subt::msgs::Artifact &_req,
     _resp.set_report_status("scored");
     this->totalScore += scoreDiff;
 
-    std::ostringstream stream;
-    stream
-      << "- event:\n"
-      << "  type: artifact_report_scored\n"
-      << "  time_sec: " << this->simTime.sec() << "\n"
-      << "  total_score: " << this->totalScore << std::endl;
-    this->LogEvent(stream.str());
-
     ignmsg << "Total score: " << this->totalScore << std::endl;
     this->Log() << "new_total_score " << this->totalScore << std::endl;
   }
@@ -1369,6 +1361,18 @@ double GameLogicPluginPrivate::ScoreArtifact(const ArtifactType &_type,
         this->firstReportTime = reportTime;
     }
   }
+
+  std::ostringstream stream;
+  stream
+    << "- event:\n"
+    << "  type: artifact_report_attempt\n"
+    << "  time_sec: " << this->simTime.sec() << "\n"
+    << "  reported_pose: " << observedObjectPose << "\n"
+    << "  artifact: " << std::get<0>(minDistance) << "\n"
+    << "  distance: " << std::get<2>(minDistance) << "\n"
+    << "  points_scored: " << score << "\n"
+    << "  total_score: " << this->totalScore + score << std::endl;
+  this->LogEvent(stream.str());
 
   this->Log() << "calculated_dist[" << std::get<2>(minDistance)
     << "] for artifact[" << std::get<0>(minDistance) << "] reported_pos["
@@ -1617,8 +1621,8 @@ void GameLogicPluginPrivate::Finish()
       << "- event:\n"
       << "  type: finished\n"
       << "  time_sec: " << this->simTime.sec() << "\n"
-      << "  elapsed_real_time " << realElapsed << "\n"
-      << "  elapsed_sim_time " << simElapsed << "\n"
+      << "  elapsed_real_time: " << realElapsed << "\n"
+      << "  elapsed_sim_time: " << simElapsed << "\n"
       << "  total_score: " << this->totalScore << std::endl;
     this->LogEvent(stream.str());
 

--- a/subt_ign/src/VisibilityPlugin.cc
+++ b/subt_ign/src/VisibilityPlugin.cc
@@ -86,7 +86,7 @@ void VisibilityPlugin::Configure(const ignition::gazebo::Entity & /*_entity*/,
 //////////////////////////////////////////////////
 void VisibilityPlugin::PreUpdate(
     const ignition::gazebo::UpdateInfo &/*_info*/,
-    ignition::gazebo::EntityComponentManager &_ecm)
+    ignition::gazebo::EntityComponentManager &/*_ecm*/)
 {
   if (this->dataPtr->worldName.empty())
     return;
@@ -121,7 +121,7 @@ void VisibilityPlugin::PreUpdate(
 //////////////////////////////////////////////////
 void VisibilityPlugin::PostUpdate(
     const ignition::gazebo::UpdateInfo &_info,
-    const ignition::gazebo::EntityComponentManager &_ecm)
+    const ignition::gazebo::EntityComponentManager &/*_ecm*/)
 {
   if (this->dataPtr->worldName.empty())
     return;

--- a/subt_ign/src/path_tracer.cc
+++ b/subt_ign/src/path_tracer.cc
@@ -1,0 +1,354 @@
+/*
+ * Copyright (C) 2020 Open Source Robotics Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+*/
+#include "path_tracer.hh"
+
+//////////////////////////////////////////////////
+Processor::Processor(const std::string &_path, int _stepSleepMs)
+  : stepSleepMs(_stepSleepMs)
+{
+  // Create the transport node with the partition used by simulation
+  // world.
+  ignition::transport::NodeOptions opts;
+  opts.SetPartition("PATH_TRACER");
+  this->markerNode = new ignition::transport::Node(opts);
+  this->ClearMarkers();
+
+  // Subscribe to the artifact poses.
+  this->SubscribeToArtifactPoseTopics();
+
+  // Playback the log file.
+  std::unique_lock<std::mutex> lock(this->mutex);
+  std::thread playbackThread(std::bind(&Processor::Playback, this, _path));
+
+  this->cv.wait(lock);
+
+  // Create a transport node that uses the default partition.
+  ignition::transport::Node node;
+
+  // Subscribe to the robot pose topic
+  bool subscribed = false;
+  for (int i = 0; i < 5 && !subscribed; ++i)
+  {
+    std::vector<std::string> topics;
+    node.TopicList(topics);
+
+    // Subscribe to the first /dynamic_pose/info topic
+    for (auto const &topic : topics)
+    {
+      if (topic.find("/dynamic_pose/info") != std::string::npos)
+      {
+        // Subscribe to a topic by registering a callback.
+        if (!node.Subscribe(topic, &Processor::Cb, this))
+        {
+          std::cerr << "Error subscribing to topic ["
+            << topic << "]" << std::endl;
+          return;
+        }
+        subscribed = true;
+        break;
+      }
+    }
+    std::this_thread::sleep_for(std::chrono::seconds(1));
+  }
+
+  // Wait for log playback to end.
+  playbackThread.join();
+
+  // Process the events log file.
+  YAML::Node events = YAML::LoadFile(_path + "/events.yml");
+  for (std::size_t i = 0; i < events.size(); ++i)
+  {
+    if (events[i]["type"].as<std::string>() == "artifact_report_attempt")
+    {
+      ignition::math::Vector3d reportedPos;
+
+      // Read the reported pose.
+      std::stringstream stream;
+      stream << events[i]["reported_pose"].as<std::string>();
+      stream >> reportedPos;
+
+      int sec = events[i]["time_sec"].as<int>();
+      std::unique_ptr<ReportData> data(new ReportData);
+      data->type = REPORT;
+      data->pos = reportedPos;
+      data->score = events[i]["points_scored"].as<int>();
+
+      this->logData[sec].push_back(std::move(data));
+    }
+  }
+  // Display all of the artifacts using visual markers.
+  this->DisplayArtifacts();
+
+  // Display all of the poses using visual markers.
+  this->DisplayPoses();
+}
+
+//////////////////////////////////////////////////
+Processor::~Processor()
+{
+  delete this->markerNode;
+  this->markerNode = nullptr;
+}
+
+//////////////////////////////////////////////////
+void Processor::ClearMarkers()
+{
+  ignition::msgs::Marker markerMsg;
+  markerMsg.set_ns("default");
+  markerMsg.set_action(ignition::msgs::Marker::DELETE_ALL);
+  markerNode->Request("/marker", markerMsg);
+  std::this_thread::sleep_for(std::chrono::seconds(1));
+}
+
+//////////////////////////////////////////////////
+void Processor::Playback(std::string _path)
+{
+  std::unique_lock<std::mutex> lock(this->mutex);
+  ignition::transport::log::Playback player(_path + "/state.tlog");
+  bool valid = false;
+  ignition::transport::log::PlaybackHandlePtr handle;
+
+  // Playback all topics
+  const int64_t addTopicResult = player.AddTopic(std::regex(".*"));
+  if (addTopicResult == 0)
+    std::cerr << "No topics to play back\n";
+  else if (addTopicResult < 0)
+    std::cerr << "Failed to advertise topics: " << addTopicResult << "\n";
+  else
+  {
+    // Begin playback
+    handle = player.Start(std::chrono::seconds(5), false);
+    if (!handle)
+    {
+      std::cerr << "Failed to start playback\n";
+      return;
+    }
+    valid = true;
+  }
+  cv.notify_all();
+  lock.unlock();
+
+  // Wait until the player stops on its own
+  if (valid)
+  {
+    std::cerr << "Playing all messages in the log file\n";
+    handle->WaitUntilFinished();
+  }
+}
+
+/////////////////////////////////////////////////
+void Processor::SubscribeToArtifactPoseTopics()
+{
+  bool subscribed = false;
+  for (int i = 0; i < 5 && !subscribed; ++i)
+  {
+    std::vector<std::string> topics;
+    this->markerNode->TopicList(topics);
+
+    for (auto const &topic : topics)
+    {
+      if (topic.find("/pose/info") != std::string::npos)
+      {
+        this->markerNode->Subscribe(topic, &Processor::ArtifactCb, this);
+        subscribed = true;
+      }
+    }
+    std::this_thread::sleep_for(std::chrono::seconds(1));
+  }
+}
+
+/////////////////////////////////////////////////
+void Processor::ArtifactCb(const ignition::msgs::Pose_V &_msg)
+{
+  // Process each pose in the message.
+  for (int i = 0; i < _msg.pose_size(); ++i)
+  {
+    // Only consider artifacts.
+    std::string name = _msg.pose(i).name();
+    if (name.find("rescue") == 0 ||
+        name.find("backpack") == 0 ||
+        name.find("vent") == 0 ||
+        name.find("gas") == 0 ||
+        name.find("drill") == 0 ||
+        name.find("extinguisher") == 0 ||
+        name.find("phone") == 0 ||
+        name.find("rope") == 0 ||
+        name.find("helmet") == 0)
+    {
+      ignition::math::Pose3d pose = ignition::msgs::Convert(_msg.pose(i));
+      this->artifacts[name] = pose;
+    }
+  }
+}
+
+//////////////////////////////////////////////////
+void Processor::DisplayPoses()
+{
+  for (auto &stepData : this->logData)
+  {
+    for (std::unique_ptr<Data> &data : stepData.second)
+    {
+      data->Render(this);
+    }
+    std::this_thread::sleep_for(std::chrono::milliseconds(this->stepSleepMs));
+  }
+}
+
+/////////////////////////////////////////////////
+void Processor::DisplayArtifacts()
+{
+  for (const auto &[name, pose] : this->artifacts)
+  {
+    this->SpawnMarker(this->colors[2], pose.Pos(),
+        ignition::msgs::Marker::SPHERE,
+        ignition::math::Vector3d(8, 8, 8));
+  }
+}
+
+//////////////////////////////////////////////////
+void Processor::SpawnMarker(ignition::math::Color &_color,
+    const ignition::math::Vector3d &_pos,
+    ignition::msgs::Marker::Type _type,
+    const ignition::math::Vector3d &_scale)
+{
+  // Create the marker message
+  ignition::msgs::Marker markerMsg;
+  ignition::msgs::Material matMsg;
+  markerMsg.set_ns("default");
+  markerMsg.set_id(this->markerId++);
+  markerMsg.set_action(ignition::msgs::Marker::ADD_MODIFY);
+  markerMsg.set_type(_type);
+  markerMsg.set_visibility(ignition::msgs::Marker::GUI);
+
+  // Set color
+  markerMsg.mutable_material()->mutable_ambient()->set_r(_color.R());
+  markerMsg.mutable_material()->mutable_ambient()->set_g(_color.G());
+  markerMsg.mutable_material()->mutable_ambient()->set_b(_color.B());
+  markerMsg.mutable_material()->mutable_ambient()->set_a(_color.A());
+  markerMsg.mutable_material()->mutable_diffuse()->set_r(_color.R());
+  markerMsg.mutable_material()->mutable_diffuse()->set_g(_color.G());
+  markerMsg.mutable_material()->mutable_diffuse()->set_b(_color.B());
+  markerMsg.mutable_material()->mutable_diffuse()->set_a(_color.A());
+  markerMsg.mutable_material()->mutable_emissive()->set_r(_color.R());
+  markerMsg.mutable_material()->mutable_emissive()->set_g(_color.G());
+  markerMsg.mutable_material()->mutable_emissive()->set_b(_color.B());
+  markerMsg.mutable_material()->mutable_emissive()->set_a(_color.A());
+
+  ignition::msgs::Set(markerMsg.mutable_scale(), _scale);
+
+  // The rest of this function adds different shapes and/or modifies shapes.
+  // Read the terminal statements to figure out what each node.Request
+  // call accomplishes.
+  ignition::msgs::Set(markerMsg.mutable_pose(),
+      ignition::math::Pose3d(_pos.X(), _pos.Y(), _pos.Z(), 0, 0, 0));
+  this->markerNode->Request("/marker", markerMsg);
+}
+
+//////////////////////////////////////////////////
+void Processor::Cb(const ignition::msgs::Pose_V &_msg)
+{
+  std::unique_ptr<RobotPoseData> data(new RobotPoseData);
+
+  // Process each pose in the message.
+  for (int i = 0; i < _msg.pose_size(); ++i)
+  {
+    // Only conder robots.
+    std::string name = _msg.pose(i).name();
+    if (name.find("_wheel") != std::string::npos ||
+        name.find("rotor_") != std::string::npos || name == "base_link") {
+      continue;
+    }
+
+    ignition::math::Pose3d pose = ignition::msgs::Convert(_msg.pose(i));
+
+    if (this->robots.find(name) == this->robots.end())
+    {
+      this->robots[name] = this->colors[this->robots.size()+3];
+      this->prevPose[name] = pose;
+    }
+
+    // Filter poses.
+    if (this->prevPose[name].Pos().Distance(pose.Pos()) > 1.0)
+    {
+      data->poses[name].push_back(pose);
+      this->prevPose[name] = pose;
+    }
+  }
+
+  int sec = _msg.header().stamp().sec();
+  // Store data.
+  if (!data->poses.empty())
+    this->logData[sec].push_back(std::move(data));
+}
+
+/////////////////////////////////////////////////
+void RobotPoseData::Render(Processor *_p)
+{
+  // Render the paths using colored spheres.
+  for (std::map<std::string,
+      std::vector<ignition::math::Pose3d>>::const_iterator
+      iter = this->poses.begin(); iter != this->poses.end(); iter++)
+  {
+    for (const ignition::math::Pose3d &p : iter->second)
+    {
+      _p->SpawnMarker(_p->robots[iter->first],
+          p.Pos() + ignition::math::Vector3d(0, 0, 0.5),
+          ignition::msgs::Marker::SPHERE,
+          ignition::math::Vector3d(1, 1, 1));
+    }
+  }
+}
+
+/////////////////////////////////////////////////
+void ReportData::Render(Processor *_p)
+{
+  // If scored, then render a green sphere.
+  // Otherwise render a red box.
+  if (this->score > 0)
+  {
+    _p->SpawnMarker(_p->colors[1], this->pos,
+        ignition::msgs::Marker::SPHERE,
+        ignition::math::Vector3d(4, 4, 4));
+  }
+  else
+  {
+    _p->SpawnMarker(_p->colors[0], this->pos,
+        ignition::msgs::Marker::BOX,
+        ignition::math::Vector3d(4, 4, 4));
+  }
+}
+
+/////////////////////////////////////////////////
+int main(int _argc, char **_argv)
+{
+  int sleep = 20;
+  if (_argc > 2)
+  {
+    try
+    {
+      sleep = std::stoi(_argv[2]);
+    }
+    catch(...)
+    {
+      std::cerr << "Invalid sleep time. Defaulting to 20ms\n";
+    }
+  }
+
+  // Create and run the processor.
+  Processor p(_argv[1], sleep);
+  return 0;
+}

--- a/subt_ign/src/path_tracer.hh
+++ b/subt_ign/src/path_tracer.hh
@@ -163,7 +163,7 @@ class Processor
   private: int markerId = 0;
 
   /// \brief Node that will display the visual markers.
-  private: ignition::transport::Node *markerNode;
+  private: std::unique_ptr<ignition::transport::Node> markerNode;
 
   /// \brief A mutex.
   private: std::mutex mutex;

--- a/subt_ign/src/path_tracer.hh
+++ b/subt_ign/src/path_tracer.hh
@@ -1,0 +1,179 @@
+/*
+ * Copyright (C) 2020 Open Source Robotics Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+*/
+#include <yaml-cpp/yaml.h>
+
+#include <mutex>
+#include <map>
+#include <iostream>
+#include <condition_variable>
+
+#include <ignition/transport.hh>
+#include <ignition/math.hh>
+#include <ignition/msgs.hh>
+#include <ignition/common/Time.hh>
+#include <ignition/transport/log/Playback.hh>
+
+// Usage:
+//
+// 1. Run the SubT world using the `path_tracer.ign` launch file along with
+// an IGN_PARTITION name of PATH_TRACER. For example
+//
+//     $ IGN_PARTITION=PATH_TRACER ign launch -v 4 path_tracer.ign worldName:=cave_qual
+//
+// 2. Run this program by passing in the directory that contains the simulation log files. Optionally specify the number of milliseconds to sleep between time step playback. If not specified a value of 20ms will be used. For example:
+//
+//     $ ./path_tracer /data/logs/ 100
+
+// Forward declaration.
+class Processor;
+
+/// \brief Type of data, which is used to determine how to visualize the
+/// data.
+enum DataType
+{
+  ROBOT  = 0,
+  REPORT = 1
+};
+
+/// \brief Base class for data visualization
+class Data
+{
+  /// \brief The type of data.
+  public: DataType type;
+
+  /// \brief Pure virtual render function.
+  /// \param[in] _p Pointer to the processor.
+  public: virtual void Render(Processor *_p) = 0;
+};
+
+/// \brief RobotPoseData contains all pose data for a single pose
+/// message callback.
+class RobotPoseData : public Data
+{
+  /// \brief All pose information.
+  public: std::map<std::string, std::vector<ignition::math::Pose3d>> poses;
+
+  /// \brief The render function for robot pose data.
+  public: void Render(Processor *_p);
+};
+
+/// \brief Artifact report data
+class ReportData : public Data
+{
+  /// \brief Position of the artifact report.
+  public: ignition::math::Vector3d pos;
+
+  /// \brief Change in score.
+  public: int score;
+
+  /// \brief The render function for artifact report data.
+  public: void Render(Processor *_p);
+};
+
+/// \brief The log file processor.
+class Processor
+{
+  /// \brief Constructor, which also kicks off all of the data
+  /// visualization.
+  /// \param[in] _path Path to the directory containing the log files.
+  public: Processor(const std::string &_path, int _stepSleepMs);
+
+  /// \brief Destructor
+  public: ~Processor();
+
+  /// \brief Clear all of the markers.
+  public: void ClearMarkers();
+
+  /// Playback a log file.
+  public: void Playback(std::string _path);
+
+  /// Subscribe to the artifact poses.
+  public: void SubscribeToArtifactPoseTopics();
+
+  /// \brief Get the artifact poses.
+  /// \param[in] _msg Pose message.
+  public: void ArtifactCb(const ignition::msgs::Pose_V &_msg);
+
+  /// \brief Display the poses.
+  public: void DisplayPoses();
+
+  /// \brief Display the artifacts.
+  public: void DisplayArtifacts();
+
+  /// \brief Helper function that spawns a visual marker.
+  /// \param[in] _color Color of the visual marker.
+  /// \param[in] _pos Position of the visual marker.
+  /// \param[in] _type Type of the visual marker.
+  /// \param[in] _scale scale of the visual marker.
+  public: void SpawnMarker(ignition::math::Color &_color,
+    const ignition::math::Vector3d &_pos,
+    ignition::msgs::Marker::Type _type,
+    const ignition::math::Vector3d &_scale);
+
+  /// \brief This callback is triggered on every pose message in the log file.
+  public: void Cb(const ignition::msgs::Pose_V &_msg);
+
+  /// \brief Mapping of robot name to color
+  public: std::map<std::string, ignition::math::Color> robots;
+
+  /// \brief The colors used to represent each robot.
+  public: std::vector<ignition::math::Color> colors =
+  {
+    // Bad Report locations
+    {1.0, 0.0, 0.0, 0.1},
+
+    // Good Artifact locations
+    {0.0, 1.0, 0.0, 0.1},
+
+    // Artifact locations.
+    {0.0, 1.0, 1.0, 0.1},
+
+    // Robot colors
+    {153/255.0, 0, 1},
+    {173/255.0, 51/255.0, 1},
+    {194/255.0, 102/255.0, 1},
+    {214/255.0, 153/255.0, 1},
+
+    {1, 153/255.0, 0},
+    {1, 173/255.0, 51/255.0},
+    {1, 194/255.0, 102/255.0},
+  };
+
+  /// \brief Last pose of a robot. This is used to reduce the number of markers.
+  private: std::map<std::string, ignition::math::Pose3d> prevPose;
+
+  /// \brief Artifacts and their pose information.
+  private:std::map<std::string, ignition::math::Pose3d> artifacts;
+
+  /// \brief Marker ID, used to create unique markers.
+  private: int markerId = 0;
+
+  /// \brief Node that will display the visual markers.
+  private: ignition::transport::Node *markerNode;
+
+  /// \brief A mutex.
+  private: std::mutex mutex;
+
+  /// \brief A condition variable.
+  private: std::condition_variable cv;
+
+  /// \brief All of the pose data.
+  private: std::map<int, std::vector<std::unique_ptr<Data>>> logData;
+
+  /// \brief Number of milliseconds to sleep between log steps.
+  private: int stepSleepMs = 20;
+};


### PR DESCRIPTION
Added a path tracer program that visualizes robot paths, artifacts, and artifact reports.

# Usage

1. You need to use Ignition Citadel. An updated docker image is in the works.

2. Run the SubT world using the `path_tracer.ign` launch file along with an IGN_PARTITION name of PATH_TRACER. For example:

```
 IGN_PARTITION=PATH_TRACER ign launch -v 4 path_tracer.ign worldName:=cave_qual
```
3.  Run this program by passing in the directory that contains the simulation log files. Optionally specify the number of milliseconds to sleep between time step playback. If not specified a value of 20ms will be used. For example, from within a subt catkin workspace:

```
./install/bin/path_tracer ~/Downloads/my_logs 30
```

Signed-off-by: Nate Koenig <nate@openrobotics.org>