### PR TITLE
Corrected path for Freyja model.xacro file wheel.dae reference.

### DIFF
--- a/submitted_models/robotika_freyja_sensor_config_1/urdf/model.xacro
+++ b/submitted_models/robotika_freyja_sensor_config_1/urdf/model.xacro
@@ -406,7 +406,7 @@
     <visual name='front_left_wheel_tire_visual'>
       <origin xyz='0 0 0' rpy='1.5708 -0 0'/>
       <geometry>
-        <mesh filename='meshes/wheel_left.dae' scale='1.30102 1.30102 2.05'/>
+        <mesh filename='package://robotika_freyja_sensor_config_1/meshes/wheel_left.dae' scale='1.30102 1.30102 2.05'/>
       </geometry>
     </visual>
     <visual name='front_left_wheel_hub_visual'>
@@ -431,7 +431,7 @@
     <visual name='front_right_wheel_tire_visual'>
       <origin xyz='0 0 0' rpy='1.5708 -0 0'/>
       <geometry>
-        <mesh filename='meshes/wheel_right.dae' scale='1.30102 1.30102 2.05'/>
+        <mesh filename='package://robotika_freyja_sensor_config_1/meshes/wheel_right.dae' scale='1.30102 1.30102 2.05'/>
       </geometry>
     </visual>
     <visual name='front_right_wheel_hub_visual'>
@@ -456,7 +456,7 @@
     <visual name='rear_left_wheel_tire_visual'>
       <origin xyz='0 0 0' rpy='1.5708 -0 0'/>
       <geometry>
-        <mesh filename='meshes/wheel_left.dae' scale='1.30102 1.30102 2.05'/>
+        <mesh filename='package://robotika_freyja_sensor_config_1/meshes/wheel_left.dae' scale='1.30102 1.30102 2.05'/>
       </geometry>
     </visual>
     <visual name='rear_left_wheel_hub_visual'>
@@ -481,7 +481,7 @@
     <visual name='rear_right_wheel_tire_visual'>
       <origin xyz='0 0 0' rpy='1.5708 -0 0'/>
       <geometry>
-        <mesh filename='meshes/wheel_right.dae' scale='1.30102 1.30102 2.05'/>
+        <mesh filename='package://robotika_freyja_sensor_config_1/meshes/wheel_right.dae' scale='1.30102 1.30102 2.05'/>
       </geometry>
     </visual>
     <visual name='rear_right_wheel_hub_visual'>


### PR DESCRIPTION
**Current issue with wheels in RViz:**
![freya_urdf_issue](https://user-images.githubusercontent.com/61025344/91227231-28415380-e6f4-11ea-9a4b-29bf32019348.png)

**Fixed reference path to wheel.dae files:**
![freyja_fixed_model_xacro](https://user-images.githubusercontent.com/61025344/91226199-b0265e00-e6f2-11ea-9dcd-9b3506196985.png)
