### PR TITLE
Break out model download into separate docker image.

### DIFF
--- a/docker/cloudsim_sim/Dockerfile
+++ b/docker/cloudsim_sim/Dockerfile
@@ -26,6 +26,7 @@ RUN sudo apt-get update -qq \
         ruby2.5 \
         ruby2.5-dev \
         software-properties-common \
+        vim \
         net-tools \
         iputils-ping \
         libyaml-cpp-dev \
@@ -37,8 +38,8 @@ VOLUME /root/.aws
 
 # install ROS and required packages
 RUN sudo /bin/sh -c 'echo "deb [trusted=yes] http://packages.ros.org/ros/ubuntu $(lsb_release -sc) main" > /etc/apt/sources.list.d/ros-latest.list' \
- && sudo apt-get update \
- && sudo apt-get install -y \
+ && sudo apt-get update -qq \
+ && sudo apt-get install -y -qq \
     python-catkin-tools \
     python-rosdep \
     python-rosinstall \
@@ -53,17 +54,10 @@ RUN sudo /bin/sh -c 'echo "deb [trusted=yes] http://packages.ros.org/ros/ubuntu 
     ros-melodic-rotors-control \
     ros-melodic-ros-ign \
  && sudo rosdep init \
- && sudo apt-get clean
+ && sudo apt-get clean -qq
 
-# Add a user with the same user_id as the user outside the container
-# Requires a docker build argument `user_id`
 ARG user_id
 ENV USERNAME developer
-# RUN useradd -U --uid ${user_id} -ms /bin/bash $USERNAME \
-#  && echo "$USERNAME:$USERNAME" | chpasswd \
-#  && adduser $USERNAME sudo \
-#  && echo "$USERNAME ALL=NOPASSWD: ALL" >> /etc/sudoers.d/$USERNAME
-# 
 USER $USERNAME
 
 # Make a couple folders for organizing docker volumes
@@ -73,8 +67,6 @@ RUN mkdir ~/workspaces ~/other
 WORKDIR /home/$USERNAME
 
 RUN rosdep update
-RUN sudo chown -R developer:developer subt_ws
-
 
 # Clone all the subt models so that you don't download them every time
 # docker is run
@@ -83,11 +75,6 @@ RUN mkdir -p subt_ws/src \
 
 WORKDIR /home/$USERNAME/subt_ws
 
-# Install Rotors
-# RUN wget https://s3.amazonaws.com/osrf-distributions/subt_robot_examples/releases/subt_robot_examples_latest.tgz
-# RUN tar xvf subt_robot_examples_latest.tgz
-
-RUN ls -l
 RUN /bin/bash -c 'source /opt/ros/melodic/setup.bash && catkin_make install'
 
 RUN /bin/sh -c 'echo ". /opt/ros/melodic/setup.bash" >> ~/.bashrc' \

--- a/docker/cloudsim_sim/Dockerfile
+++ b/docker/cloudsim_sim/Dockerfile
@@ -1,17 +1,9 @@
 # Ubuntu 18.04 with nvidia-docker2 beta opengl support
-FROM nvidia/opengl:1.0-glvnd-devel-ubuntu18.04
-
-RUN export DEBIAN_FRONTEND=noninteractive \
- && apt-get update \
- && apt-get install -y \
-    tzdata \
- && ln -fs /usr/share/zoneinfo/America/Los_Angeles /etc/localtime \
- && dpkg-reconfigure --frontend noninteractive tzdata \
- && apt-get clean
+FROM osrf/subt-virtual-testbed:models_latest
 
 # Tools I find useful during development
-RUN apt-get update -qq \
- && apt-get install --no-install-recommends -y -qq \
+RUN sudo apt-get update -qq \
+ && sudo apt-get install --no-install-recommends -y -qq \
         build-essential \
         bwm-ng \
         atop \
@@ -34,22 +26,19 @@ RUN apt-get update -qq \
         ruby2.5 \
         ruby2.5-dev \
         software-properties-common \
-        sudo \
-        vim \
-        wget \
         net-tools \
         iputils-ping \
         libyaml-cpp-dev \
- && apt-get clean -qq
+ && sudo apt-get clean -qq
 
 # Install AWS CLI. This is needed by cloudsim to capture ROS logs.
 RUN pip3 install --upgrade awscli=="1.16.220"
 VOLUME /root/.aws
 
 # install ROS and required packages
