### PR TITLE
Wheel Slip Testing Dockerfile

### DIFF
--- a/docker/wheel_slip_test/Dockerfile
+++ b/docker/wheel_slip_test/Dockerfile
@@ -1,0 +1,190 @@
+# Ubuntu 18.04 with nvidia-docker2 beta opengl support
+FROM nvidia/opengl:1.0-glvnd-devel-ubuntu18.04
+
+# Tools I find useful during development
+RUN apt-get update -qq \
+ && apt-get install -y -qq \
+        build-essential \
+        bwm-ng \
+        cmake \
+        cppcheck \
+        gdb \
+        git \
+        libbluetooth-dev \
+        libcwiid-dev \
+        libgoogle-glog-dev \
+        libspnav-dev \
+        libusb-dev \
+        lsb-release \
+        python3-dbg \
+        python3-empy \
+        python3-numpy \
+        python3-setuptools \
+        python3-pip \
+        python3-venv \
+        ruby2.5 \
+        ruby2.5-dev \
+        software-properties-common \
+        sudo \
+        vim \
+        wget \
+        net-tools \
+        iputils-ping \
+        libyaml-cpp-dev \
+ && apt-get clean -qq
+
+# Add a user with the same user_id as the user outside the container
+# Requires a docker build argument `user_id`
+ARG user_id
+ENV USERNAME developer
+RUN useradd -U --uid ${user_id} -ms /bin/bash $USERNAME \
+ && echo "$USERNAME:$USERNAME" | chpasswd \
+ && adduser $USERNAME sudo \
+ && echo "$USERNAME ALL=NOPASSWD: ALL" >> /etc/sudoers.d/$USERNAME
+
+# Commands below run as the developer user
+USER $USERNAME
+
+# Make a couple folders for organizing docker volumes
+RUN mkdir ~/workspaces ~/other
+
+# When running a container start in the developer's home folder
+WORKDIR /home/$USERNAME
+
+RUN export DEBIAN_FRONTEND=noninteractive \
+ && sudo apt-get update -qq \
+ && sudo -E apt-get install -y -qq \
+    tzdata \
+ && sudo ln -fs /usr/share/zoneinfo/America/Los_Angeles /etc/localtime \
+ && sudo dpkg-reconfigure --frontend noninteractive tzdata \
+ && sudo apt-get clean -qq
+
+# install ROS and required packages
+RUN sudo /bin/sh -c 'echo "deb [trusted=yes] http://packages.ros.org/ros/ubuntu $(lsb_release -sc) main" > /etc/apt/sources.list.d/ros-latest.list' \
+ && sudo /bin/sh -c 'apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-key C1CF6E31E6BADE8868B172B4F42ED6FBAB17C654' \
+ && sudo apt-get update -qq \
+ && sudo apt-get install -y -qq \
+    python-catkin-tools \
+    python-rosdep \
+    python-rosinstall \
+    ros-melodic-desktop \
+    ros-melodic-joystick-drivers \
+    ros-melodic-pointcloud-to-laserscan \
+    ros-melodic-robot-localization \
+    ros-melodic-spacenav-node \
+    ros-melodic-tf2-sensor-msgs \
+    ros-melodic-twist-mux \
+    ros-melodic-rviz-imu-plugin \
+    ros-melodic-rotors-control \
+ && sudo rosdep init \
+ && sudo apt-get clean -qq
+
+RUN rosdep update
+
+# sdformat8-sdf conflicts with sdformat-sdf installed from gazebo
+# so we need to workaround this using a force overwrite
+# Do this before installing ign-gazebo
+RUN sudo /bin/sh -c 'echo "deb [trusted=yes] http://packages.osrfoundation.org/gazebo/ubuntu-stable `lsb_release -cs` main" > /etc/apt/sources.list.d/gazebo-stable.list' \
+ && sudo /bin/sh -c 'wget http://packages.osrfoundation.org/gazebo.key -O - | sudo apt-key add -' \
+ && sudo /bin/sh -c 'apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-key C1CF6E31E6BADE8868B172B4F42ED6FBAB17C654'
+
+# install source dependencies for ignition-blueprint
+# DART
+RUN sudo apt-get update -qq \
+  && sudo apt-get -y remove \
+    libdart* \
+  && sudo apt-get -y install \
+    build-essential \
+    cmake \
+    pkg-config \
+    git \
+    libeigen3-dev \
+    libassimp-dev \
+    libccd-dev \
+    libfcl-dev \
+    libboost-regex-dev \
+    libboost-system-dev \
+    libopenscenegraph-dev \
+    libnlopt-dev \
+    coinor-libipopt-dev \
+    libbullet-dev \
+    libode-dev \
+    liboctomap-dev \
+    libflann-dev \
+    libtinyxml2-dev \
+    liburdfdom-dev \
+    libxi-dev libxmu-dev freeglut3-dev \
+  && sudo apt-get clean -qq
+WORKDIR /home/$USERNAME
+RUN git clone -b force_dependent_slip https://github.com/azeey/dart.git \
+  && cd dart \
+  && mkdir build && cd build && cmake .. && make -j4 && sudo make install
+# ign-physics
+WORKDIR /home/$USERNAME
+RUN sudo apt-get -qq update \
+  && sudo apt-get -y install lsb-release \
+  && sudo /bin/sh -c 'echo "deb http://packages.osrfoundation.org/gazebo/ubuntu-stable `lsb_release -cs` main" > /etc/apt/sources.list.d/gazebo-stable.list' \
+  && apt-key adv --keyserver keyserver.ubuntu.com --recv-keys D2486D2DD83DB69272AFE98867170598AF249743 \
+  && sudo apt-add-repository -s "deb http://packages.osrfoundation.org/gazebo/ubuntu-stable $(lsb_release -c -s) main" \
+  && sudo apt-get -y install \
+    doxygen \
+    libignition-cmake2-dev \
+    libignition-math6-dev \
+    libignition-plugin-dev \
+    libignition-common3-dev \
+    libignition-math6-eigen3-dev \
+    libsdformat8-dev \
+  && sudo apt-get -qq clean
+RUN sudo apt-get -qq update \
+  && sudo apt-get -y install g++-8 \
+  && sudo update-alternatives --install \
+    /usr/bin/gcc gcc /usr/bin/gcc-8 800 \
+    --slave /usr/bin/g++ g++ /usr/bin/g++-8 \
+    --slave /usr/bin/gcov gcov /usr/bin/gcov-8 \
+  && sudo apt-get -qq clean
+RUN git clone -b set_slip_compliance https://github.com/ignitionrobotics/ign-physics \
+  && cd ign-physics \
+  && mkdir build && cd build && cmake -DBUILD_TESTING=0 .. && make && sudo make install
+# ign-gazebo
+WORKDIR /home/$USERNAME
+RUN sudo apt-get -qq update \
+  && sudo apt-get -y install \
+    cmake build-essential curl cppcheck g++-8 libbenchmark-dev libgflags-dev doxygen ruby-ronn libtinyxml2-dev libtinyxml-dev software-properties-common libeigen3-dev qtdeclarative5-models-plugin \
+    libignition-rendering2-dev \
+    libignition-tools-dev \
+    libignition-transport7-dev \
+    libignition-gui2-dev \
+    libignition-msgs4-dev \
+    libignition-fuel-tools3-dev \
+    libignition-sensors2-dev \
+  && sudo apt-get -qq clean
+RUN git clone -b wheel_slip_system https://github.com/ignitionrobotics/ign-gazebo \
+  && cd ign-gazebo \
+  && mkdir build && cd build && cmake .. && make && sudo make install
+
+# ignition-launch depends on ignition-gazebo, so we must install this AFTER building ignition-gazebo from source
+# (if we install if before building ignition-gazebo from source, it will automatically install the ignition-gazebo deb package dependencies)
+RUN sudo apt-get -qq update \
+  && sudo apt-get -y install \
+    libignition-launch-dev \
+  && sudo apt-get -qq clean
+
+# install the ros to ign bridge
+RUN sudo apt-get update -qq \
+ && sudo apt-get install -y -qq \
+    ros-melodic-ros-ign \
+ && sudo apt-get clean -qq
+
+# Download the public models
+#WORKDIR /home/$USERNAME
+#RUN ign fuel download -v 4 -j 16 -u "https://fuel.ignitionrobotics.org/OpenRobotics/collections/SubT Tech Repo"
+
+# build subt repo
+RUN mkdir -p /home/$USERNAME/subt_ws/src \
+  && cd /home/$USERNAME/subt_ws/src \
+  && git clone -b wheel_slip https://github.com/azeey/subt.git
+WORKDIR /home/$USERNAME/subt_ws
+RUN /bin/bash -c "source /opt/ros/melodic/setup.bash && catkin_make install" \
+  && echo "source /home/$USERNAME/subt_ws/install/setup.bash" >> /home/$USERNAME/.bashrc
+
+CMD [ "bash" ]

