### PR TITLE
Distribute niosh docker layers

### DIFF
--- a/docker/cloudsim_sim/Dockerfile
+++ b/docker/cloudsim_sim/Dockerfile
@@ -111,7 +111,19 @@ RUN mkdir -p subt_ws/src \
  && git clone https://github.com/osrf/subt
 
 # Download the public models
-RUN ign fuel download -v 4 -j 16 -u "https://fuel.ignitionrobotics.org/OpenRobotics/collections/SubT Tech Repo"
+RUN ign fuel download -v 4 -j 8 -u "https://fuel.ignitionrobotics.org/OpenRobotics/collections/SubT Tech Repo"
+
+# Download niosh models, set 1.
+COPY download_niosh_1.sh ./
+RUN ./download_niosh_1.sh
+
+# Download niosh models, set 2.
+COPY download_niosh_2.sh ./
+RUN ./download_niosh_2.sh
+
+# Download niosh models, set 3.
+COPY download_niosh_3.sh ./
+RUN ./download_niosh_3.sh
 
 WORKDIR /home/$USERNAME/subt_ws
 

--- a/docker/download_niosh_1.sh
+++ b/docker/download_niosh_1.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+
+# Download niosh models
+ign fuel download --url "https://fuel.ignitionrobotics.org/OpenRobotics/models/NIOSH Staging Area" -v 4
+ign fuel download --url "https://fuel.ignitionrobotics.org/OpenRobotics/models/NIOSH Segment 01 Section 01" -v 4
+ign fuel download --url "https://fuel.ignitionrobotics.org/OpenRobotics/models/NIOSH Segment 01 Section 02" -v 4
+ign fuel download --url "https://fuel.ignitionrobotics.org/OpenRobotics/models/NIOSH Segment 01 Section 03" -v 4
+ign fuel download --url "https://fuel.ignitionrobotics.org/OpenRobotics/models/NIOSH Segment 01 Section 04" -v 4
+ign fuel download --url "https://fuel.ignitionrobotics.org/OpenRobotics/models/NIOSH Segment 01 Section 05" -v 4

--- a/docker/download_niosh_1.sh
+++ b/docker/download_niosh_1.sh
@@ -2,8 +2,8 @@
 
 # Download niosh models
 ign fuel download --url "https://fuel.ignitionrobotics.org/OpenRobotics/models/NIOSH Staging Area" -v 4
-ign fuel download --url "https://fuel.ignitionrobotics.org/OpenRobotics/models/NIOSH Segment 01 Section 01" -v 4
-ign fuel download --url "https://fuel.ignitionrobotics.org/OpenRobotics/models/NIOSH Segment 01 Section 02" -v 4
-ign fuel download --url "https://fuel.ignitionrobotics.org/OpenRobotics/models/NIOSH Segment 01 Section 03" -v 4
-ign fuel download --url "https://fuel.ignitionrobotics.org/OpenRobotics/models/NIOSH Segment 01 Section 04" -v 4
-ign fuel download --url "https://fuel.ignitionrobotics.org/OpenRobotics/models/NIOSH Segment 01 Section 05" -v 4
+ign fuel download --url "https://fuel.ignitionrobotics.org/OpenRobotics/models/NIOSH SR Course Section 01" -v 4
+ign fuel download --url "https://fuel.ignitionrobotics.org/OpenRobotics/models/NIOSH SR Course Section 02" -v 4
+ign fuel download --url "https://fuel.ignitionrobotics.org/OpenRobotics/models/NIOSH SR Course Section 03" -v 4
+ign fuel download --url "https://fuel.ignitionrobotics.org/OpenRobotics/models/NIOSH SR Course Section 04" -v 4
+ign fuel download --url "https://fuel.ignitionrobotics.org/OpenRobotics/models/NIOSH SR Course Section 05" -v 4

--- a/docker/download_niosh_2.sh
+++ b/docker/download_niosh_2.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+
+# Download niosh models
+ign fuel download --url "https://fuel.ignitionrobotics.org/OpenRobotics/models/NIOSH Segment 01 Section 06" -v 4
+ign fuel download --url "https://fuel.ignitionrobotics.org/OpenRobotics/models/NIOSH Segment 01 Section 07" -v 4
+ign fuel download --url "https://fuel.ignitionrobotics.org/OpenRobotics/models/NIOSH Segment 01 Section 08" -v 4
+ign fuel download --url "https://fuel.ignitionrobotics.org/OpenRobotics/models/NIOSH Segment 01 Section 09" -v 4
+ign fuel download --url "https://fuel.ignitionrobotics.org/OpenRobotics/models/NIOSH Segment 01 Section 10" -v 4
+ign fuel download --url "https://fuel.ignitionrobotics.org/OpenRobotics/models/NIOSH Segment 01 Section 11" -v 4