-RUN /bin/sh -c 'echo "deb [trusted=yes] http://packages.ros.org/ros/ubuntu $(lsb_release -sc) main" > /etc/apt/sources.list.d/ros-latest.list' \
- && apt-get update \
- && apt-get install -y \
+RUN sudo /bin/sh -c 'echo "deb [trusted=yes] http://packages.ros.org/ros/ubuntu $(lsb_release -sc) main" > /etc/apt/sources.list.d/ros-latest.list' \
+ && sudo apt-get update \
+ && sudo apt-get install -y \
     python-catkin-tools \
     python-rosdep \
     python-rosinstall \
@@ -62,38 +51,19 @@ RUN /bin/sh -c 'echo "deb [trusted=yes] http://packages.ros.org/ros/ubuntu $(lsb
     ros-melodic-twist-mux \
     ros-melodic-rviz-imu-plugin \
     ros-melodic-rotors-control \
- && rosdep init \
- && apt-get clean
-
-# sdformat8-sdf conflicts with sdformat-sdf installed from gazebo
-# so we need to workaround this using a force overwrite
-# Do this before installing ign-gazebo
-RUN /bin/sh -c 'echo "deb [trusted=yes] http://packages.osrfoundation.org/gazebo/ubuntu-stable `lsb_release -cs` main" > /etc/apt/sources.list.d/gazebo-stable.list' \
- && /bin/sh -c 'wget http://packages.osrfoundation.org/gazebo.key -O - | apt-key add -' \
- && /bin/sh -c 'apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-key C1CF6E31E6BADE8868B172B4F42ED6FBAB17C654'
-
-# install ign-blueprint
-RUN apt-get update \
-&&  apt-get install -y \
-    ignition-blueprint \
- && apt-get clean
-
-# install the ros to ign bridge
-RUN apt-get update \
- && apt-get install -y \
     ros-melodic-ros-ign \
- && apt-get clean
+ && sudo rosdep init \
+ && sudo apt-get clean
 
 # Add a user with the same user_id as the user outside the container
 # Requires a docker build argument `user_id`
 ARG user_id
 ENV USERNAME developer
-RUN useradd -U --uid ${user_id} -ms /bin/bash $USERNAME \
- && echo "$USERNAME:$USERNAME" | chpasswd \
- && adduser $USERNAME sudo \
- && echo "$USERNAME ALL=NOPASSWD: ALL" >> /etc/sudoers.d/$USERNAME
-
-# Commands below run as the developer user
+# RUN useradd -U --uid ${user_id} -ms /bin/bash $USERNAME \
+#  && echo "$USERNAME:$USERNAME" | chpasswd \
+#  && adduser $USERNAME sudo \
+#  && echo "$USERNAME ALL=NOPASSWD: ALL" >> /etc/sudoers.d/$USERNAME
+# 
 USER $USERNAME
 
 # Make a couple folders for organizing docker volumes
@@ -103,15 +73,13 @@ RUN mkdir ~/workspaces ~/other
 WORKDIR /home/$USERNAME
 
 RUN rosdep update
+RUN sudo chown -R developer:developer subt_ws
+
 
 # Clone all the subt models so that you don't download them every time
 # docker is run
 RUN mkdir -p subt_ws/src \
- && cd subt_ws/src \
- && git clone https://github.com/osrf/subt
-
-# Download the public models
-RUN ign fuel download -v 4 -j 16 -u "https://fuel.ignitionrobotics.org/OpenRobotics/collections/SubT Tech Repo"
+ && git clone https://github.com/osrf/subt subt_ws/src/subt
 
 WORKDIR /home/$USERNAME/subt_ws
 
@@ -119,6 +87,7 @@ WORKDIR /home/$USERNAME/subt_ws
 # RUN wget https://s3.amazonaws.com/osrf-distributions/subt_robot_examples/releases/subt_robot_examples_latest.tgz
 # RUN tar xvf subt_robot_examples_latest.tgz
 
+RUN ls -l
 RUN /bin/bash -c 'source /opt/ros/melodic/setup.bash && catkin_make install'
 
 RUN /bin/sh -c 'echo ". /opt/ros/melodic/setup.bash" >> ~/.bashrc' \

