### PR TITLE
Publish robot name and type information

### DIFF
--- a/subt_ign/src/GameLogicPlugin.cc
+++ b/subt_ign/src/GameLogicPlugin.cc
@@ -1246,12 +1246,27 @@ void GameLogicPlugin::PostUpdate(
       (*param->mutable_params())["config"].set_type(
           ignition::msgs::Any::STRING);
       (*param->mutable_params())["config"].set_string_value(
-          robot.second.first);
+          robot.second.second);
 
       (*param->mutable_params())["platform"].set_type(
           ignition::msgs::Any::STRING);
       (*param->mutable_params())["platform"].set_string_value(
-          robot.second.second);
+          robot.second.first);
+    }
+
+    // Add in marsupial pairs.
+    for (const std::pair<std::string, std::string> &pair :
+         this->dataPtr->marsupialPairs)
+    {
+      ignition::msgs::Param *param = robotMsg.add_param();
+      (*param->mutable_params())["marsupial_parent"].set_type(
+          ignition::msgs::Any::STRING);
+      (*param->mutable_params())["marsupial_parent"].set_string_value(
+          pair.first);
+      (*param->mutable_params())["marsupial_child"].set_type(
+          ignition::msgs::Any::STRING);
+      (*param->mutable_params())["marsupial_child"].set_string_value(
+          pair.second);
     }
     this->dataPtr->robotPub.Publish(robotMsg);
   }


### PR DESCRIPTION
This creates the `/subt/robots` Ignition Transport topic which contains robot name and configuration information.

# Testing

1. ign launch -v 4 cloudsim_sim.ign worldName:=simple_cave_01 circuit:=cave robotName1:=X1 robotConfig1:=X1_SENSOR_CONFIG_1 robotName2:=X2 robotConfig2:=X3_SENSOR_CONFIG_3 marsupial1:=X1:X2``

2. `ign topic -et /subt/robots` should produce the following output:

```
param {
  params {
    key: "config"
    value {
      type: STRING
      string_value: "X1 CONFIG 1"
    }
  }
  params {
    key: "name"
    value {
      type: STRING
      string_value: "X1"
    }
  }
  params {
    key: "platform"
    value {
      type: STRING
      string_value: "X1"
    }
  }
}
param {
  params {
    key: "config"
    value {
      type: STRING
      string_value: "X3 UAV CONFIG 3"
    }
  }
  params {
    key: "name"
    value {
      type: STRING
      string_value: "X2"
    }
  }
  params {
    key: "platform"
    value {
      type: STRING
      string_value: "X3"
    }
  }
}
param {
  params {
    key: "marsupial_child"
    value {
      type: STRING
      string_value: "X2"
    }
  }
  params {
    key: "marsupial_parent"
    value {
      type: STRING
      string_value: "X1"
    }
  }
}

```
Signed-off-by: Nate Koenig <nate@openrobotics.org>