--- a/docker/download_niosh_2.sh
+++ b/docker/download_niosh_2.sh
@@ -1,9 +1,9 @@
 #!/usr/bin/env bash
 
 # Download niosh models
-ign fuel download --url "https://fuel.ignitionrobotics.org/OpenRobotics/models/NIOSH Segment 01 Section 06" -v 4
-ign fuel download --url "https://fuel.ignitionrobotics.org/OpenRobotics/models/NIOSH Segment 01 Section 07" -v 4
-ign fuel download --url "https://fuel.ignitionrobotics.org/OpenRobotics/models/NIOSH Segment 01 Section 08" -v 4
-ign fuel download --url "https://fuel.ignitionrobotics.org/OpenRobotics/models/NIOSH Segment 01 Section 09" -v 4
-ign fuel download --url "https://fuel.ignitionrobotics.org/OpenRobotics/models/NIOSH Segment 01 Section 10" -v 4
-ign fuel download --url "https://fuel.ignitionrobotics.org/OpenRobotics/models/NIOSH Segment 01 Section 11" -v 4
+ign fuel download --url "https://fuel.ignitionrobotics.org/OpenRobotics/models/NIOSH SR Course Section 06" -v 4
+ign fuel download --url "https://fuel.ignitionrobotics.org/OpenRobotics/models/NIOSH SR Course Section 07" -v 4
+ign fuel download --url "https://fuel.ignitionrobotics.org/OpenRobotics/models/NIOSH SR Course Section 08" -v 4
+ign fuel download --url "https://fuel.ignitionrobotics.org/OpenRobotics/models/NIOSH SR Course Section 09" -v 4
+ign fuel download --url "https://fuel.ignitionrobotics.org/OpenRobotics/models/NIOSH SR Course Section 10" -v 4
+ign fuel download --url "https://fuel.ignitionrobotics.org/OpenRobotics/models/NIOSH SR Course Section 11" -v 4

--- a/docker/download_niosh_3.sh
+++ b/docker/download_niosh_3.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+
+# Download niosh models
+ign fuel download --url "https://fuel.ignitionrobotics.org/OpenRobotics/models/NIOSH Segment 02 Section 01" -v 4
+ign fuel download --url "https://fuel.ignitionrobotics.org/OpenRobotics/models/NIOSH Segment 02 Section 02" -v 4
+ign fuel download --url "https://fuel.ignitionrobotics.org/OpenRobotics/models/NIOSH Segment 02 Section 03" -v 4
+ign fuel download --url "https://fuel.ignitionrobotics.org/OpenRobotics/models/NIOSH Segment 02 Section 04" -v 4
+ign fuel download --url "https://fuel.ignitionrobotics.org/OpenRobotics/models/NIOSH Segment 02 Section 05" -v 4
+ign fuel download --url "https://fuel.ignitionrobotics.org/OpenRobotics/models/NIOSH Segment 02 Section 06" -v 4

--- a/docker/download_niosh_3.sh
+++ b/docker/download_niosh_3.sh
@@ -1,9 +1,9 @@
 #!/usr/bin/env bash
 
 # Download niosh models
-ign fuel download --url "https://fuel.ignitionrobotics.org/OpenRobotics/models/NIOSH Segment 02 Section 01" -v 4
-ign fuel download --url "https://fuel.ignitionrobotics.org/OpenRobotics/models/NIOSH Segment 02 Section 02" -v 4
-ign fuel download --url "https://fuel.ignitionrobotics.org/OpenRobotics/models/NIOSH Segment 02 Section 03" -v 4
-ign fuel download --url "https://fuel.ignitionrobotics.org/OpenRobotics/models/NIOSH Segment 02 Section 04" -v 4
-ign fuel download --url "https://fuel.ignitionrobotics.org/OpenRobotics/models/NIOSH Segment 02 Section 05" -v 4
-ign fuel download --url "https://fuel.ignitionrobotics.org/OpenRobotics/models/NIOSH Segment 02 Section 06" -v 4
+ign fuel download --url "https://fuel.ignitionrobotics.org/OpenRobotics/models/NIOSH EX Course Section 01" -v 4
+ign fuel download --url "https://fuel.ignitionrobotics.org/OpenRobotics/models/NIOSH EX Course Section 02" -v 4
+ign fuel download --url "https://fuel.ignitionrobotics.org/OpenRobotics/models/NIOSH EX Course Section 03" -v 4
+ign fuel download --url "https://fuel.ignitionrobotics.org/OpenRobotics/models/NIOSH EX Course Section 04" -v 4
+ign fuel download --url "https://fuel.ignitionrobotics.org/OpenRobotics/models/NIOSH EX Course Section 05" -v 4
+ign fuel download --url "https://fuel.ignitionrobotics.org/OpenRobotics/models/NIOSH EX Course Section 06" -v 4

