### PR TITLE
Path tracer colors

### DIFF
--- a/subt_ign/src/path_tracer.cc
+++ b/subt_ign/src/path_tracer.cc
@@ -17,76 +17,40 @@
 #include "path_tracer.hh"
 
 //////////////////////////////////////////////////
+// Load a color from YAML helper function.
+// \param[in] _node YAML node that contains color information
+// \param[in] _def Default color value that is used if a color property is
+// missing.
+ignition::math::Color loadColor(const YAML::Node &_node, double _def = 1.0)
+{
+  ignition::math::Color clr(_def, _def, _def, _def);
+
+  if (_node["r"])
+    clr.R(_node["r"].as<double>());
+
+  if (_node["g"])
+    clr.G(_node["g"].as<double>());
+
+  if (_node["b"])
+    clr.B(_node["b"].as<double>());
+
+  if (_node["a"])
+    clr.A(_node["a"].as<double>());
+
+  return clr;
+}
+
+//////////////////////////////////////////////////
 MarkerColor::MarkerColor(const YAML::Node &_node)
 {
   if (_node["ambient"])
-  {
-    if (_node["ambient"]["r"])
-      this->ambient.R(_node["ambient"]["r"].as<double>());
-    else
-      this->ambient.R(1.0);
-
-    if (_node["ambient"]["g"])
-      this->ambient.G(_node["ambient"]["g"].as<double>());
-    else
-      this->ambient.G(1.0);
-
-    if (_node["ambient"]["b"])
-      this->ambient.B(_node["ambient"]["b"].as<double>());
-    else
-      this->ambient.B(1.0);
-
-    if (_node["ambient"]["a"])
-      this->ambient.A(_node["ambient"]["a"].as<double>());
-    else
-      this->ambient.A(1.0);
-  }
+    this->ambient = loadColor(_node["ambient"]);
 
   if (_node["diffuse"])
-  {
-    if (_node["diffuse"]["r"])
-      this->diffuse.R(_node["diffuse"]["r"].as<double>());
-    else
-      this->diffuse.R(1.0);
-
-    if (_node["diffuse"]["g"])
-      this->diffuse.G(_node["diffuse"]["g"].as<double>());
-    else
-      this->diffuse.G(1.0);
-
-    if (_node["diffuse"]["b"])
-      this->diffuse.B(_node["diffuse"]["b"].as<double>());
-    else
-      this->diffuse.B(1.0);
-
-    if (_node["diffuse"]["a"])
-      this->diffuse.A(_node["diffuse"]["a"].as<double>());
-    else
-      this->diffuse.A(1.0);
-  }
+    this->diffuse = loadColor(_node["diffuse"]);
 
   if (_node["emissive"])
-  {
-    if (_node["emissive"]["r"])
-      this->emissive.R(_node["emissive"]["r"].as<double>());
-    else
-      this->emissive.R(1.0);
-
-    if (_node["emissive"]["g"])
-      this->emissive.G(_node["emissive"]["g"].as<double>());
-    else
-      this->emissive.G(1.0);
-
-    if (_node["emissive"]["b"])
-      this->emissive.B(_node["emissive"]["b"].as<double>());
-    else
-      this->emissive.B(1.0);
-
-    if (_node["emissive"]["a"])
-      this->emissive.A(_node["emissive"]["a"].as<double>());
-    else
-      this->emissive.A(1.0);
-  }
+    this->emissive = loadColor(_node["emissive"]);
 }
 
 //////////////////////////////////////////////////

--- a/subt_ign/src/path_tracer.cc
+++ b/subt_ign/src/path_tracer.cc
@@ -79,10 +79,12 @@ Processor::Processor(const std::string &_path, const std::string &_configPath)
       {
         cfg = YAML::LoadFile(_configPath);
       }
-      catch (...)
+      catch (YAML::Exception &ex)
       {
         std::cerr << "Unable to load configuration file["
-          << _configPath << "]\n";
+          << _configPath << "]: "
+          << "error at line " << ex.mark.line + 1 << ", column "
+          << ex.mark.column + 1 << ": " << ex.msg << "\n";
       }
     }
     else

--- a/subt_ign/src/path_tracer.cc
+++ b/subt_ign/src/path_tracer.cc
@@ -17,8 +17,8 @@
 #include "path_tracer.hh"
 
 //////////////////////////////////////////////////
