### PR TITLE
Max breadcrumb log

### DIFF
--- a/subt_ign/src/GameLogicPlugin.cc
+++ b/subt_ign/src/GameLogicPlugin.cc
@@ -676,7 +676,7 @@ void GameLogicPluginPrivate::OnRockFallDeployRemainingEvent(
           << "- event:\n"
           << "  type: max_rock_falls\n"
           << "  time_sec: " << this->simTime.sec() << "\n"
-          << "  robot: " << name << std::endl;
+          << "  model: " << name << std::endl;
 
         this->LogEvent(stream.str());
       }

--- a/subt_ign/src/GameLogicPlugin.cc
+++ b/subt_ign/src/GameLogicPlugin.cc
@@ -625,7 +625,7 @@ void GameLogicPluginPrivate::OnBreadcrumbDeployEvent(
   std::string name = "_unknown_";
 
   // Get the name of the model from the topic name, where the topic name
-  // look like '/model/{model_name}/detach'.
+  // look like '/model/{model_name}/deploy'.
   if (topicParts.size() > 1)
     name = topicParts[1];
 

--- a/subt_ign/src/GameLogicPlugin.cc
+++ b/subt_ign/src/GameLogicPlugin.cc
@@ -189,6 +189,13 @@ class subt::GameLogicPluginPrivate
   public: void OnBreadcrumbDeployEvent(const ignition::msgs::Empty &_msg,
     const transport::MessageInfo &_info);
 
+  /// \brief Rock fall remaining subscription callback.
+  /// \param[in] _msg Remaining count.
+  /// \param[in] _info Message information.
+  public: void OnRockFallDeployRemainingEvent(
+    const ignition::msgs::Int32 &_msg,
+    const transport::MessageInfo &_info);
+
   /// \brief Battery subscription callback.
   /// \param[in] _msg Battery message.
   /// \param[in] _info Message information.
@@ -448,6 +455,11 @@ class subt::GameLogicPluginPrivate
 
   /// \brief Models with dead batteries.
   public: std::set<std::string> deadBatteries;
+
+  /// \brief Map of model name to {sim_time_sec, deployments_over_max}. This
+  /// map is ued to log when no more rock falls are possible for a rock
+  /// fall model.
+  public: std::map<std::string, std::pair<int, int>> rockFallsMax;
 };
 
 //////////////////////////////////////////////////
@@ -637,6 +649,42 @@ void GameLogicPluginPrivate::OnBreadcrumbDeployEvent(
     << "  robot: " << name << std::endl;
 
   this->LogEvent(stream.str());
+}
+
+//////////////////////////////////////////////////
+void GameLogicPluginPrivate::OnRockFallDeployRemainingEvent(
+    const ignition::msgs::Int32 &_msg,
+    const transport::MessageInfo &_info)
+{
+  if (_msg.data() == 0) {
+    std::vector<std::string> topicParts = common::split(_info.Topic(), "/");
+    std::string name = "_unknown_";
+
+    // Get the name of the model from the topic name, where the topic name
+    // look like '/model/{model_name}/deploy'.
+    if (topicParts.size() > 1)
+      name = topicParts[1];
+
+    // Sim time is used to make sure that we report only once per rock fall,
+    // and not once for every rock in the rock fall.
+    if (this->rockFallsMax[name].first != this->simTime.sec())
+    {
+      if (this->rockFallsMax[name].second > 0)
+      {
+        std::ostringstream stream;
+        stream
+          << "- event:\n"
+          << "  type: max_rock_falls\n"
+          << "  time_sec: " << this->simTime.sec() << "\n"
+          << "  robot: " << name << std::endl;
+
+        this->LogEvent(stream.str());
+      }
+
+      this->rockFallsMax[name].second++;
+      this->rockFallsMax[name].first = this->simTime.sec();
+    }
+  }
 }
 
 //////////////////////////////////////////////////
@@ -843,6 +891,20 @@ void GameLogicPlugin::PostUpdate(
           const gazebo::components::Pose *_poseComp,
           const gazebo::components::Static *) -> bool
       {
+        // Subscribe to remaining rock fall deploy topics. We are doing a
+        // blanket subscribe even though a model in this function may not be
+        // a rock fall.
+        if (this->dataPtr->rockFallsMax.find(_nameComp->Data()) ==
+            this->dataPtr->rockFallsMax.end())
+        {
+          std::string deployRemainingTopic = std::string("/model/") +
+                  _nameComp->Data() + "/breadcrumbs/Rock/deploy/remaining";
+          this->dataPtr->rockFallsMax[_nameComp->Data()] = {0, 0};
+          this->dataPtr->node.Subscribe(deployRemainingTopic,
+              &GameLogicPluginPrivate::OnRockFallDeployRemainingEvent,
+              this->dataPtr.get());
+        }
+
         this->dataPtr->poses[_nameComp->Data()] = _poseComp->Data();
         for (std::pair<const subt::ArtifactType,
             std::map<std::string, ignition::math::Pose3d>> &artifactPair :


### PR DESCRIPTION
This adds an event to the `events.yml` file when a rock fall has reached its maximum deployment.

Requires: https://github.com/ignitionrobotics/ign-gazebo/pull/308

## To Test:

1. `ign launch cloudsim_sim.ign worldName:=cave_circuit_practice_01 circuit:=cave robotName1:=X1 robotConfig1:=X1_SENSOR_CONFIG_1`

2. `tail -f /tmp/ign/logs/events.yml`

3. Move the robot to a rock fall:

```
ign service -s /world/cave_circuit_practice_01/set_pose /set_pose --reqtype ignition.msgs.Pose --reptype ignition.msgs.Boolean --timeout 300 --req 'name: "X1", position { x: 282 y:-105.3  z: -24.44}'
```

4. Move the robot out of the rock fall detector:

```
ign service -s /world/cave_circuit_practice_01/set_pose /set_pose --reqtype ignition.msgs.Pose --reptype ignition.msgs.Boolean --timeout 300 --req 'name: "X1", position { x: 0 y:0  z: 0}'
```

5. Repeat steps 3 & 4 five more times, and you should see:

```
- event:
  type: max_rock_falls
  time_sec: 37
  model: medium_rock_fall_1
```