### PR TITLE
Add ROS keys to subt_shell/Dockerfile before installing ROS

### DIFF
--- a/docker/subt_shell/Dockerfile
+++ b/docker/subt_shell/Dockerfile
@@ -61,6 +61,7 @@ RUN export DEBIAN_FRONTEND=noninteractive \
 
 # install ROS and required packages
 RUN sudo /bin/sh -c 'echo "deb [trusted=yes] http://packages.ros.org/ros/ubuntu $(lsb_release -sc) main" > /etc/apt/sources.list.d/ros-latest.list' \
+ && sudo /bin/sh -c 'apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-key C1CF6E31E6BADE8868B172B4F42ED6FBAB17C654' \
  && sudo apt-get update -qq \
  && sudo apt-get install -y -qq \
     python-catkin-tools \


### PR DESCRIPTION
As the title suggests, I added the ROS keys to `docker/subt_shell/Dockerfile` before installing `ros-melodic` and accompanying ROS packages (this is [already done](https://github.com/osrf/subt/blob/7cdf922b8ba06eb52b7b9468adf9a077bdbf50ce/docker/subt_shell/Dockerfile#L89) when installing `ignition-blueprint`). I found that without this line, you are given the following error message, which sometimes results in the build of this Docker image failing:

`W: GPG error: http://packages.ros.org/ros/ubuntu bionic InRelease: The following signatures couldn't be verified because the public key is not available: NO_PUBKEY F42ED6FBAB17C654`

Signed-off-by: Ashton Larkin <ashton@openrobotics.org>