--- a/docker/wheel_slip_test/Dockerfile
+++ b/docker/wheel_slip_test/Dockerfile
@@ -162,29 +162,52 @@ RUN git clone -b wheel_slip_system https://github.com/ignitionrobotics/ign-gazeb
   && cd ign-gazebo \
   && mkdir build && cd build && cmake .. && make && sudo make install
 
-# ignition-launch depends on ignition-gazebo, so we must install this AFTER building ignition-gazebo from source
-# (if we install if before building ignition-gazebo from source, it will automatically install the ignition-gazebo deb package dependencies)
-RUN sudo apt-get -qq update \
-  && sudo apt-get -y install \
-    libignition-launch-dev \
-  && sudo apt-get -qq clean
+# ignition-launch depends on ignition-gazebo (and ignition-physics), so we must install this from source as well
+# (if we install debian package, it will automatically install the debian package dependencies, overriding the source installs)
+WORKDIR /home/$USERNAME
+RUN git clone https://github.com/ignitionrobotics/ign-launch.git \
+  && cd ign-launch \
+  && git checkout ignition-launch_1.9.0 \
+  && mkdir build && cd build && cmake .. && make && sudo make install
 
 # install the ros to ign bridge
-RUN sudo apt-get update -qq \
- && sudo apt-get install -y -qq \
-    ros-melodic-ros-ign \
- && sudo apt-get clean -qq
+RUN mkdir -p /home/$USERNAME/ros_ign_ws/src
+WORKDIR /home/$USERNAME/ros_ign_ws/src
+RUN git clone https://github.com/ignitionrobotics/ros_ign.git \
+  && cd ros_ign \
+  && git checkout 0.9.3
+WORKDIR /home/$USERNAME/ros_ign_ws
+RUN rosdep install --from-paths src -i -y --rosdistro melodic \
+  --skip-keys=ignition-gazebo2 \
+  --skip-keys=ignition-gazebo3 \
+  --skip-keys=ignition-msgs4 \
+  --skip-keys=ignition-msgs5 \
+  --skip-keys=ignition-rendering2 \
+  --skip-keys=ignition-rendering3 \
+  --skip-keys=ignition-sensors2 \
+  --skip-keys=ignition-sensors3 \
+  --skip-keys=ignition-transport7 \
+  --skip-keys=ignition-transport8 \
+  && /bin/bash -c "source /opt/ros/melodic/setup.bash && catkin_make install"
 
 # Download the public models
