### PR TITLE
Visibility table enhancements

### DIFF
--- a/subt_ign/CMakeLists.txt
+++ b/subt_ign/CMakeLists.txt
@@ -181,6 +181,7 @@ install(TARGETS validate_connections
   RUNTIME DESTINATION bin)
 
 add_library(Visibility
+  STATIC
   src/ign_to_fcl.cc
   src/SimpleDOTParser.cc
   src/VisibilityRfModel.cc

--- a/subt_ign/CMakeLists.txt
+++ b/subt_ign/CMakeLists.txt
@@ -35,7 +35,11 @@ find_package(ignition-launch1 REQUIRED)
 find_package(sdformat8 REQUIRED)
 find_package(yaml-cpp REQUIRED)
 
-find_package(FCL REQUIRED)
+find_package(PkgConfig REQUIRED)
+pkg_check_modules(LIBFCL_PC REQUIRED fcl)
+# find *absolute* paths to LIBFCL_INCLUDE_DIRS and LIBFCL_LIBRARIES
+find_path(LIBFCL_INCLUDE_DIRS fcl/config.h HINTS ${LIBFCL_PC_INCLUDE_DIR} ${LIBFCL_PC_INCLUDE_DIRS})
+find_library(LIBFCL_LIBRARIES fcl HINTS ${LIBFCL_PC_LIBRARY_DIRS})
 
 ###########
 ## Build ##
@@ -47,6 +51,8 @@ include_directories(
   ${PROJECT_BINARY_DIR}/include
   ${CATKIN_DEVEL_PREFIX}/include
 )
+
+message(STATUS ${LIBFCL_INCLUDE_DIRS})
 
 link_directories()
 
@@ -189,18 +195,16 @@ add_library(Visibility
 )
 target_include_directories(Visibility
   PUBLIC
-  ${FCL_INCLUDE_DIRS}
   ${catkin_INCLUDE_DIRS}
+  ${LIBFCL_INCLUDE_DIRS}
 )
 target_link_libraries(
   Visibility
   PUBLIC
   ignition-gazebo${IGN_GAZEBO_VER}::core
-  ${FCL_LIBRARIES}
+  ${LIBFCL_LIBRARIES}
   ${catkin_LIBRARIES}
 )
-
-message(STATUS ${FCL_INCLUDE_DIRS})
 
 add_executable(validate_visibility_table
   src/validate_visibility_table.cc)

--- a/subt_ign/CMakeLists.txt
+++ b/subt_ign/CMakeLists.txt
@@ -35,6 +35,8 @@ find_package(ignition-launch1 REQUIRED)
 find_package(sdformat8 REQUIRED)
 find_package(yaml-cpp REQUIRED)
 
+find_package(FCL REQUIRED)
+
 ###########
 ## Build ##
 ###########
@@ -178,13 +180,32 @@ install(TARGETS validate_connections
   LIBRARY DESTINATION lib
   RUNTIME DESTINATION bin)
 
-add_executable(validate_visibility_table
+add_library(Visibility
+  src/ign_to_fcl.cc
+  src/SimpleDOTParser.cc
+  src/VisibilityRfModel.cc
   src/VisibilityTable.cc
-  src/SimpleDOTParser.cc)
+)
+target_include_directories(Visibility
+  PUBLIC
+  ${FCL_INCLUDE_DIRS}
+  ${catkin_INCLUDE_DIRS}
+)
+target_link_libraries(
+  Visibility
+  PUBLIC
+  ignition-gazebo${IGN_GAZEBO_VER}::core
+  ${FCL_LIBRARIES}
+  ${catkin_LIBRARIES}
+)
+
+message(STATUS ${FCL_INCLUDE_DIRS})
+
+add_executable(validate_visibility_table
+  src/validate_visibility_table.cc)
 target_link_libraries(validate_visibility_table
-  PRIVATE
-    ignition-gazebo${IGN_GAZEBO_VER}::core
-    ${catkin_LIBRARIES}
+  PRIVATE 
+  Visibility
 )
 install(TARGETS validate_visibility_table
   ARCHIVE DESTINATION lib
@@ -195,9 +216,6 @@ install(TARGETS validate_visibility_table
 set(comms_broker_plugin_name CommsBrokerPlugin)
 add_library(${comms_broker_plugin_name}
   src/CommsBrokerPlugin.cc
-  src/VisibilityRfModel.cc
-  src/VisibilityTable.cc
-  src/SimpleDOTParser.cc
 )
 target_include_directories(${comms_broker_plugin_name}
   PRIVATE ${CATKIN_DEVEL_PREFIX}/include)
@@ -211,7 +229,7 @@ target_link_libraries(${comms_broker_plugin_name}
   ignition-transport7::ignition-transport7
   sdformat8::sdformat8
   ${protobuf_lib_name}
-  ${catkin_LIBRARIES}
+  Visibility
 )
 install(TARGETS ${comms_broker_plugin_name}
   ARCHIVE DESTINATION lib
@@ -222,14 +240,9 @@ install(TARGETS ${comms_broker_plugin_name}
 set(visibility_plugin_name VisibilityPlugin)
 add_library(${visibility_plugin_name} SHARED
   src/VisibilityPlugin.cc
-  src/VisibilityTable.cc
-  src/SimpleDOTParser.cc
 )
-target_include_directories(${visibility_plugin_name}
-  PRIVATE ${CATKIN_DEVEL_PREFIX}/include)
 target_link_libraries(${visibility_plugin_name}
   PRIVATE
-  ignition-gazebo${IGN_GAZEBO_VER}::core
   ignition-common3::ignition-common3
   ignition-math6::ignition-math6
   ignition-msgs4::ignition-msgs4
@@ -238,7 +251,7 @@ target_link_libraries(${visibility_plugin_name}
   ignition-transport7::ignition-transport7
   sdformat8::sdformat8
   ${protobuf_lib_name}
-  ${catkin_LIBRARIES}
+  Visibility
 )
 install(TARGETS ${visibility_plugin_name}
   ARCHIVE DESTINATION lib

--- a/subt_ign/CMakeLists.txt
+++ b/subt_ign/CMakeLists.txt
@@ -26,7 +26,7 @@ set(IGN_GAZEBO_VER ${ignition-gazebo2_VERSION_MAJOR})
 
 file(MAKE_DIRECTORY ${CATKIN_DEVEL_PREFIX}/include)
 
-find_package(ignition-common3 REQUIRED)
+find_package(ignition-common3 REQUIRED COMPONENTS graphics)
 find_package(ignition-math6 REQUIRED)
 find_package(ignition-msgs4 REQUIRED)
 find_package(ignition-transport7 REQUIRED)
@@ -202,6 +202,8 @@ target_link_libraries(
   Visibility
   PUBLIC
   ignition-gazebo${IGN_GAZEBO_VER}::core
+  ignition-common3::ignition-common3
+  ignition-common3::graphics
   ${LIBFCL_LIBRARIES}
   ${catkin_LIBRARIES}
 )

--- a/subt_ign/include/subt_ign/VisibilityTable.hh
+++ b/subt_ign/include/subt_ign/VisibilityTable.hh
@@ -208,6 +208,8 @@ namespace subt
     private: std::vector<
              std::pair<ignition::math::AxisAlignedBox, uint64_t>> worldSegments;
 
+    /// \brief A map between each segment's id and the corresponding name.
+    /// This is used for looking up the corresponding names in generating LUT.
     private: std::map<uint64_t, std::string> worldSegmentNames;
 
     /// \brief A map of model name to its bounding box. Used for generating LUT
@@ -218,7 +220,7 @@ namespace subt
              std::shared_ptr<fcl::CollisionObject>> collisionObjs;
 
     /// \brief A map that stores 3D points an the vertex id in which are located
-    public : std::map<std::tuple<int32_t, int32_t, int32_t>, uint64_t> vertices;
+    private: std::map<std::tuple<int32_t, int32_t, int32_t>, uint64_t> vertices;
 
     /// \brief The path where the Gazebo world is located.
     private: std::string worldPath;

--- a/subt_ign/include/subt_ign/VisibilityTable.hh
+++ b/subt_ign/include/subt_ign/VisibilityTable.hh
@@ -27,7 +27,10 @@
 #include <ignition/math/graph/Vertex.hh>
 #include <subt_ign/VisibilityTypes.hh>
 
-#include <fcl/narrowphase/collision_object.h>
+namespace fcl
+{
+  class CollisionObject;
+}
 
 namespace subt
 {
@@ -91,7 +94,7 @@ namespace subt
     /// \param[in] _collObjs Collision Objects of models.
     /// \sa Generate
     public: void SetModelCollisionObjects(
-        const std::map<std::string, std::shared_ptr<fcl::CollisionObjectf>> &_collObjs);
+        const std::map<std::string, std::shared_ptr<fcl::CollisionObject>> &_collObjs);
 
     /// \brief Get the collection of sampled 3D points and their associated
     /// vertex id.
@@ -212,7 +215,7 @@ namespace subt
 
     /// \brief A map of model name to its bounding box. Used for generating LUT
     private: std::map<std::string, 
-             std::shared_ptr<fcl::CollisionObjectf>> collisionObjs;
+             std::shared_ptr<fcl::CollisionObject>> collisionObjs;
 
     /// \brief A map that stores 3D points an the vertex id in which are located
     public : std::map<std::tuple<int32_t, int32_t, int32_t>, uint64_t> vertices;

--- a/subt_ign/include/subt_ign/VisibilityTable.hh
+++ b/subt_ign/include/subt_ign/VisibilityTable.hh
@@ -27,6 +27,8 @@
 #include <ignition/math/graph/Vertex.hh>
 #include <subt_ign/VisibilityTypes.hh>
 
+#include <fcl/narrowphase/collision_object.h>
+
 namespace subt
 {
   /// \brief This class stores the connectivity between pairs of sections of a
@@ -84,6 +86,12 @@ namespace subt
     /// \sa Generate
     public: void SetModelBoundingBoxes(
         const std::map<std::string, ignition::math::AxisAlignedBox> &_boxes);
+
+    /// \brief Set the collision objects of models. Used for generating LUT
+    /// \param[in] _collObjs Collision Objects of models.
+    /// \sa Generate
+    public: void SetModelCollisionObjects(
+        const std::map<std::string, std::shared_ptr<fcl::CollisionObjectf>> &_collObjs);
 
     /// \brief Get the collection of sampled 3D points and their associated
     /// vertex id.
@@ -197,11 +205,17 @@ namespace subt
     private: std::vector<
              std::pair<ignition::math::AxisAlignedBox, uint64_t>> worldSegments;
 
+    private: std::map<uint64_t, std::string> worldSegmentNames;
+
     /// \brief A map of model name to its bounding box. Used for generating LUT
     private: std::map<std::string, ignition::math::AxisAlignedBox> bboxes;
 
+    /// \brief A map of model name to its bounding box. Used for generating LUT
+    private: std::map<std::string, 
+             std::shared_ptr<fcl::CollisionObjectf>> collisionObjs;
+
     /// \brief A map that stores 3D points an the vertex id in which are located
-    private: std::map<std::tuple<int32_t, int32_t, int32_t>, uint64_t> vertices;
+    public : std::map<std::tuple<int32_t, int32_t, int32_t>, uint64_t> vertices;
 
     /// \brief The path where the Gazebo world is located.
     private: std::string worldPath;

--- a/subt_ign/package.xml
+++ b/subt_ign/package.xml
@@ -17,5 +17,9 @@
   <depend>subt_rf_interface</depend>
   <depend>subt_communication_model</depend>
   <depend>subt_communication_broker</depend>
+
+  <depend>libccd-dev</depend>
+  <depend>libfcl-dev</depend>
+
   <test_depend>rostest</test_depend>
 </package>

--- a/subt_ign/src/VisibilityPlugin.cc
+++ b/subt_ign/src/VisibilityPlugin.cc
@@ -20,8 +20,11 @@
 #include <ignition/math/AxisAlignedBox.hh>
 
 #include <ignition/gazebo/components/AxisAlignedBox.hh>
+#include <ignition/gazebo/components/Collision.hh>
 #include <ignition/gazebo/components/Model.hh>
 #include <ignition/gazebo/components/Name.hh>
+#include <ignition/gazebo/components/Geometry.hh> 
+#include <ignition/gazebo/components/ParentEntity.hh>
 #include <ignition/gazebo/components/Pose.hh>
 #include <ignition/gazebo/components/Static.hh>
 #include <ignition/gazebo/components/World.hh>
@@ -29,9 +32,15 @@
 #include <ignition/gazebo/EntityComponentManager.hh>
 #include <ignition/gazebo/Util.hh>
 
+#include <sdf/Mesh.hh>
+#include <ignition/common/MeshManager.hh>
+#include <ignition/common/Mesh.hh>
+#include <ignition/common/SubMesh.hh>
 
 #include "subt_ign/VisibilityTable.hh"
 #include "subt_ign/VisibilityPlugin.hh"
+
+#include "ign_to_fcl.hh"
 
 IGNITION_ADD_PLUGIN(
     subt::VisibilityPlugin,
@@ -50,6 +59,8 @@ class subt::VisibilityPluginPrivate
 {
   /// \brief A map of model name ot its bounding box
   public: std::map<std::string, ignition::math::AxisAlignedBox> bboxes;
+
+  public: std::map<std::string, std::shared_ptr<fcl::CollisionObjectf>> fclObjs;
 
   /// \brief Name of the world
   public: std::string worldName;
@@ -132,6 +143,53 @@ void VisibilityPlugin::PostUpdate(
   if (s < 1)
     return;
 
+  _ecm.Each<gazebo::components::Collision,
+            gazebo::components::Name,
+            gazebo::components::Pose,
+            gazebo::components::Geometry,
+            gazebo::components::CollisionElement,
+            gazebo::components::ParentEntity>(
+      [&](const Entity &_entity,
+          const components::Collision *,
+          const components::Name *_name,
+          const components::Pose *_pose,
+          const components::Geometry *_geom,
+          const components::CollisionElement *_collElement,
+          const components::ParentEntity *_parent) -> bool
+      {
+        const sdf::Collision& collision = _collElement->Data();
+
+        if (_geom->Data().Type() == sdf::GeometryType::MESH)
+        {
+          const sdf::Mesh *meshSdf = _geom->Data().MeshShape();
+          if (nullptr == meshSdf)
+          {
+            ignwarn << "Mesh geometry for collision [" << _name->Data()
+                    << "] missing mesh shape." << std::endl;
+            return true;
+          }
+
+          auto &meshManager = *ignition::common::MeshManager::Instance();
+          auto fullPath = asFullPath(meshSdf->Uri(), meshSdf->FilePath());
+          auto *mesh = meshManager.Load(fullPath);
+          if (nullptr == mesh)
+          {
+            ignwarn << "Failed to load mesh from [" << fullPath
+                    << "]." << std::endl;
+            return true;
+          }
+
+          auto gP = _ecm.Component<gazebo::components::ParentEntity>(_parent->Data())->Data();
+          auto parentPose = _ecm.Component<gazebo::components::Pose>(gP)->Data();
+          auto parentName = _ecm.Component<gazebo::components::Name>(gP)->Data();
+          auto collisionObj = convert_to_fcl(*mesh, parentPose); 
+          collisionObj->computeAABB();
+          this->dataPtr->fclObjs[parentName] = collisionObj;
+        }
+
+        return true;
+      });
+
   // get all the bounding boxes
   _ecm.Each<gazebo::components::Model,
             gazebo::components::Name,
@@ -145,6 +203,20 @@ void VisibilityPlugin::PostUpdate(
       {
         // todo store bboxes instead
         this->dataPtr->bboxes[_nameComp->Data()] = _aabb->Data();
+
+        auto it = this->dataPtr->fclObjs.find(_nameComp->Data());
+        if (it == this->dataPtr->fclObjs.end())
+        {
+          std::cout << "Couldn't find fcl obj for: " << _nameComp->Data() << std::endl;
+          return true;
+        }
+
+        auto fclAABB = it->second->getAABB();
+
+        std::cout << _nameComp->Data() << std::endl;
+        std::cout << fclAABB.center()(0) << " " << fclAABB.center()(1) << " " << fclAABB.center()(2) << std::endl;
+        std::cout << _aabb->Data().Center().X() << " " << _aabb->Data().Center().Y()  << " " << _aabb->Data().Center().Z() << std::endl;
+
         return true;
       });
 
@@ -152,6 +224,7 @@ void VisibilityPlugin::PostUpdate(
   subt::VisibilityTable table;
   table.Load(this->dataPtr->worldName, false);
   table.SetModelBoundingBoxes(this->dataPtr->bboxes);
+  table.SetModelCollisionObjects(this->dataPtr->fclObjs);
   table.Generate();
 
   // Send SIGINT to terminate Gazebo.

--- a/subt_ign/src/VisibilityPlugin.cc
+++ b/subt_ign/src/VisibilityPlugin.cc
@@ -60,7 +60,7 @@ class subt::VisibilityPluginPrivate
   /// \brief A map of model name ot its bounding box
   public: std::map<std::string, ignition::math::AxisAlignedBox> bboxes;
 
-  public: std::map<std::string, std::shared_ptr<fcl::CollisionObjectf>> fclObjs;
+  public: std::map<std::string, std::shared_ptr<fcl::CollisionObject>> fclObjs;
 
   /// \brief Name of the world
   public: std::string worldName;
@@ -145,20 +145,14 @@ void VisibilityPlugin::PostUpdate(
 
   _ecm.Each<gazebo::components::Collision,
             gazebo::components::Name,
-            gazebo::components::Pose,
             gazebo::components::Geometry,
-            gazebo::components::CollisionElement,
             gazebo::components::ParentEntity>(
-      [&](const Entity &_entity,
+      [&](const Entity &,
           const components::Collision *,
           const components::Name *_name,
-          const components::Pose *_pose,
           const components::Geometry *_geom,
-          const components::CollisionElement *_collElement,
           const components::ParentEntity *_parent) -> bool
       {
-        const sdf::Collision& collision = _collElement->Data();
-
         if (_geom->Data().Type() == sdf::GeometryType::MESH)
         {
           const sdf::Mesh *meshSdf = _geom->Data().MeshShape();
@@ -214,7 +208,9 @@ void VisibilityPlugin::PostUpdate(
         auto fclAABB = it->second->getAABB();
 
         std::cout << _nameComp->Data() << std::endl;
-        std::cout << fclAABB.center()(0) << " " << fclAABB.center()(1) << " " << fclAABB.center()(2) << std::endl;
+        std::cout << fclAABB.center()[0] << " " 
+                  << fclAABB.center()[1] << " " 
+                  << fclAABB.center()[2] << std::endl;
         std::cout << _aabb->Data().Center().X() << " " << _aabb->Data().Center().Y()  << " " << _aabb->Data().Center().Z() << std::endl;
 
         return true;

--- a/subt_ign/src/VisibilityTable.cc
+++ b/subt_ign/src/VisibilityTable.cc
@@ -248,10 +248,6 @@ uint64_t VisibilityTable::Index(const ignition::math::Vector3d &_position) const
   }
   else 
   {
-    std::cerr << _position << " overlaps with tiles ";
-    for (auto const &id : result)
-      std::cerr << "[" << id << "], ";
-
     // Fall back to using FCL to find the closest mesh.
     auto box = std::make_shared<fcl::Box<float>>(0.01, 0.01, 0.01);
     auto boxObj = std::make_shared<fcl::CollisionObjectf>(box,  
@@ -285,7 +281,6 @@ uint64_t VisibilityTable::Index(const ignition::math::Vector3d &_position) const
       }
     }
 
-    std::cerr << closestIdx << " " << closestDist << std::endl;
     return closestIdx;
   }
 }
@@ -620,6 +615,7 @@ void VisibilityTable::BuildLUT()
 
   for (auto z = this->kMinZ; z <= this->kMaxZ; z += zstep)
   {
+    ignmsg << "Spawning worker thread: " << z << "-" << z+zstep << std::endl;
     workers.push_back(std::thread(functor, z, z + zstep));
   }
 

--- a/subt_ign/src/ign_to_fcl.cc
+++ b/subt_ign/src/ign_to_fcl.cc
@@ -16,7 +16,7 @@ namespace subt
 {
 
 std::shared_ptr<Model> 
-convert_to_fcl(const ignition::common::Mesh& mesh)
+convert_to_fcl(const ignition::common::Mesh &_mesh)
 {
   auto ret = std::make_shared<Model>();
 
@@ -25,8 +25,6 @@ convert_to_fcl(const ignition::common::Mesh& mesh)
   for (auto ii = 0u; ii < mesh.SubMeshCount(); ++ii)
   {
     auto submesh = mesh.SubMeshByIndex(ii).lock();
-    std::cout << submesh->VertexCount() << " " << submesh->IndexCount() << std::endl;
-
     std::vector<fcl::Vector3f> vertices;
     std::vector<fcl::Triangle> triangles;
 
@@ -58,8 +56,8 @@ convert_to_fcl(const ignition::common::Mesh& mesh)
 }
 
 std::shared_ptr<fcl::CollisionObjectf>
-convert_to_fcl(const ignition::common::Mesh& mesh,
-               const ignition::math::Pose3d& pose)
+convert_to_fcl(const ignition::common::Mesh &_mesh,
+               const ignition::math::Pose3d &_pose)
 {
   auto model = convert_to_fcl(mesh);
 
@@ -77,4 +75,4 @@ convert_to_fcl(const ignition::common::Mesh& mesh,
   return obj;
 }
 
-}
+}  // namespace subt

--- a/subt_ign/src/ign_to_fcl.cc
+++ b/subt_ign/src/ign_to_fcl.cc
@@ -1,9 +1,9 @@
 #include "ign_to_fcl.hh"
 
-#include <fcl/common/types.h>
-
-#include <fcl/math/triangle.h>
-#include <fcl/math/geometry.h>
+#include <fcl/config.h>
+#include <fcl/data_types.h>
+#include <fcl/math/matrix_3f.h>
+#include <fcl/math/vec_3f.h>
 
 #include <ignition/common/Mesh.hh>
 #include <ignition/common/SubMesh.hh>
@@ -22,10 +22,10 @@ convert_to_fcl(const ignition::common::Mesh &_mesh)
 
   ret->beginModel();
 
-  for (auto ii = 0u; ii < mesh.SubMeshCount(); ++ii)
+  for (auto ii = 0u; ii < _mesh.SubMeshCount(); ++ii)
   {
-    auto submesh = mesh.SubMeshByIndex(ii).lock();
-    std::vector<fcl::Vector3f> vertices;
+    auto submesh = _mesh.SubMeshByIndex(ii).lock();
+    std::vector<fcl::Vec3f> vertices;
     std::vector<fcl::Triangle> triangles;
 
     vertices.reserve(submesh->VertexCount());
@@ -33,7 +33,7 @@ convert_to_fcl(const ignition::common::Mesh &_mesh)
 
     for(size_t jj = 0; jj < submesh->VertexCount(); ++jj)
     {
-      vertices.push_back(fcl::Vector3f(
+      vertices.push_back(fcl::Vec3f(
             submesh->Vertex(jj).X(),
             submesh->Vertex(jj).Y(),
             submesh->Vertex(jj).Z()));
@@ -55,23 +55,23 @@ convert_to_fcl(const ignition::common::Mesh &_mesh)
   return ret;
 }
 
-std::shared_ptr<fcl::CollisionObjectf>
+std::shared_ptr<fcl::CollisionObject>
 convert_to_fcl(const ignition::common::Mesh &_mesh,
                const ignition::math::Pose3d &_pose)
 {
-  auto model = convert_to_fcl(mesh);
+  auto model = convert_to_fcl(_mesh);
 
-  Eigen::Matrix3f rot;
+  fcl::Matrix3f rot;
   for(size_t ii = 0; ii < 3; ++ii)
   {
     for(size_t jj = 0; jj < 3; ++jj)
     {
-      rot(ii, jj) = ignition::math::Matrix3d(pose.Rot())(ii, jj);
+      rot(ii, jj) = ignition::math::Matrix3d(_pose.Rot())(ii, jj);
     }
   }
 
-  auto obj = std::make_shared<fcl::CollisionObjectf>(model, rot, 
-      Eigen::Vector3f(pose.Pos().X(), pose.Pos().Y(), pose.Pos().Z()));
+  auto obj = std::make_shared<fcl::CollisionObject>(model, rot, 
+      fcl::Vec3f(_pose.Pos().X(), _pose.Pos().Y(), _pose.Pos().Z()));
   return obj;
 }
 

--- a/subt_ign/src/ign_to_fcl.cc
+++ b/subt_ign/src/ign_to_fcl.cc
@@ -1,0 +1,80 @@
+#include "ign_to_fcl.hh"
+
+#include <fcl/common/types.h>
+
+#include <fcl/math/triangle.h>
+#include <fcl/math/geometry.h>
+
+#include <ignition/common/Mesh.hh>
+#include <ignition/common/SubMesh.hh>
+
+#include <memory>
+#include <iostream>
+#include <vector>
+
+namespace subt
+{
+
+std::shared_ptr<Model> 
+convert_to_fcl(const ignition::common::Mesh& mesh)
+{
+  auto ret = std::make_shared<Model>();
+
+  ret->beginModel();
+
+  for (auto ii = 0u; ii < mesh.SubMeshCount(); ++ii)
+  {
+    auto submesh = mesh.SubMeshByIndex(ii).lock();
+    std::cout << submesh->VertexCount() << " " << submesh->IndexCount() << std::endl;
+
+    std::vector<fcl::Vector3f> vertices;
+    std::vector<fcl::Triangle> triangles;
+
+    vertices.reserve(submesh->VertexCount());
+    triangles.reserve(submesh->IndexCount() / 3);
+
+    for(size_t jj = 0; jj < submesh->VertexCount(); ++jj)
+    {
+      vertices.push_back(fcl::Vector3f(
+            submesh->Vertex(jj).X(),
+            submesh->Vertex(jj).Y(),
+            submesh->Vertex(jj).Z()));
+    }
+
+    for(size_t jj = 0; jj < submesh->IndexCount() / 3; jj += 3)
+    {
+      triangles.push_back(fcl::Triangle(
+            submesh->Index(jj),
+            submesh->Index(jj),
+            submesh->Index(jj)));
+    }
+
+    ret->addSubModel(vertices, triangles);
+  }
+
+  ret->endModel();
+
+  return ret;
+}
+
+std::shared_ptr<fcl::CollisionObjectf>
+convert_to_fcl(const ignition::common::Mesh& mesh,
+               const ignition::math::Pose3d& pose)
+{
+  auto model = convert_to_fcl(mesh);
+
+  Eigen::Matrix3f rot;
+  for(size_t ii = 0; ii < 3; ++ii)
+  {
+    for(size_t jj = 0; jj < 3; ++jj)
+    {
+      rot(ii, jj) = ignition::math::Matrix3d(pose.Rot())(ii, jj);
+    }
+  }
+
+  auto obj = std::make_shared<fcl::CollisionObjectf>(model, rot, 
+      Eigen::Vector3f(pose.Pos().X(), pose.Pos().Y(), pose.Pos().Z()));
+  return obj;
+}
+
+}

--- a/subt_ign/src/ign_to_fcl.hh
+++ b/subt_ign/src/ign_to_fcl.hh
@@ -1,9 +1,9 @@
 #ifndef IGN_TO_FCL_HH_
 #define IGN_TO_FCL_HH_
 
-#include <fcl/narrowphase/collision_object.h>
-#include <fcl/geometry/bvh/BVH_model.h>
-#include <fcl/math/bv/OBBRSS.h>
+#include <fcl/collision_object.h>
+#include <fcl/BVH/BVH_model.h>
+#include <fcl/BV/OBBRSS.h>
 
 #include <ignition/common/Mesh.hh>
 #include <ignition/math/Pose3.hh>
@@ -18,7 +18,7 @@ namespace subt
 /// BVH = Bounding Volume Heirarchy
 /// OBB = Oriented Bounding Box
 /// RSS = Rectange Swept Sphere
-using Model = fcl::BVHModel<fcl::OBBRSSf>;
+using Model = fcl::BVHModel<fcl::OBBRSS>;
 
 /// \brief Create an fcl model from an ignition mesh.
 ///
@@ -36,7 +36,7 @@ convert_to_fcl(const ignition::common::Mesh &_mesh);
 /// \param[in] _mesh mesh to convert to fcl model.
 /// \param[in] _pose world pose of the model.
 /// \return collision object when successfully converted otherwise nullptr
-std::shared_ptr<fcl::CollisionObjectf>
+std::shared_ptr<fcl::CollisionObject>
 convert_to_fcl(const ignition::common::Mesh &_mesh,
                const ignition::math::Pose3d &_pose);
 

--- a/subt_ign/src/ign_to_fcl.hh
+++ b/subt_ign/src/ign_to_fcl.hh
@@ -13,17 +13,33 @@
 namespace subt
 {
 
+/// \brief Convenience alias for the type of fcl model that is
+/// being used.  
+/// BVH = Bounding Volume Heirarchy
+/// OBB = Oriented Bounding Box
+/// RSS = Rectange Swept Sphere
 using Model = fcl::BVHModel<fcl::OBBRSSf>;
 
+/// \brief Create an fcl model from an ignition mesh.
+///
+/// Note that only triangle meshes are currently supported.
+///
+/// \param[in] _mesh mesh to convert to fcl model.
+/// \return model when successfully converted otherwise nullptr
 std::shared_ptr<Model> 
-convert_to_fcl(const ignition::common::Mesh& mesh);
+convert_to_fcl(const ignition::common::Mesh &_mesh);
 
+/// \brief Create an fcl CollisionObject from an ignition mesh+pose
+///
+/// Note that only triangle meshes are currently supported.
+///
+/// \param[in] _mesh mesh to convert to fcl model.
+/// \param[in] _pose world pose of the model.
+/// \return collision object when successfully converted otherwise nullptr
 std::shared_ptr<fcl::CollisionObjectf>
-convert_to_fcl(const ignition::common::Mesh& mesh,
-               const ignition::math::Pose3d& pose);
+convert_to_fcl(const ignition::common::Mesh &_mesh,
+               const ignition::math::Pose3d &_pose);
 
-}
+}  // namespace subt
 
-
-
-#endif
+#endif  // IGN_TO_FCL_HH_

--- a/subt_ign/src/ign_to_fcl.hh
+++ b/subt_ign/src/ign_to_fcl.hh
@@ -1,0 +1,29 @@
+#ifndef IGN_TO_FCL_HH_
+#define IGN_TO_FCL_HH_
+
+#include <fcl/narrowphase/collision_object.h>
+#include <fcl/geometry/bvh/BVH_model.h>
+#include <fcl/math/bv/OBBRSS.h>
+
+#include <ignition/common/Mesh.hh>
+#include <ignition/math/Pose3.hh>
+
+#include <subt_ign/VisibilityTypes.hh>
+
+namespace subt
+{
+
+using Model = fcl::BVHModel<fcl::OBBRSSf>;
+
+std::shared_ptr<Model> 
+convert_to_fcl(const ignition::common::Mesh& mesh);
+
+std::shared_ptr<fcl::CollisionObjectf>
+convert_to_fcl(const ignition::common::Mesh& mesh,
+               const ignition::math::Pose3d& pose);
+
+}
+
+
+
+#endif

--- a/subt_ign/src/validate_visibility_table.cc
+++ b/subt_ign/src/validate_visibility_table.cc
@@ -1,0 +1,51 @@
+/*
+ * Copyright (C) 2020 Open Source Robotics Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+
+#include "subt_ign/VisibilityTable.hh"
+
+using VisibilityTable = subt::VisibilityTable;
+
+int main(int argc, char **argv)
+{
+  if (argc != 2)
+  {
+    std::cerr << "Usage run_visibility_table <world>" << std::endl << std::endl;
+    std::cerr << "Example: ./run_visibility_table simple_cave_02" << std::endl;
+    return -1;
+  }
+
+  VisibilityTable visibilityTable;
+  visibilityTable.Load(argv[1], true);
+
+  // Uncomment for checking visibility table information. E.g.:
+
+  // auto tileId = visibilityTable.Index({90, 2.42, 0.26});
+  // auto tileId = visibilityTable.Index({29.59, 2.36, 0.77});
+  // std::cout << "Tile id: " << tileId << std::endl;
+
+  // Add relays. E.g.:
+  // visibilityTable.PopulateVisibilityInfo(
+  // {
+  //   {26.67, 103.91, 1.2}, // #11
+  //   {50, 125, 2},         // #3
+  //   {100, 125, 0},        // #5
+  // });
+
+  return 0;
+}
+


### PR DESCRIPTION
* Use threads to accelerate computation (distributing the space equally
across the threads)
* Split visiblity functionality into library to deduplicate compilation
* New validate_visibility_table cc file for main function
* Use FCL's distance function to disambiguate overlapped tile segments

Signed-off-by: Michael Carroll <michael@openrobotics.org>