--- a/docker/download_niosh_3.sh
+++ b/docker/download_niosh_3.sh
@@ -7,3 +7,5 @@ ign fuel download --url "https://fuel.ignitionrobotics.org/OpenRobotics/models/N
 ign fuel download --url "https://fuel.ignitionrobotics.org/OpenRobotics/models/NIOSH EX Course Section 04" -v 4
 ign fuel download --url "https://fuel.ignitionrobotics.org/OpenRobotics/models/NIOSH EX Course Section 05" -v 4
 ign fuel download --url "https://fuel.ignitionrobotics.org/OpenRobotics/models/NIOSH EX Course Section 06" -v 4
+ign fuel download --url "https://fuel.ignitionrobotics.org/OpenRobotics/models/NIOSH EX Course Shell" -v 4
+ign fuel download --url "https://fuel.ignitionrobotics.org/OpenRobotics/models/NIOSH SR Course Shell" -v 4

--- a/docker/subt_sim_entry/Dockerfile
+++ b/docker/subt_sim_entry/Dockerfile
@@ -107,6 +107,18 @@ RUN mkdir -p subt_ws/src \
 # Download the public models
 RUN ign fuel download -v 4 -j 16 -u "https://fuel.ignitionrobotics.org/OpenRobotics/collections/SubT Tech Repo"
 
+# Download niosh models, set 1.
+COPY download_niosh_1.sh ./
+RUN ./download_niosh_1.sh
+
+# Download niosh models, set 2.
+COPY download_niosh_2.sh ./
+RUN ./download_niosh_2.sh
+
+# Download niosh models, set 3.
+COPY download_niosh_3.sh ./
+RUN ./download_niosh_3.sh
+
 WORKDIR /home/$USERNAME/subt_ws
 
 # Install Rotors

--- a/subt_ign/src/GameLogicPlugin.cc
+++ b/subt_ign/src/GameLogicPlugin.cc
@@ -392,6 +392,9 @@ class subt::GameLogicPluginPrivate
   /// \brief Ignition transport for the remaining artifact reports.
   public: transport::Node::Publisher artifactReportPub;
 
+  /// \brief Ignition transport that publishes robot name and type info.
+  public: transport::Node::Publisher robotPub;
+
   /// \brief Logpath.
   public: std::string logPath{"/dev/null"};
 