-#WORKDIR /home/$USERNAME
-#RUN ign fuel download -v 4 -j 16 -u "https://fuel.ignitionrobotics.org/OpenRobotics/collections/SubT Tech Repo"
+WORKDIR /home/$USERNAME
+RUN ign fuel download -v 4 -j 16 -u "https://fuel.ignitionrobotics.org/OpenRobotics/collections/SubT Tech Repo"
 
-# build subt repo
+# manual teleop with keyboard
+RUN sudo apt-get -qq update \
+  && sudo apt-get -y install \
+    ros-melodic-teleop-twist-keyboard \
+  && sudo apt-get -qq clean
+
+# build subt repo (wheel slip fork)
 RUN mkdir -p /home/$USERNAME/subt_ws/src \
   && cd /home/$USERNAME/subt_ws/src \
   && git clone -b wheel_slip https://github.com/azeey/subt.git
 WORKDIR /home/$USERNAME/subt_ws
-RUN /bin/bash -c "source /opt/ros/melodic/setup.bash && catkin_make install" \
-  && echo "source /home/$USERNAME/subt_ws/install/setup.bash" >> /home/$USERNAME/.bashrc
+RUN /bin/bash -c "source /home/$USERNAME/ros_ign_ws/install/setup.bash && catkin_make install" \
+  && echo "source /home/$USERNAME/subt_ws/install/setup.bash" >> /home/$USERNAME/.bashrc \
+  # https://github.com/ignitionrobotics/ign-launch#known-issue-of-command-line-tools
+  && echo "export IGN_CONFIG_PATH=/usr/local/share/ignition" >> /home/$USERNAME/.bashrc
 
 CMD [ "bash" ]


### PR DESCRIPTION
Here's a Dockerfile that can be used to create an environment for testing the wheel slip PR. It builds `dart`, `ignition-physics`, and `ignition-gazebo` from source, and also builds the forked `osrf/subt` repo that has the wheel slip changes.

To build the image, run the following commands:
```
cd docker
./build.bash wheel_slip_test
```

Use `docker/run.bash` to start a container with this image:
```
cd docker
./run.bash wheel_slip_test
```

You can then start a simulator with a robot you want to test:
```
ign launch -v 4 cave_circuit.ign worldName:=cave_qual robotName1:=X1 robotConfig1:=<YOUR_ROBOT_CONFIG>
```

Then, drive the robot around manually using keyboard teleop:
```
rosrun teleop_twist_keyboard teleop_twist_keyboard.py /cmd_vel:=/X1/cmd_vel
```