### PR TITLE
Add scripts for thumbnails and model download

### DIFF
--- a/subt_ign/scripts/capture_thumbnails.sh
+++ b/subt_ign/scripts/capture_thumbnails.sh
@@ -1,0 +1,73 @@
+#!/bin/bash
+#
+# Captures 5 thumbnails (iso, top, side, front, rear) for a model. Stores thumbnails in ~/model_thumbnails/<MODEL NAME>
+#
+# Requirements: "shutter" installed, "blank.sdf" world
+# Note the "blank.sdf" world has custom lighting and white background. Another world could be used, but the world *must* have the ignition UserCommands plugin. See the "blank.sdf" world for example.
+# 
+# Usage: 	
+#		ign gazebo -v 4 blank.sdf 
+#		./capture_thumbnails "X1 Config 1" 0.3 
+# 		(./capture_thumbnails <MODEL NAME> <ZOOM>)
+#
+# Recommended zoom values:
+#     * 0.50 for X1
+#     * 0.35 for X2
+#     * 0.27 for X3
+#     * 0.32 for X4
+# Screenshot location values (window_x, window_y) may need to be adjusted based on your screen size and the model you capture.
+
+if [ -z "$1" ]
+then
+	printf "No model entered.\nUsage: ./capture_thumbnails <MODEL NAME> <ZOOM>\n"
+	exit
+else
+	model=$1
+	dir="$HOME/model_thumbnails/$model/thumbnails"
+	size="800,600" # width, height in pixels (do not change), SubT Virtual Portal uses this aspect ratio
+	window_x=317
+	window_y=282
+	sides_window_y=$(($window_y-120)) # adjust Y for side screenshots due to focus on ground plane
+	zoom=$2	
+	world=blank
+	printf "Capturing thumbnails for $model in $dir\n"
+	mkdir -p "$dir"
+fi
+
+# Spawn the model at origin
+printf "Spawn model $model at origin\n"
+ign service -s /world/$world/create --reqtype ignition.msgs.EntityFactory --reptype ignition.msgs.Boolean --timeout 5000 --req 'sdf: ''"<?xml version=\"1.0\" ?>''<sdf version=\"1.6\">''<include>''<name>model</name>'"<uri>https://fuel.ignitionrobotics.org/1.0/OpenRobotics/models/$model</uri>"'</include>''</sdf>' >/dev/null 2>&1
+ign service -s /gui/view_angle --reqtype ignition.msgs.Vector3d --reptype ignition.msgs.Boolean --timeout 2000 --req 'x:0 y:0 z:0' >/dev/null
+#sleep 1
+
+# Iso view screenshot
+printf "Iso view.\n"
+ign service -s /gui/move_to --reqtype ignition.msgs.StringMsg --reptype ignition.msgs.Boolean --timeout 2000 --req 'data: "model"' >/dev/null
+ign service -s /gui/view_angle --reqtype ignition.msgs.Vector3d --reptype ignition.msgs.Boolean --timeout 2000 --req "x:-$zoom y:$zoom z:-$zoom" >/dev/null
+shutter -s="$window_x,$window_y,$size" -e -n -o "$dir"/1.png >/dev/null 2>&1
+
+# Top view screenshot
+printf "Top view.\n"
+ign service -s /gui/view_angle --reqtype ignition.msgs.Vector3d --reptype ignition.msgs.Boolean --timeout 2000 --req 'x:0 y:0 z:-1' >/dev/null
+shutter -s="$window_x,$window_y,$size" -e -n -o "$dir"/2.png >/dev/null 2>&1
+
+# Side view screenshot
+printf "Side view.\n"
+ign service -s /gui/view_angle --reqtype ignition.msgs.Vector3d --reptype ignition.msgs.Boolean --timeout 2000 --req 'x:0 y:0.9 z:0' >/dev/null
+shutter -s="$window_x,$sides_window_y,$size" -e -n -o "$dir"/3.png >/dev/null 2>&1
+
+# Front view screenshot
+printf "Front view.\n"
+ign service -s /gui/view_angle --reqtype ignition.msgs.Vector3d --reptype ignition.msgs.Boolean --timeout 2000 --req 'x:-1 y:0 z:0' >/dev/null
+shutter -s="$window_x,$sides_window_y,$size" -e -n -o "$dir"/4.png >/dev/null 2>&1
+
+# Rear view screenshot
+printf "Rear view.\n"
+ign service -s /gui/view_angle --reqtype ignition.msgs.Vector3d --reptype ignition.msgs.Boolean --timeout 2000 --req 'x:1 y:0 z:0' >/dev/null
+shutter -s="$window_x,$sides_window_y,$size" -e -n -o "$dir"/5.png >/dev/null 2>&1
+
+# Remove the model
+printf "Remove model.\n"
+ign service -s /world/$world/remove --reqtype ignition.msgs.Entity --reptype ignition.msgs.Boolean --timeout 2000 --req 'name: "model" type: MODEL' >/dev/null
+
+printf "Captured thumbnails for $model in $dir\n"

