### PR TITLE
Fix marsupial link on the Explorer R2

### DIFF
--- a/subt_ign/launch/cave_circuit.ign
+++ b/subt_ign/launch/cave_circuit.ign
@@ -105,6 +105,13 @@
     end
   end
 
+  MARSUPIAL_PARENT_LINK_NAMES = {
+     "X1" => "base_link",
+     "EXPLORER_X1" => "base_link",
+     "EXPLORER_R2" => "Rear_Rocker_Link",
+     "CSIRO_DATA61_OZBOT_ATR" => "base_link"
+   }
+
   MARSUPIAL_VALID_ROBOT_PAIRS = {
     "X1" => ["X3", "MARBLE_QAV500", "CERBERUS_GAGARIN"],
     "EXPLORER_X1" =>["X3", "MARBLE_QAV500", "CERBERUS_GAGARIN"],
@@ -115,7 +122,7 @@
   MARSUPIAL_PARENT_ROBOT_POSITION_OFFSETS = {
     "X1" => Vector3d.new(0, 0, 0.717),
     "EXPLORER_X1" => Vector3d.new(0, 0, 0.717),
-    "EXPLORER_R2" => Vector3d.new(-0.45, 0, 0.662),
+    "EXPLORER_R2" => Vector3d.new(-0.402375, 0, 0.6874),
     "CSIRO_DATA61_OZBOT_ATR" => Vector3d.new(-0.15, 0, 0.528)
   }
 
@@ -1459,9 +1466,10 @@
 
     if marsupialParents.has_key?(name)
       childModelName = marsupialParents[name]
-       detachableJointPlugin = REXML::Document.new <<-HEREDOC
+      parentModelName = marsupialChildren[childModelName]
+      detachableJointPlugin = REXML::Document.new <<-HEREDOC
          <plugin filename="libignition-gazebo-detachable-joint-system.so" name="ignition::gazebo::systems::DetachableJoint">
-         <parent_link>base_link</parent_link>
+           <parent_link>#{MARSUPIAL_PARENT_LINK_NAMES[robots[parentModelName].type]}</parent_link>
          <child_model>#{childModelName}</child_model>
          <child_link>base_link</child_link>
          <topic>/model/#{childModelName}/detach</topic>

--- a/subt_ign/launch/cloudsim_sim.ign
+++ b/subt_ign/launch/cloudsim_sim.ign
@@ -112,6 +112,13 @@
     end
   end
 
+  MARSUPIAL_PARENT_LINK_NAMES = {
+     "X1" => "base_link",
+     "EXPLORER_X1" => "base_link",
+     "EXPLORER_R2" => "Rear_Rocker_Link",
+     "CSIRO_DATA61_OZBOT_ATR" => "base_link"
+   }
+
   MARSUPIAL_VALID_ROBOT_PAIRS = {
     "X1" => ["X3", "MARBLE_QAV500", "CERBERUS_GAGARIN"],
     "EXPLORER_X1" =>["X3", "MARBLE_QAV500", "CERBERUS_GAGARIN"],
@@ -122,7 +129,7 @@
   MARSUPIAL_PARENT_ROBOT_POSITION_OFFSETS = {
     "X1" => Vector3d.new(0, 0, 0.717),
     "EXPLORER_X1" => Vector3d.new(0, 0, 0.717),
-    "EXPLORER_R2" => Vector3d.new(-0.45, 0, 0.662),
+    "EXPLORER_R2" => Vector3d.new(-0.402375, 0, 0.6874),
     "CSIRO_DATA61_OZBOT_ATR" => Vector3d.new(-0.15, 0, 0.528)
   }
 
@@ -1500,9 +1507,10 @@
 
     if marsupialParents.has_key?(name)
       childModelName = marsupialParents[name]
-       detachableJointPlugin = REXML::Document.new <<-HEREDOC
+      parentModelName = marsupialChildren[childModelName]
+      detachableJointPlugin = REXML::Document.new <<-HEREDOC
          <plugin filename="libignition-gazebo-detachable-joint-system.so" name="ignition::gazebo::systems::DetachableJoint">
-         <parent_link>base_link</parent_link>
+           <parent_link>#{MARSUPIAL_PARENT_LINK_NAMES[robots[parentModelName].type]}</parent_link>
          <child_model>#{childModelName}</child_model>
          <child_link>base_link</child_link>
          <topic>/model/#{childModelName}/detach</topic>

--- a/subt_ign/launch/competition.ign
+++ b/subt_ign/launch/competition.ign
@@ -102,6 +102,13 @@
     end
   end
 
+  MARSUPIAL_PARENT_LINK_NAMES = {
+     "X1" => "base_link",
+     "EXPLORER_X1" => "base_link",
+     "EXPLORER_R2" => "Rear_Rocker_Link",
+     "CSIRO_DATA61_OZBOT_ATR" => "base_link"
+   }
+
   MARSUPIAL_VALID_ROBOT_PAIRS = {
     "X1" => ["X3", "MARBLE_QAV500", "CERBERUS_GAGARIN"],
     "EXPLORER_X1" =>["X3", "MARBLE_QAV500", "CERBERUS_GAGARIN"],
@@ -112,7 +119,7 @@
   MARSUPIAL_PARENT_ROBOT_POSITION_OFFSETS = {
     "X1" => Vector3d.new(0, 0, 0.717),
     "EXPLORER_X1" => Vector3d.new(0, 0, 0.717),
-    "EXPLORER_R2" => Vector3d.new(-0.45, 0, 0.662),
+    "EXPLORER_R2" => Vector3d.new(-0.402375, 0, 0.6874),
     "CSIRO_DATA61_OZBOT_ATR" => Vector3d.new(-0.15, 0, 0.528)
   }
 
@@ -1456,9 +1463,10 @@
 
     if marsupialParents.has_key?(name)
       childModelName = marsupialParents[name]
-       detachableJointPlugin = REXML::Document.new <<-HEREDOC
+      parentModelName = marsupialChildren[childModelName]
+      detachableJointPlugin = REXML::Document.new <<-HEREDOC
          <plugin filename="libignition-gazebo-detachable-joint-system.so" name="ignition::gazebo::systems::DetachableJoint">
-         <parent_link>base_link</parent_link>
+           <parent_link>#{MARSUPIAL_PARENT_LINK_NAMES[robots[parentModelName].type]}</parent_link>
          <child_model>#{childModelName}</child_model>
          <child_link>base_link</child_link>
          <topic>/model/#{childModelName}/detach</topic>

--- a/subt_ign/launch/tunnel_circuit_practice.ign
+++ b/subt_ign/launch/tunnel_circuit_practice.ign
@@ -105,6 +105,13 @@
     end
   end
 
+  MARSUPIAL_PARENT_LINK_NAMES = {
+     "X1" => "base_link",
+     "EXPLORER_X1" => "base_link",
+     "EXPLORER_R2" => "Rear_Rocker_Link",
+     "CSIRO_DATA61_OZBOT_ATR" => "base_link"
+   }
+
   MARSUPIAL_VALID_ROBOT_PAIRS = {
     "X1" => ["X3", "MARBLE_QAV500", "CERBERUS_GAGARIN"],
     "EXPLORER_X1" =>["X3", "MARBLE_QAV500", "CERBERUS_GAGARIN"],
@@ -115,7 +122,7 @@
   MARSUPIAL_PARENT_ROBOT_POSITION_OFFSETS = {
     "X1" => Vector3d.new(0, 0, 0.717),
     "EXPLORER_X1" => Vector3d.new(0, 0, 0.717),
-    "EXPLORER_R2" => Vector3d.new(-0.45, 0, 0.662),
+    "EXPLORER_R2" => Vector3d.new(-0.402375, 0, 0.6874),
     "CSIRO_DATA61_OZBOT_ATR" => Vector3d.new(-0.15, 0, 0.528)
   }
 
@@ -1459,9 +1466,10 @@
 
     if marsupialParents.has_key?(name)
       childModelName = marsupialParents[name]
-       detachableJointPlugin = REXML::Document.new <<-HEREDOC
+      parentModelName = marsupialChildren[childModelName]
+      detachableJointPlugin = REXML::Document.new <<-HEREDOC
          <plugin filename="libignition-gazebo-detachable-joint-system.so" name="ignition::gazebo::systems::DetachableJoint">
-         <parent_link>base_link</parent_link>
+           <parent_link>#{MARSUPIAL_PARENT_LINK_NAMES[robots[parentModelName].type]}</parent_link>
          <child_model>#{childModelName}</child_model>
          <child_link>base_link</child_link>
          <topic>/model/#{childModelName}/detach</topic>

--- a/subt_ign/launch/urban_circuit.ign
+++ b/subt_ign/launch/urban_circuit.ign
@@ -105,6 +105,13 @@
     end
   end
 
+  MARSUPIAL_PARENT_LINK_NAMES = {
+     "X1" => "base_link",
+     "EXPLORER_X1" => "base_link",
+     "EXPLORER_R2" => "Rear_Rocker_Link",
+     "CSIRO_DATA61_OZBOT_ATR" => "base_link"
+   }
+
   MARSUPIAL_VALID_ROBOT_PAIRS = {
     "X1" => ["X3", "MARBLE_QAV500", "CERBERUS_GAGARIN"],
     "EXPLORER_X1" =>["X3", "MARBLE_QAV500", "CERBERUS_GAGARIN"],
@@ -115,7 +122,7 @@
   MARSUPIAL_PARENT_ROBOT_POSITION_OFFSETS = {
     "X1" => Vector3d.new(0, 0, 0.717),
     "EXPLORER_X1" => Vector3d.new(0, 0, 0.717),
-    "EXPLORER_R2" => Vector3d.new(-0.45, 0, 0.662),
+    "EXPLORER_R2" => Vector3d.new(-0.402375, 0, 0.6874),
     "CSIRO_DATA61_OZBOT_ATR" => Vector3d.new(-0.15, 0, 0.528)
   }
 
@@ -1459,9 +1466,10 @@
 
     if marsupialParents.has_key?(name)
       childModelName = marsupialParents[name]
-       detachableJointPlugin = REXML::Document.new <<-HEREDOC
+      parentModelName = marsupialChildren[childModelName]
+      detachableJointPlugin = REXML::Document.new <<-HEREDOC
          <plugin filename="libignition-gazebo-detachable-joint-system.so" name="ignition::gazebo::systems::DetachableJoint">
-         <parent_link>base_link</parent_link>
+           <parent_link>#{MARSUPIAL_PARENT_LINK_NAMES[robots[parentModelName].type]}</parent_link>
          <child_model>#{childModelName}</child_model>
          <child_link>base_link</child_link>
          <topic>/model/#{childModelName}/detach</topic>


### PR DESCRIPTION
This fixes the `parent_link` for the EXPLORER_R2 model. Child models should be attached to the "Rear_Rocker_Link" in order to prevent the child model from rotating when the `base_link` rotates. See image below.

![new_link](https://user-images.githubusercontent.com/1587438/91087887-0669a300-e606-11ea-8a08-888d55e4d8d0.png)

Signed-off-by: Nate Koenig <nate@openrobotics.org>