### PR TITLE
Change unique_robot count to be based on robot platform types

### DIFF
--- a/subt_ign/include/subt_ign/RobotPlatformTypes.hh
+++ b/subt_ign/include/subt_ign/RobotPlatformTypes.hh
@@ -25,17 +25,17 @@ const std::vector<std::string> robotPlatformTypes = {
   "X4",
   "HUSKY",
   "TEAMBASE",
-  "ANYMAL",
+  "ANYMAL_B",
   "M100",
   "FREYJA",
   "KLOUBAK",
   "HD2",
   "QAV500",
-  "EXPLORER_R2",
-  "EXPLORER_DS1",
-  "CSIRO_DATA61_OZBOT_ATR",
-  "CTU_CRAS_NORLAB_ABSOLEM",
-  "CERBERUS_GAGARIN"
+  "R2",
+  "DS1",
+  "OZBOT_ATR",
+  "ABSOLEM",
+  "GAGARIN"
 };
 
 #endif

--- a/subt_ign/include/subt_ign/RobotPlatformTypes.hh
+++ b/subt_ign/include/subt_ign/RobotPlatformTypes.hh
@@ -1,0 +1,41 @@
+/*
+ * Copyright (C) 2020 Open Source Robotics Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+*/
+#ifndef SUBT_IGN_ROBOTPLATFORMTYPES_HH_
+#define SUBT_IGN_ROBOTPLATFORMTYPES_HH_
+/// \brief List of robot platform types. This is used to count unique robot
+/// types.
+const std::vector<std::string> robotPlatformTypes = {
+  "X1",
+  "X2",
+  "X3",
+  "X4",
+  "HUSKY",
+  "TEAMBASE",
+  "ANYMAL",
+  "M100",
+  "FREYJA",
+  "KLOUBAK",
+  "HD2",
+  "QAV500",
+  "EXPLORER_R2",
+  "EXPLORER_DS1",
+  "CSIRO_DATA61_OZBOT_ATR",
+  "CTU_CRAS_NORLAB_ABSOLEM",
+  "CERBERUS_GAGARIN"
+};
+
+#endif

--- a/subt_ign/src/GameLogicPlugin.cc
+++ b/subt_ign/src/GameLogicPlugin.cc
@@ -60,6 +60,7 @@
 #include "subt_ign/CommonTypes.hh"
 #include "subt_ign/GameLogicPlugin.hh"
 #include "subt_ign/protobuf/artifact.pb.h"
+#include "subt_ign/RobotPlatformTypes.hh"
 
 IGNITION_ADD_PLUGIN(
     subt::GameLogicPlugin,
@@ -381,9 +382,8 @@ class subt::GameLogicPluginPrivate
   /// \brief Names of the spawned robots.
   public: std::set<std::string> robotNames;
 
-  /// \brief Source file paths of the spawned robots.
-  /// For keeping track of unique robot models.
-  public: std::set<std::string> robotSourceFilePaths;
+  /// \brief Robot types for keeping track of unique robot platform types.
+  public: std::set<std::string> robotTypes;
 
   /// \brief The unique artifact reports received.
   public: std::vector<std::string> uniqueReports;
@@ -767,7 +767,13 @@ void GameLogicPlugin::PostUpdate(
               auto filePath =
                 _ecm.Component<gazebo::components::SourceFilePath>(
                 model->Data());
-              this->dataPtr->robotSourceFilePaths.insert(filePath->Data());
+
+              // Store unique robot platform information.
+              for (const std::string &type : robotPlatformTypes)
+              {
+                if (filePath->Data().find(type) != std::string::npos)
+                  this->dataPtr->robotTypes.insert(type);
+              }
 
               // Subscribe to detach topics. We are doing a blanket
               // subscribe even though a robot model may not be marsupial.
@@ -1805,7 +1811,7 @@ void GameLogicPluginPrivate::LogRobotArtifactData() const
   out << YAML::Key << "robot_count";
   out << YAML::Value << this->robotNames.size();
   out << YAML::Key << "unique_robot_count";
-  out << YAML::Value << this->robotSourceFilePaths.size();
+  out << YAML::Value << this->robotTypes.size();
   out << YAML::Key << "sim_time";
   out << YAML::Value << simElapsed;
   out << YAML::Key << "real_time";

--- a/subt_ign/src/GameLogicPlugin.cc
+++ b/subt_ign/src/GameLogicPlugin.cc
@@ -771,7 +771,11 @@ void GameLogicPlugin::PostUpdate(
               // Store unique robot platform information.
               for (const std::string &type : robotPlatformTypes)
               {
-                if (filePath->Data().find(type) != std::string::npos)
+                std::string platformNameUpper = filePath->Data();
+                std::transform(platformNameUpper.begin(),
+                    platformNameUpper.end(),
+                    platformNameUpper.begin(), ::toupper);
+                if (platformNameUpper.find(type) != std::string::npos)
                   this->dataPtr->robotTypes.insert(type);
               }
 


### PR DESCRIPTION
Log unique robot platforms instead of unique robots.

Signed-off-by: Nate Koenig <nate@openrobotics.org>