--- a/docker/subt_models/Dockerfile
+++ b/docker/subt_models/Dockerfile
@@ -1,0 +1,48 @@
+# Ubuntu 18.04 with nvidia-docker2 beta opengl support
+FROM nvidia/opengl:1.0-glvnd-devel-ubuntu18.04
+
+RUN export DEBIAN_FRONTEND=noninteractive \
+ && apt-get update \
+ && apt-get install --no-install-recommends -y \
+    tzdata \
+    sudo \
+    wget \
+    gnupg \
+    lsb-release \
+ && ln -fs /usr/share/zoneinfo/America/Los_Angeles /etc/localtime \
+ && dpkg-reconfigure --frontend noninteractive tzdata \
+ && apt-get clean
+
+# sdformat8-sdf conflicts with sdformat-sdf installed from gazebo
+# so we need to workaround this using a force overwrite
+# Do this before installing ign-gazebo
+RUN /bin/sh -c 'echo "deb [trusted=yes] http://packages.osrfoundation.org/gazebo/ubuntu-stable `lsb_release -cs` main" > /etc/apt/sources.list.d/gazebo-stable.list' \
+ && /bin/sh -c 'wget http://packages.osrfoundation.org/gazebo.key -O - | apt-key add -' \
+ && /bin/sh -c 'apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-key C1CF6E31E6BADE8868B172B4F42ED6FBAB17C654'
+
+# install ign-blueprint
+RUN apt-get update \
+&&  apt-get install -y \
+    ignition-blueprint \
+ && apt-get clean
+
+# Add a user with the same user_id as the user outside the container
+# Requires a docker build argument `user_id`
+ARG user_id
+ENV USERNAME developer
+RUN useradd -U --uid ${user_id} -ms /bin/bash $USERNAME \
+ && echo "$USERNAME:$USERNAME" | chpasswd \
+ && adduser $USERNAME sudo \
+ && echo "$USERNAME ALL=NOPASSWD: ALL" >> /etc/sudoers.d/$USERNAME
+
+# Commands below run as the developer user
+USER $USERNAME
+
+# When running a container start in the developer's home folder
+WORKDIR /home/$USERNAME
+
+# Download the public models
+RUN ign fuel download -v 4 -j 16 -u "https://fuel.ignitionrobotics.org/OpenRobotics/collections/SubT Tech Repo"
+
+# Copy entry point script, and set the entrypoint
+# ENTRYPOINT ["./run_sim.bash"]

--- a/docker/subt_models/run_sim.bash
+++ b/docker/subt_models/run_sim.bash
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+
+. /opt/ros/melodic/setup.bash
+. ~/subt_ws/install/setup.sh
+
+mkdir -p /tmp/ign/logs
+
+# Network traffic monitoring
+FILE=/tmp/ign/logs/network_traffic.csv
+echo "unix timestamp;iface_name;bytes_out/s;bytes_in/s;bytes_total/s;bytes_in;bytes_out;packets_out/s;packets_in/s;packets_total/s;packets_in;packets_out;errors_out/s;errors_in/s;errors_in;errors_out" > $FILE
+bwm-ng -o csv -c 0 -t 1000 -T rate -I eth0 >> $FILE &
+
+# atop process monitoring
+atop -R -w /tmp/ign/logs/atop_log &
+
+ign launch -v 4 $@

--- a/docker/subt_sim_entry/Dockerfile
+++ b/docker/subt_sim_entry/Dockerfile
@@ -1,9 +1,9 @@
 # Ubuntu 18.04 with nvidia-docker2 beta opengl support
-FROM nvidia/opengl:1.0-glvnd-devel-ubuntu18.04
+FROM osrf/subt-virtual-testbed:models_latest
 
 # Tools I find useful during development
-RUN apt-get update -qq \
- && apt-get install -y -qq \
+RUN sudo apt-get update -qq \
+ && sudo apt-get install --no-install-recommends -y -qq \
         build-essential \
         cmake \
         cppcheck \
@@ -24,39 +24,12 @@ RUN apt-get update -qq \
         ruby2.5 \
         ruby2.5-dev \
         software-properties-common \
-        sudo \
         vim \
-        wget \
         net-tools \
         iputils-ping \
         libyaml-cpp-dev \