-Processor::Processor(const std::string &_path, int _stepSleepMs)
-  : stepSleepMs(_stepSleepMs)
+Processor::Processor(const std::string &_path, double _rtf)
+  : rtf(_rtf)
 {
   // Create the transport node with the partition used by simulation
   // world.
@@ -200,13 +200,21 @@ void Processor::ArtifactCb(const ignition::msgs::Pose_V &_msg)
 //////////////////////////////////////////////////
 void Processor::DisplayPoses()
 {
-  for (auto &stepData : this->logData)
+  for (std::map<int, std::vector<std::unique_ptr<Data>>>::iterator iter =
+       this->logData.begin(); iter != this->logData.end(); ++iter)
   {
-    for (std::unique_ptr<Data> &data : stepData.second)
+    for (std::unique_ptr<Data> &data : iter->second)
     {
       data->Render(this);
     }
-    std::this_thread::sleep_for(std::chrono::milliseconds(this->stepSleepMs));
+
+    // Get the next time stamp, and sleep the correct amount of time.
+    auto next = std::next(iter, 1);
+    if (next != this->logData.end())
+    {
+      int sleepTime = ((next->first - iter->first) / this->rtf)*1000;
+      std::this_thread::sleep_for(std::chrono::milliseconds(sleepTime));
+    }
   }
 }
 
@@ -337,20 +345,26 @@ void ReportData::Render(Processor *_p)
 /////////////////////////////////////////////////
 int main(int _argc, char **_argv)
 {
-  int sleep = 20;
+  double rtf = 1;
   if (_argc > 2)
   {
     try
     {
-      sleep = std::stoi(_argv[2]);
+      rtf = std::stod(_argv[2]);
     }
     catch(...)
     {
-      std::cerr << "Invalid sleep time. Defaulting to 20ms\n";
+      std::cerr << "Invalid RTF. Defaulting to 1.0\n";
     }
   }
 
+  if (rtf <= 0)
+  {
+    std::cerr << "Invalid RTF of [" << rtf << "]. Defaulting to 1.0\n";
+    rtf = 1.0;
+  }
+
   // Create and run the processor.
-  Processor p(_argv[1], sleep);
+  Processor p(_argv[1], rtf);
   return 0;
 }

--- a/subt_ign/src/path_tracer.hh
+++ b/subt_ign/src/path_tracer.hh
@@ -90,7 +90,8 @@ class Processor
   /// \brief Constructor, which also kicks off all of the data
   /// visualization.
   /// \param[in] _path Path to the directory containing the log files.
-  public: Processor(const std::string &_path, int _stepSleepMs);
+  /// \param[in] _rtf Real time factor for playback.
+  public: Processor(const std::string &_path, double _rtf);
 
   /// \brief Destructor
   public: ~Processor();
@@ -174,6 +175,6 @@ class Processor
   /// \brief All of the pose data.
   private: std::map<int, std::vector<std::unique_ptr<Data>>> logData;
 
-  /// \brief Number of milliseconds to sleep between log steps.
-  private: int stepSleepMs = 20;
+  /// \brief Realtime factor for playback.
+  private: double rtf = 1.0;
 };

--- a/subt_ign/src/path_tracer.yml
+++ b/subt_ign/src/path_tracer.yml
@@ -1,0 +1,81 @@
+incorrect_report_color:
+  ambient:
+    r: 1.0
+    g: 0.0
+    b: 0.0
+    a: 0.5
+  diffuse:
+    r: 1.0
+    g: 0.0
+    b: 0.0
+    a: 0.5
+  emissive:
+    r: 0.2
+    g: 0.0
+    b: 0.0
+    a: 0.1
+correct_report_color:
+  ambient:
+    r: 0.0
+    g: 1.0
+    b: 0.0
+    a: 1.0
+  diffuse:
+    r: 0.0
+    g: 1.0
+    b: 0.0
+    a: 1.0
+  emissive:
+    r: 0.0
+    g: 1.0
+    b: 0.0
+    a: 1.0
+artficat_location_color:
+  ambient:
+    r: 0.0
+    g: 1.0
+    b: 1.0
+    a: 0.5
+  diffuse:
+    r: 0.0
+    g: 1.0
+    b: 1.0
+    a: 0.5
+  emissive:
+    r: 0.0
+    g: 1.0
+    b: 1.0
+    a: 0.5
+robot_colors:
+  1:
+    ambient:
+      r: 0.0
+      g: 1.0
+      b: 1.0
+      a: 0.5
+    diffuse:
+      r: 0.0
+      g: 1.0
+      b: 1.0
+      a: 0.5
+    emissive:
+      r: 0.0
+      g: 1.0
+      b: 1.0
+      a: 0.5
+  2:
+    ambient:
+      r: 0.0
+      g: 1.0
+      b: 1.0
+      a: 0.5
+    diffuse:
+      r: 0.0
+      g: 1.0
+      b: 1.0
+      a: 0.5
+    emissive:
+      r: 0.0
+      g: 1.0
+      b: 1.0
+      a: 0.5


### PR DESCRIPTION
Add support for a YAML configuration file, which has the form:

```
rtf: 4.0
incorrect_report_color:
  ambient:
    r: 1.0
    g: 0.0
    b: 0.0
    a: 0.5
  diffuse:
    r: 1.0
    g: 0.0
    b: 0.0
    a: 0.5
  emissive:
    r: 0.2
    g: 0.0
    b: 0.0
    a: 0.1
correct_report_color:
  ambient:
    r: 0.0
    g: 1.0
    b: 0.0
    a: 1.0
  diffuse:
    r: 0.0
    g: 1.0
    b: 0.0
    a: 1.0
  emissive:
    r: 0.0
    g: 1.0
    b: 0.0
    a: 1.0
artifact_location_color:
  ambient:
    r: 0.0
    g: 1.0
    b: 1.0
    a: 0.5
  diffuse:
    r: 0.0
    g: 1.0
    b: 1.0
    a: 0.5
  emissive:
    r: 0.0
    g: 0.2
    b: 0.2
    a: 0.5
robot_colors:
  - color:
    ambient:
      r: 0.6
      g: 0.0
      b: 1.0
      a: 1.0
    diffuse:
      r: 0.6
      g: 0.0
      b: 1.0
      a: 1.0
    emissive:
      r: 0.6
      g: 0.0
      b: 1.0
      a: 1.0
  - color:
    ambient:
      r: 0.678
      g: 0.2
      b: 1.0
      a: 1.0
    diffuse:
      r: 0.678
      g: 0.2
      b: 1.0
      a: 1.0
    emissive:
      r: 0.678
      g: 0.2
      b: 1.0
      a: 1.0
  - color:
    ambient:
      r: 0.761
      g: 0.4
      b: 1.0
      a: 1.0
    diffuse:
      r: 0.761
      g: 0.4
      b: 1.0
      a: 1.0
    emissive:
      r: 0.761
      g: 0.4
      b: 1.0
      a: 1.0
```