--- a/subt_ign/scripts/download_models.py
+++ b/subt_ign/scripts/download_models.py
@@ -1,0 +1,57 @@
+# Download models from the SubT Tech Repo into .zip files in the current directory (does not require Ignition install)
+# May choose a subset of models (e.g., robots, artifacts, tiles) or download all models
+#
+#   Usage: 
+#           python download_models.py <TYPE>
+#
+#   Valid types:
+#           1: All models
+#           2: Robots
+#           3: Artifacts 
+#           4: Tunnel tiles
+#           5: Urban tiles
+#           6: Cave tiles
+
+import sys, json, requests
+
+model_filters = {
+    1: "*",
+    2: "categories:Robots",
+    3: "tags:artifact",
+    4: "Tunnel*",
+    5: "Urban*",
+    6: "Cave*"
+}
+
+if (len(sys.argv) != 2):
+    print("""Usage: python download_models.py <TYPE>
+    Valid types:
+        1: All models
+        2: Robots
+        3: Artifacts 
+        4: Tunnel tiles
+        5: Urban tiles
+        6: Cave tiles""")
+    exit()
+else:
+    model_filter = model_filters.get(int(sys.argv[1]), "*") 
+    # Note: if the type is not in the list, all models will be downloaded
+    print("Downloading SubT Tech Repo models matching the filter: %s\nThis may take a few minutes..." % model_filter)
+
+# URLs for getting model names and files
+repo_url = 'https://fuel.ignitionrobotics.org/1.0/models?per_page=500&q=collections:SubT%20Tech%20Repo%26'
+download_url = 'https://fuel.ignitionrobotics.org/1.0/OpenRobotics/models/'
+
+# Get a list of models matching the filter
+models = requests.get(repo_url+model_filter)
+models_dict = json.loads(models.text)
+
+# For each model in list, download the model
+for entry in models_dict:
+    model_name = entry['name']
+    print('  Downloading %s' % model_name)
+    download_res = requests.get(download_url+model_name+'.zip',stream=True)
+    with open(model_name+'.zip', 'wb') as fd:
+        for chunk in download_res.iter_content(chunk_size=1024*1024):
+            fd.write(chunk)
+print('Done.')

--- a/subt_ign/worlds/blank.sdf
+++ b/subt_ign/worlds/blank.sdf
@@ -1,0 +1,87 @@
+<?xml version="1.0" ?>
+<!-- Blank world used for taking thumbnails of models -->
+<sdf version="1.6">
+  <world name="blank">
+    <plugin
+      filename="libignition-gazebo-user-commands-system.so"
+      name="ignition::gazebo::systems::UserCommands">
+    </plugin>
+    <plugin
+      filename="libignition-gazebo-scene-broadcaster-system.so"
+      name="ignition::gazebo::systems::SceneBroadcaster">
+    </plugin>
+    <gui fullscreen="0">
+      <!-- 3D scene -->
+      <plugin filename="GzScene3D" name="3D View">
+        <ignition-gui>
+          <title>3D View</title>
+          <property type="bool" key="showTitleBar">false</property>
+          <property type="string" key="state">docked</property>
+        </ignition-gui>
+
+        <engine>ogre2</engine>
+        <scene>scene</scene>
+        <ambient_light>1.0 1.0 1.0 1.0</ambient_light>
+        <background_color>1.0 1.0 1.0</background_color>
+        <camera_pose>-6 0 6 0 0.5 0</camera_pose>
+      </plugin>
+      
+    </gui>
+
+    <light type="directional" name="sun">
+      <cast_shadows>true</cast_shadows>
+      <pose>0 0 10 0 0 0</pose>
+      <diffuse>1.0 1.0 1.0 1</diffuse>
+      <specular>0.2 0.2 0.2 1</specular>
+      <attenuation>
+        <range>1000</range>
+        <constant>0.1</constant>
+        <linear>0.001</linear>
+        <quadratic>0.0001</quadratic>
+      </attenuation>
+      <direction>-0.5 0.1 -0.9</direction>
+    </light>
+
+    <light type="directional" name="front">
+      <cast_shadows>true</cast_shadows>
+      <pose>5 0 3 0 0 0</pose>
+      <diffuse>1.0 1.0 1.0 1</diffuse>
+      <specular>0.2 0.2 0.2 1</specular>
+      <attenuation>
+        <range>1000</range>
+        <constant>0.1</constant>
+        <linear>0.001</linear>
+        <quadratic>0.0001</quadratic>
+      </attenuation>
+      <direction>-0.866 0 -0.5</direction>
+    </light>
+    <light type="directional" name="rear">
+      <cast_shadows>true</cast_shadows>
+      <pose>-5 0 3 0 0 0</pose>
+      <diffuse>1.0 1.0 1.0 1</diffuse>
+      <specular>0.2 0.2 0.2 1</specular>
+      <attenuation>
+        <range>1000</range>
+        <constant>0.1</constant>
+        <linear>0.001</linear>
+        <quadratic>0.0001</quadratic>
+      </attenuation>
+      <direction>0.866 0 -0.5</direction>
+    </light>
+    <light type="directional" name="side">
+      <cast_shadows>true</cast_shadows>
+      <pose>0 -5 1 0 0 0</pose>
+      <diffuse>1.0 1.0 1.0 1</diffuse>
+      <specular>0.2 0.2 0.2 1</specular>
+      <attenuation>
+        <range>1000</range>
+        <constant>0.1</constant>
+        <linear>0.001</linear>
+        <quadratic>0.0001</quadratic>
+      </attenuation>
+      <direction>0 0.9 -0.1</direction>
+    </light>
+
+
+  </world>
+</sdf>


### PR DESCRIPTION
This adds two scripts:
* `capture_thumbnails.sh` - captures model thumbnails for a given model to use on Fuel
* `download_models.py` - downloads models from the SubT Tech Repo (can be used without Ignition installed)

And one world:
* `blank.sdf` - an empty, well-lit world useful for capturing model thumbnails