### PR TITLE
Fix build order

### DIFF
--- a/subt_ros/CMakeLists.txt
+++ b/subt_ros/CMakeLists.txt
@@ -71,7 +71,7 @@ target_link_libraries(subt_ros_relay
     ignition-transport7::ignition-transport7
     ${catkin_LIBRARIES}
 )
-add_dependencies(subt_ros_relay ${catkin_EXPORTED_TARGETS})
+add_dependencies(subt_ros_relay ${${PROJECT_NAME}_EXPORTED_TARGETS} ${catkin_EXPORTED_TARGETS})
 
 add_executable(set_pose_relay src/SetPoseRelay.cc)
 target_include_directories(set_pose_relay


### PR DESCRIPTION
Messages need to be built before subt_ros_relay. This is a blocker for reliable workspace builds. Please merge ASAP!

I got this error today during docker image build. The error only shows sometimes as it is caused by build ordering. Building with a single build thread (in linear order) should reliably trigger the issue.

```
#50 126.2 Starting >>> subt_ros                                                          
Finished <<< subt_comms_test                                             [ 6.1 seconds ] 
Finished <<< subt_comms_relay                                            [ 25.4 seconds ]
_______________________________________________________________________________ke (21... 
#50 153.3 Errors << subt_ros:make /opt/ros/cras_subt/logs/subt_ros/build.make.000.log    
#50 153.3 /opt/ros/cras_subt/src/subt/subt_ros/src/SubtRosRelay.cc:33:10: fatal error: subt_ros/CompetitionClock.h: No such file or directory
#50 153.3  #include <subt_ros/CompetitionClock.h>
#50 153.3           ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~
#50 153.3 compilation terminated.
#50 153.3 make[2]: *** [CMakeFiles/subt_ros_relay.dir/src/SubtRosRelay.cc.o] Error 1
#50 153.3 make[1]: *** [CMakeFiles/subt_ros_relay.dir/all] Error 2
#50 153.3 make[1]: *** Waiting for unfinished jobs....
#50 153.3 make: *** [all] Error 2
```

As per http://wiki.ros.org/catkin/CMakeLists.txt#Important_Prerequisites.2FConstraints :

>     If you have a package which builds messages and/or services as well as executables that use these, you need to create an explicit dependency on the automatically-generated message target so that they are built in the correct order. (some_target is the name of the target set by add_executable()): 

>  `add_dependencies(some_target ${${PROJECT_NAME}_EXPORTED_TARGETS})`