- && apt-get clean -qq
-
-# Add a user with the same user_id as the user outside the container
-# Requires a docker build argument `user_id`
-ARG user_id
-ENV USERNAME developer
-RUN useradd -U --uid ${user_id} -ms /bin/bash $USERNAME \
- && echo "$USERNAME:$USERNAME" | chpasswd \
- && adduser $USERNAME sudo \
- && echo "$USERNAME ALL=NOPASSWD: ALL" >> /etc/sudoers.d/$USERNAME
-
-# Commands below run as the developer user
-USER $USERNAME
-
-# Make a couple folders for organizing docker volumes
-RUN mkdir ~/workspaces ~/other
-
-# When running a container start in the developer's home folder
-WORKDIR /home/$USERNAME
-
-RUN export DEBIAN_FRONTEND=noninteractive \
- && sudo apt-get update -qq \
- && sudo -E apt-get install -y -qq \
-    tzdata \
- && sudo ln -fs /usr/share/zoneinfo/America/Los_Angeles /etc/localtime \
- && sudo dpkg-reconfigure --frontend noninteractive tzdata \
  && sudo apt-get clean -qq
+
 
 # install ROS and required packages
 RUN sudo /bin/sh -c 'echo "deb [trusted=yes] http://packages.ros.org/ros/ubuntu $(lsb_release -sc) main" > /etc/apt/sources.list.d/ros-latest.list' \
@@ -74,44 +47,28 @@ RUN sudo /bin/sh -c 'echo "deb [trusted=yes] http://packages.ros.org/ros/ubuntu 
     ros-melodic-twist-mux \
     ros-melodic-rviz-imu-plugin \
     ros-melodic-rotors-control \
+    ros-melodic-ros-ign \
  && sudo rosdep init \
  && sudo apt-get clean -qq
 
+ARG user_id
+ENV USERNAME developer
+USER $USERNAME
+
+# Make a couple folders for organizing docker volumes
+RUN mkdir ~/workspaces ~/other
+
+# When running a container start in the developer's home folder
+WORKDIR /home/$USERNAME
+
 RUN rosdep update
-
-# sdformat8-sdf conflicts with sdformat-sdf installed from gazebo
-# so we need to workaround this using a force overwrite
-# Do this before installing ign-gazebo
-RUN sudo /bin/sh -c 'echo "deb [trusted=yes] http://packages.osrfoundation.org/gazebo/ubuntu-stable `lsb_release -cs` main" > /etc/apt/sources.list.d/gazebo-stable.list' \
- && sudo /bin/sh -c 'wget http://packages.osrfoundation.org/gazebo.key -O - | sudo apt-key add -' \
- && sudo /bin/sh -c 'apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-key C1CF6E31E6BADE8868B172B4F42ED6FBAB17C654'
-
-# install ign-blueprint
-RUN sudo apt-get update -qq \
- && sudo apt-get install -y -qq \
-    ignition-blueprint \
- && sudo apt-get clean -qq
-
-# install the ros to ign bridge
-RUN sudo apt-get update -qq \
- && sudo apt-get install -y -qq \
-    ros-melodic-ros-ign \
- && sudo apt-get clean -qq
 
 # Clone all the subt models so that you don't download them every time
 # docker is run
 RUN mkdir -p subt_ws/src \
- && cd subt_ws/src \
- && git clone https://github.com/osrf/subt
-
-# Download the public models
-RUN ign fuel download -v 4 -j 16 -u "https://fuel.ignitionrobotics.org/OpenRobotics/collections/SubT Tech Repo"
+ && git clone https://github.com/osrf/subt subt_ws/src/subt
 
 WORKDIR /home/$USERNAME/subt_ws
-
-# Install Rotors
-# RUN wget https://s3.amazonaws.com/osrf-distributions/subt_robot_examples/releases/subt_robot_examples_latest.tgz
-# RUN tar xvf subt_robot_examples_latest.tgz
 
 RUN /bin/bash -c 'source /opt/ros/melodic/setup.bash && catkin_make install'
 


### PR DESCRIPTION
This makes an new docker image that contains `ignition-blueprint` and the SubT models. This new image also acts as a base image for `cloudsim_sim` and `subt_sim_entry`.

The purpose for this is speed. If only code has changed, then we only need to rebuild `cloudsim_sim` and `subt_sim_entry` without re-downloading all of the models.

Usage of `cloudsim_sim` and `subt_sim_entry` does not change.

Signed-off-by: Nate Koenig <nate@openrobotics.org>