@@ -592,6 +595,9 @@ void GameLogicPlugin::Configure(const ignition::gazebo::Entity & /*_entity*/,
 
   this->dataPtr->artifactReportPub =
     this->dataPtr->node.Advertise<ignition::msgs::Int32>("/subt/artifact_reports_remaining");
+
+  this->dataPtr->robotPub =
+    this->dataPtr->node.Advertise<ignition::msgs::Param_V>("/subt/robots");
 
   this->dataPtr->publishThread.reset(new std::thread(
         &GameLogicPluginPrivate::PublishScore, this->dataPtr.get()));
@@ -1224,6 +1230,45 @@ void GameLogicPlugin::PostUpdate(
     limitMsg.set_data(this->dataPtr->reportCountLimit -
         this->dataPtr->reportCount);
     this->dataPtr->artifactReportPub.Publish(limitMsg);
+
+    // Publish robot name and type information.
+    ignition::msgs::Param_V robotMsg;
+    for (const std::pair<std::string,
+         std::pair<std::string, std::string>> &robot :
+         this->dataPtr->robotFullTypes)
+    {
+      ignition::msgs::Param *param = robotMsg.add_param();
+      (*param->mutable_params())["name"].set_type(
+          ignition::msgs::Any::STRING);
+      (*param->mutable_params())["name"].set_string_value(
+          robot.first);
+
+      (*param->mutable_params())["config"].set_type(
+          ignition::msgs::Any::STRING);
+      (*param->mutable_params())["config"].set_string_value(
+          robot.second.second);
+
+      (*param->mutable_params())["platform"].set_type(
+          ignition::msgs::Any::STRING);
+      (*param->mutable_params())["platform"].set_string_value(
+          robot.second.first);
+    }
+
+    // Add in marsupial pairs.
+    for (const std::pair<std::string, std::string> &pair :
+         this->dataPtr->marsupialPairs)
+    {
+      ignition::msgs::Param *param = robotMsg.add_param();
+      (*param->mutable_params())["marsupial_parent"].set_type(
+          ignition::msgs::Any::STRING);
+      (*param->mutable_params())["marsupial_parent"].set_string_value(
+          pair.first);
+      (*param->mutable_params())["marsupial_child"].set_type(
+          ignition::msgs::Any::STRING);
+      (*param->mutable_params())["marsupial_child"].set_string_value(
+          pair.second);
+    }
+    this->dataPtr->robotPub.Publish(robotMsg);
   }
 
   this->dataPtr->CheckRobotFlip();

--- a/subt_ign/worlds/niosh_ex_config_a.dot
+++ b/subt_ign/worlds/niosh_ex_config_a.dot
@@ -4,12 +4,12 @@ graph {
   /* Base station / Staging area */
   0   [label="0::base_station::BaseStation"];
 
-  1   [label="1::NIOSH Segment 02 Section 01::niosh_seg02_sec01"];
-  2   [label="2::NIOSH Segment 02 Section 02::niosh_seg02_sec02"];
-  3   [label="3::NIOSH Segment 02 Section 03::niosh_seg02_sec03"];
-  4   [label="4::NIOSH Segment 02 Section 04::niosh_seg02_sec04"];
-  5   [label="5::NIOSH Segment 02 Section 05::niosh_seg02_sec05"];
-  6   [label="6::NIOSH Segment 02 Section 06::niosh_seg02_sec06"];
+  1   [label="1::NIOSH EX Course Section 01::niosh_seg02_sec01"];
+  2   [label="2::NIOSH EX Course Section 02::niosh_seg02_sec02"];
+  3   [label="3::NIOSH EX Course Section 03::niosh_seg02_sec03"];
+  4   [label="4::NIOSH EX Course Section 04::niosh_seg02_sec04"];
+  5   [label="5::NIOSH EX Course Section 05::niosh_seg02_sec05"];
+  6   [label="6::NIOSH EX Course Section 06::niosh_seg02_sec06"];
 
   /* ==== Edges ==== */
 

--- a/subt_ign/worlds/niosh_ex_config_a.sdf
+++ b/subt_ign/worlds/niosh_ex_config_a.sdf
@@ -155,37 +155,37 @@
     <!-- Tunnel tiles and artifacts -->
     <include>
       <name>sec_01</name>
-      <uri>https://fuel.ignitionrobotics.org/1.0/OpenRobotics/models/NIOSH Segment 02 Section 01</uri>
+      <uri>https://fuel.ignitionrobotics.org/1.0/OpenRobotics/models/NIOSH EX Course Section 01</uri>
       <pose>9.650000 -1.050000 5.000 0 0 -1.57</pose>
     </include>
 
     <include>
       <name>sec_02</name>
-      <uri>https://fuel.ignitionrobotics.org/1.0/OpenRobotics/models/NIOSH Segment 02 Section 02</uri>
+      <uri>https://fuel.ignitionrobotics.org/1.0/OpenRobotics/models/NIOSH EX Course Section 02</uri>
       <pose>9.650000 -1.050000 5.000 0 0 -1.57</pose>
     </include>
 
     <include>
       <name>sec_03</name>
-      <uri>https://fuel.ignitionrobotics.org/1.0/OpenRobotics/models/NIOSH Segment 02 Section 03</uri>
+      <uri>https://fuel.ignitionrobotics.org/1.0/OpenRobotics/models/NIOSH EX Course Section 03</uri>
       <pose>9.650000 -1.050000 5.000 0 0 -1.57</pose>
     </include>
 
     <include>
       <name>sec_04</name>
-      <uri>https://fuel.ignitionrobotics.org/1.0/OpenRobotics/models/NIOSH Segment 02 Section 04</uri>
+      <uri>https://fuel.ignitionrobotics.org/1.0/OpenRobotics/models/NIOSH EX Course Section 04</uri>
       <pose>9.650000 -1.050000 5.000 0 0 -1.57</pose>
     </include>
 
     <include>
       <name>sec_05</name>
-      <uri>https://fuel.ignitionrobotics.org/1.0/OpenRobotics/models/NIOSH Segment 02 Section 05</uri>
+      <uri>https://fuel.ignitionrobotics.org/1.0/OpenRobotics/models/NIOSH EX Course Section 05</uri>
       <pose>9.650000 -1.050000 5.000 0 0 -1.57</pose>
     </include>
 
     <include>
       <name>sec_06</name>
-      <uri>https://fuel.ignitionrobotics.org/1.0/OpenRobotics/models/NIOSH Segment 02 Section 06</uri>
+      <uri>https://fuel.ignitionrobotics.org/1.0/OpenRobotics/models/NIOSH EX Course Section 06</uri>
       <pose>9.650000 -1.050000 5.000 0 0 -1.57</pose>
     </include>
 
@@ -197,7 +197,7 @@
 
     <include>
       <name>shell</name>
-      <uri>https://fuel.ignitionrobotics.org/1.0/OpenRobotics/models/NIOSH Segment 02 Shell</uri>
+      <uri>https://fuel.ignitionrobotics.org/1.0/OpenRobotics/models/NIOSH EX Course Shell</uri>
       <pose>9.650000 -1.050000 5.000 0 0 -1.57</pose>
     </include>
 

--- a/subt_ign/worlds/niosh_ex_config_b.dot
+++ b/subt_ign/worlds/niosh_ex_config_b.dot
@@ -4,12 +4,12 @@ graph {
   /* Base station / Staging area */
   0   [label="0::base_station::BaseStation"];
 
-  1   [label="1::NIOSH Segment 02 Section 01::niosh_seg02_sec01"];
-  2   [label="2::NIOSH Segment 02 Section 02::niosh_seg02_sec02"];
-  3   [label="3::NIOSH Segment 02 Section 03::niosh_seg02_sec03"];
-  4   [label="4::NIOSH Segment 02 Section 04::niosh_seg02_sec04"];
-  5   [label="5::NIOSH Segment 02 Section 05::niosh_seg02_sec05"];
-  6   [label="6::NIOSH Segment 02 Section 06::niosh_seg02_sec06"];
+  1   [label="1::NIOSH EX Course Section 01::niosh_seg02_sec01"];
+  2   [label="2::NIOSH EX Course Section 02::niosh_seg02_sec02"];
+  3   [label="3::NIOSH EX Course Section 03::niosh_seg02_sec03"];
+  4   [label="4::NIOSH EX Course Section 04::niosh_seg02_sec04"];
+  5   [label="5::NIOSH EX Course Section 05::niosh_seg02_sec05"];
+  6   [label="6::NIOSH EX Course Section 06::niosh_seg02_sec06"];
 
   /* ==== Edges ==== */
 

--- a/subt_ign/worlds/niosh_ex_config_b.sdf
+++ b/subt_ign/worlds/niosh_ex_config_b.sdf
@@ -155,37 +155,37 @@
     <!-- Tunnel tiles and artifacts -->
     <include>
       <name>sec_01</name>
-      <uri>https://fuel.ignitionrobotics.org/1.0/OpenRobotics/models/NIOSH Segment 02 Section 01</uri>
+      <uri>https://fuel.ignitionrobotics.org/1.0/OpenRobotics/models/NIOSH EX Course Section 01</uri>
       <pose>9.650000 -1.050000 5.000 0 0 -1.57</pose>
     </include>
 
     <include>
       <name>sec_02</name>
-      <uri>https://fuel.ignitionrobotics.org/1.0/OpenRobotics/models/NIOSH Segment 02 Section 02</uri>
+      <uri>https://fuel.ignitionrobotics.org/1.0/OpenRobotics/models/NIOSH EX Course Section 02</uri>
       <pose>9.650000 -1.050000 5.000 0 0 -1.57</pose>
     </include>
 
     <include>
       <name>sec_03</name>
-      <uri>https://fuel.ignitionrobotics.org/1.0/OpenRobotics/models/NIOSH Segment 02 Section 03</uri>
+      <uri>https://fuel.ignitionrobotics.org/1.0/OpenRobotics/models/NIOSH EX Course Section 03</uri>
       <pose>9.650000 -1.050000 5.000 0 0 -1.57</pose>
     </include>
 
     <include>
       <name>sec_04</name>
-      <uri>https://fuel.ignitionrobotics.org/1.0/OpenRobotics/models/NIOSH Segment 02 Section 04</uri>
+      <uri>https://fuel.ignitionrobotics.org/1.0/OpenRobotics/models/NIOSH EX Course Section 04</uri>
       <pose>9.650000 -1.050000 5.000 0 0 -1.57</pose>
     </include>
 
     <include>
       <name>sec_05</name>
-      <uri>https://fuel.ignitionrobotics.org/1.0/OpenRobotics/models/NIOSH Segment 02 Section 05</uri>
+      <uri>https://fuel.ignitionrobotics.org/1.0/OpenRobotics/models/NIOSH EX Course Section 05</uri>
       <pose>9.650000 -1.050000 5.000 0 0 -1.57</pose>
     </include>
 
     <include>
       <name>sec_06</name>
-      <uri>https://fuel.ignitionrobotics.org/1.0/OpenRobotics/models/NIOSH Segment 02 Section 06</uri>
+      <uri>https://fuel.ignitionrobotics.org/1.0/OpenRobotics/models/NIOSH EX Course Section 06</uri>
       <pose>9.650000 -1.050000 5.000 0 0 -1.57</pose>
     </include>
 
@@ -197,7 +197,7 @@
 
     <include>
       <name>shell</name>
-      <uri>https://fuel.ignitionrobotics.org/1.0/OpenRobotics/models/NIOSH Segment 02 Shell</uri>
+      <uri>https://fuel.ignitionrobotics.org/1.0/OpenRobotics/models/NIOSH EX Course Shell</uri>
       <pose>9.650000 -1.050000 5.000 0 0 -1.57</pose>
     </include>
 

--- a/subt_ign/worlds/niosh_sr_config_a.dot
+++ b/subt_ign/worlds/niosh_sr_config_a.dot
@@ -4,17 +4,17 @@ graph {
   /* Base station / Staging area */
   0   [label="0::base_station::BaseStation"];
 
-  1   [label="1::NIOSH Segment 01 Section 01::sec_01"];
-  2   [label="2::NIOSH Segment 01 Section 02::sec_02"];
-  3   [label="3::NIOSH Segment 01 Section 03::sec_03"];
-  4   [label="4::NIOSH Segment 01 Section 04::sec_04"];
-  5   [label="5::NIOSH Segment 01 Section 05::sec_05"];
-  6   [label="6::NIOSH Segment 01 Section 06::sec_06"];
-  7   [label="7::NIOSH Segment 01 Section 07::sec_07"];
-  8   [label="8::NIOSH Segment 01 Section 08::sec_08"];
-  9   [label="9::NIOSH Segment 01 Section 09::sec_09"];
-  10  [label="10::NIOSH Segment 01 Section 10::sec_10"];
-  11  [label="11::NIOSH Segment 01 Section 11::sec_11"];
+  1   [label="1::NIOSH SR Course Section 01::sec_01"];
+  2   [label="2::NIOSH SR Course Section 02::sec_02"];
+  3   [label="3::NIOSH SR Course Section 03::sec_03"];
+  4   [label="4::NIOSH SR Course Section 04::sec_04"];
+  5   [label="5::NIOSH SR Course Section 05::sec_05"];
+  6   [label="6::NIOSH SR Course Section 06::sec_06"];
+  7   [label="7::NIOSH SR Course Section 07::sec_07"];
+  8   [label="8::NIOSH SR Course Section 08::sec_08"];
+  9   [label="9::NIOSH SR Course Section 09::sec_09"];
+  10  [label="10::NIOSH SR Course Section 10::sec_10"];
+  11  [label="11::NIOSH SR Course Section 11::sec_11"];
 
   /* ==== Edges ==== */
 

--- a/subt_ign/worlds/niosh_sr_config_a.sdf
+++ b/subt_ign/worlds/niosh_sr_config_a.sdf
@@ -156,67 +156,67 @@
     <include>
       <name>sec_01</name>
       <pose>-0.5 18.4 -2.17 0 0 -1.57</pose>
-      <uri>https://fuel.ignitionrobotics.org/1.0/OpenRobotics/models/NIOSH Segment 01 Section 01</uri>
+      <uri>https://fuel.ignitionrobotics.org/1.0/OpenRobotics/models/NIOSH SR Course Section 01</uri>
     </include>
 
     <include>
       <name>sec_02</name>
       <pose>-0.5 18.4 -2.17 0 0 -1.57</pose>
-      <uri>https://fuel.ignitionrobotics.org/1.0/OpenRobotics/models/NIOSH Segment 01 Section 02</uri>
+      <uri>https://fuel.ignitionrobotics.org/1.0/OpenRobotics/models/NIOSH SR Course Section 02</uri>
     </include>
 
     <include>
       <name>sec_03</name>
       <pose>-0.5 18.4 -2.17 0 0 -1.57</pose>
-      <uri>https://fuel.ignitionrobotics.org/1.0/OpenRobotics/models/NIOSH Segment 01 Section 03</uri>
+      <uri>https://fuel.ignitionrobotics.org/1.0/OpenRobotics/models/NIOSH SR Course Section 03</uri>
     </include>
 
     <include>
       <name>sec_04</name>
       <pose>-0.5 18.4 -2.17 0 0 -1.57</pose>
-      <uri>https://fuel.ignitionrobotics.org/1.0/OpenRobotics/models/NIOSH Segment 01 Section 04</uri>
+      <uri>https://fuel.ignitionrobotics.org/1.0/OpenRobotics/models/NIOSH SR Course Section 04</uri>
     </include>
 
     <include>
       <name>sec_05</name>
       <pose>-0.5 18.4 -2.17 0 0 -1.57</pose>
-      <uri>https://fuel.ignitionrobotics.org/1.0/OpenRobotics/models/NIOSH Segment 01 Section 05</uri>
+      <uri>https://fuel.ignitionrobotics.org/1.0/OpenRobotics/models/NIOSH SR Course Section 05</uri>
     </include>
 
     <include>
       <name>sec_06</name>
       <pose>-0.5 18.4 -2.17 0 0 -1.57</pose>
-      <uri>https://fuel.ignitionrobotics.org/1.0/OpenRobotics/models/NIOSH Segment 01 Section 06</uri>
+      <uri>https://fuel.ignitionrobotics.org/1.0/OpenRobotics/models/NIOSH SR Course Section 06</uri>
     </include>
 
     <include>
       <name>sec_07</name>
       <pose>-0.5 18.4 -2.17 0 0 -1.57</pose>
-      <uri>https://fuel.ignitionrobotics.org/1.0/OpenRobotics/models/NIOSH Segment 01 Section 07</uri>
+      <uri>https://fuel.ignitionrobotics.org/1.0/OpenRobotics/models/NIOSH SR Course Section 07</uri>
     </include>
 
     <include>
       <name>sec_08</name>
       <pose>-0.5 18.4 -2.17 0 0 -1.57</pose>
-      <uri>https://fuel.ignitionrobotics.org/1.0/OpenRobotics/models/NIOSH Segment 01 Section 08</uri>
+      <uri>https://fuel.ignitionrobotics.org/1.0/OpenRobotics/models/NIOSH SR Course Section 08</uri>
     </include>
 
     <include>
       <name>sec_09</name>
       <pose>-0.5 18.4 -2.17 0 0 -1.57</pose>
-      <uri>https://fuel.ignitionrobotics.org/1.0/OpenRobotics/models/NIOSH Segment 01 Section 09</uri>
+      <uri>https://fuel.ignitionrobotics.org/1.0/OpenRobotics/models/NIOSH SR Course Section 09</uri>
     </include>
 
     <include>
       <name>sec_10</name>
       <pose>-0.5 18.4 -2.17 0 0 -1.57</pose>
-      <uri>https://fuel.ignitionrobotics.org/1.0/OpenRobotics/models/NIOSH Segment 01 Section 10</uri>
+      <uri>https://fuel.ignitionrobotics.org/1.0/OpenRobotics/models/NIOSH SR Course Section 10</uri>
     </include>
 
     <include>
       <name>sec_11</name>
       <pose>-0.5 18.4 -2.17 0 0 -1.57</pose>
-      <uri>https://fuel.ignitionrobotics.org/1.0/OpenRobotics/models/NIOSH Segment 01 Section 11</uri>
+      <uri>https://fuel.ignitionrobotics.org/1.0/OpenRobotics/models/NIOSH SR Course Section 11</uri>
     </include>
 
     <include>
@@ -228,7 +228,7 @@
     <include>
       <name>shell</name>
       <pose>-0.5 18.4 -2.17 0 0 -1.57</pose>
-      <uri>https://fuel.ignitionrobotics.org/1.0/OpenRobotics/models/NIOSH Segment 01 Shell</uri>
+      <uri>https://fuel.ignitionrobotics.org/1.0/OpenRobotics/models/NIOSH SR Course Shell</uri>
     </include>
 
     <include>

--- a/subt_ign/worlds/niosh_sr_config_b.dot
+++ b/subt_ign/worlds/niosh_sr_config_b.dot
@@ -4,17 +4,17 @@ graph {
   /* Base station / Staging area */
   0   [label="0::base_station::BaseStation"];
 
-  1   [label="1::NIOSH Segment 01 Section 01::sec_01"];
-  2   [label="2::NIOSH Segment 01 Section 02::sec_02"];
-  3   [label="3::NIOSH Segment 01 Section 03::sec_03"];
-  4   [label="4::NIOSH Segment 01 Section 04::sec_04"];
-  5   [label="5::NIOSH Segment 01 Section 05::sec_05"];
-  6   [label="6::NIOSH Segment 01 Section 06::sec_06"];
-  7   [label="7::NIOSH Segment 01 Section 07::sec_07"];
-  8   [label="8::NIOSH Segment 01 Section 08::sec_08"];
-  9   [label="9::NIOSH Segment 01 Section 09::sec_09"];
-  10  [label="10::NIOSH Segment 01 Section 10::sec_10"];
-  11  [label="11::NIOSH Segment 01 Section 11::sec_11"];
+  1   [label="1::NIOSH SR Course Section 01::sec_01"];
+  2   [label="2::NIOSH SR Course Section 02::sec_02"];
+  3   [label="3::NIOSH SR Course Section 03::sec_03"];
+  4   [label="4::NIOSH SR Course Section 04::sec_04"];
+  5   [label="5::NIOSH SR Course Section 05::sec_05"];
+  6   [label="6::NIOSH SR Course Section 06::sec_06"];
+  7   [label="7::NIOSH SR Course Section 07::sec_07"];
+  8   [label="8::NIOSH SR Course Section 08::sec_08"];
+  9   [label="9::NIOSH SR Course Section 09::sec_09"];
+  10  [label="10::NIOSH SR Course Section 10::sec_10"];
+  11  [label="11::NIOSH SR Course Section 11::sec_11"];
 
   /* ==== Edges ==== */
 

--- a/subt_ign/worlds/niosh_sr_config_b.sdf
+++ b/subt_ign/worlds/niosh_sr_config_b.sdf
@@ -156,67 +156,67 @@
     <include>
       <name>sec_01</name>
       <pose>-0.5 18.4 -2.17 0 0 -1.57</pose>
-      <uri>https://fuel.ignitionrobotics.org/1.0/OpenRobotics/models/NIOSH Segment 01 Section 01</uri>
+      <uri>https://fuel.ignitionrobotics.org/1.0/OpenRobotics/models/NIOSH SR Course Section 01</uri>
     </include>
 
     <include>
       <name>sec_02</name>
       <pose>-0.5 18.4 -2.17 0 0 -1.57</pose>
-      <uri>https://fuel.ignitionrobotics.org/1.0/OpenRobotics/models/NIOSH Segment 01 Section 02</uri>
+      <uri>https://fuel.ignitionrobotics.org/1.0/OpenRobotics/models/NIOSH SR Course Section 02</uri>
     </include>
 
     <include>
       <name>sec_03</name>
       <pose>-0.5 18.4 -2.17 0 0 -1.57</pose>
-      <uri>https://fuel.ignitionrobotics.org/1.0/OpenRobotics/models/NIOSH Segment 01 Section 03</uri>
+      <uri>https://fuel.ignitionrobotics.org/1.0/OpenRobotics/models/NIOSH SR Course Section 03</uri>
     </include>
 
     <include>
       <name>sec_04</name>
       <pose>-0.5 18.4 -2.17 0 0 -1.57</pose>
-      <uri>https://fuel.ignitionrobotics.org/1.0/OpenRobotics/models/NIOSH Segment 01 Section 04</uri>
+      <uri>https://fuel.ignitionrobotics.org/1.0/OpenRobotics/models/NIOSH SR Course Section 04</uri>
     </include>
 
     <include>
       <name>sec_05</name>
       <pose>-0.5 18.4 -2.17 0 0 -1.57</pose>
-      <uri>https://fuel.ignitionrobotics.org/1.0/OpenRobotics/models/NIOSH Segment 01 Section 05</uri>
+      <uri>https://fuel.ignitionrobotics.org/1.0/OpenRobotics/models/NIOSH SR Course Section 05</uri>
     </include>
 
     <include>
       <name>sec_06</name>
       <pose>-0.5 18.4 -2.17 0 0 -1.57</pose>
-      <uri>https://fuel.ignitionrobotics.org/1.0/OpenRobotics/models/NIOSH Segment 01 Section 06</uri>
+      <uri>https://fuel.ignitionrobotics.org/1.0/OpenRobotics/models/NIOSH SR Course Section 06</uri>
     </include>
 
     <include>
       <name>sec_07</name>
       <pose>-0.5 18.4 -2.17 0 0 -1.57</pose>
-      <uri>https://fuel.ignitionrobotics.org/1.0/OpenRobotics/models/NIOSH Segment 01 Section 07</uri>
+      <uri>https://fuel.ignitionrobotics.org/1.0/OpenRobotics/models/NIOSH SR Course Section 07</uri>
     </include>
 
     <include>
       <name>sec_08</name>
       <pose>-0.5 18.4 -2.17 0 0 -1.57</pose>
-      <uri>https://fuel.ignitionrobotics.org/1.0/OpenRobotics/models/NIOSH Segment 01 Section 08</uri>
+      <uri>https://fuel.ignitionrobotics.org/1.0/OpenRobotics/models/NIOSH SR Course Section 08</uri>
     </include>
 
     <include>
       <name>sec_09</name>
       <pose>-0.5 18.4 -2.17 0 0 -1.57</pose>
-      <uri>https://fuel.ignitionrobotics.org/1.0/OpenRobotics/models/NIOSH Segment 01 Section 09</uri>
+      <uri>https://fuel.ignitionrobotics.org/1.0/OpenRobotics/models/NIOSH SR Course Section 09</uri>
     </include>
 
     <include>
       <name>sec_10</name>
       <pose>-0.5 18.4 -2.17 0 0 -1.57</pose>
-      <uri>https://fuel.ignitionrobotics.org/1.0/OpenRobotics/models/NIOSH Segment 01 Section 10</uri>
+      <uri>https://fuel.ignitionrobotics.org/1.0/OpenRobotics/models/NIOSH SR Course Section 10</uri>
     </include>
 
     <include>
       <name>sec_11</name>
       <pose>-0.5 18.4 -2.17 0 0 -1.57</pose>
-      <uri>https://fuel.ignitionrobotics.org/1.0/OpenRobotics/models/NIOSH Segment 01 Section 11</uri>
+      <uri>https://fuel.ignitionrobotics.org/1.0/OpenRobotics/models/NIOSH SR Course Section 11</uri>
     </include>
 
     <include>
@@ -228,7 +228,7 @@
     <include>
       <name>shell</name>
       <pose>-0.5 18.4 -2.17 0 0 -1.57</pose>
-      <uri>https://fuel.ignitionrobotics.org/1.0/OpenRobotics/models/NIOSH Segment 01 Shell</uri>
+      <uri>https://fuel.ignitionrobotics.org/1.0/OpenRobotics/models/NIOSH SR Course Shell</uri>
     </include>
 
     <include>


### PR DESCRIPTION
I've moved the NIOSH tiles out of the `SubT Tech Repo` in order to download them into separate docker layers. This will let us push new docker images to ECR by avoiding a single layer that is too large.