### PR TITLE
Fix build order in subt_ign

### DIFF
--- a/subt_ign/CMakeLists.txt
+++ b/subt_ign/CMakeLists.txt
@@ -19,7 +19,7 @@ find_package(catkin REQUIRED
     subt_rf_interface
     subt_communication_model
     subt_communication_broker
-    subt_msgs
+    subt_ros
 )
 
 find_package(ignition-gazebo2 2.1 QUIET REQUIRED)

--- a/subt_ign/package.xml
+++ b/subt_ign/package.xml
@@ -17,6 +17,7 @@
   <depend>subt_rf_interface</depend>
   <depend>subt_communication_model</depend>
   <depend>subt_communication_broker</depend>
+  <depend>subt_ros</depend>
 
   <depend>libccd-dev</depend>
   <depend>libfcl-dev</depend>


### PR DESCRIPTION
#602 broke clean build. The newly added messages are in subt_ros, not in subt_msgs. This PR fixes it.