### PR TITLE
Log robot names and configurations in run.yml

### DIFF
--- a/subt_ign/src/GameLogicPlugin.cc
+++ b/subt_ign/src/GameLogicPlugin.cc
@@ -385,6 +385,11 @@ class subt::GameLogicPluginPrivate
   /// \brief Robot types for keeping track of unique robot platform types.
   public: std::set<std::string> robotTypes;
 
+  /// \brief Map of robot name to {platform, config}. For example:
+  /// {"MY_ROBOT_NAME", {"X1", "X1 SENSOR CONFIG 1"}}.
+  public: std::map<std::string, std::pair<std::string, std::string>>
+          robotFullTypes;
+
   /// \brief The unique artifact reports received.
   public: std::vector<std::string> uniqueReports;
 
@@ -776,7 +781,16 @@ void GameLogicPlugin::PostUpdate(
                     platformNameUpper.end(),
                     platformNameUpper.begin(), ::toupper);
                 if (platformNameUpper.find(type) != std::string::npos)
+                {
                   this->dataPtr->robotTypes.insert(type);
+
+                  // The full type is in the directory name, which is third
+                  // from the end (.../TYPE/VERSION/model.sdf).
+                  std::vector<std::string> pathParts =
+                    ignition::common::split(platformNameUpper, "/");
+                  this->dataPtr->robotFullTypes[mName->Data()] =
+                    {type, pathParts[pathParts.size()-3]};
+                }
               }
 
               // Subscribe to detach topics. We are doing a blanket
@@ -1821,9 +1835,22 @@ void GameLogicPluginPrivate::LogRobotArtifactData() const
   // 20. Total cumulative elevation loss by all the robots.
   // 21. Max elevation reached by a robot
   // 22. Min elevation reached by a robot
+  // 23. Robot configurations and marsupial pairs.
 
   YAML::Emitter out;
   out << YAML::BeginMap;
+
+  out << YAML::Key << "robots";
+  out << YAML::Value << YAML::BeginMap;
+  for (auto const &pair : this->robotFullTypes)
+  {
+    out << YAML::Key << pair.first;
+    out << YAML::Value << YAML::BeginMap;
+    out << YAML::Key << "platform" << YAML::Value << pair.second.first;
+    out << YAML::Key << "config" << YAML::Value << pair.second.second;
+    out << YAML::EndMap;
+  }
+  out << YAML::EndMap;
 
   out << YAML::Key << "marsupials";
   out << YAML::Value << YAML::BeginMap;


### PR DESCRIPTION
Tested using:

```
ign launch cloudsim_sim.ign worldName:=simple_cave_01 circuit:=cave robotName1:=MY_X1 robotConfig1:=X1_SENSOR_CONFIG_1 robotName2:=TEST_X2 robotConfig2:=X2_SENSOR_CONFIG_3 robotName3:=X3_CHILD robotConfig3:=X3_SENSOR_CONFIG_1 marsupial1:=MY_X1:X3_CHILD
```

which produces the following in `run.yml`:

```
robots:
  MY_X1:
    platform: X1
    config: X1 CONFIG 1
  TEST_X2:
    platform: X2
    config: X2 CONFIG 3
  X3_CHILD:
    platform: X3
    config: X3 UAV CONFIG 1
marsupials:
  MY_X1: X3_CHILD
```

Signed-off-by: Nate Koenig <nate@openrobotics.org>