### PR TITLE
Fix build error in subt_example (citadel branch)

### DIFF
--- a/subt_example/CMakeLists.txt
+++ b/subt_example/CMakeLists.txt
@@ -46,7 +46,7 @@ add_executable(teleop_node src/teleop_node.cc)
 add_dependencies(teleop_node ${catkin_EXPORTED_TARGETS})
 target_link_libraries(teleop_node ${catkin_LIBRARIES})
 
-add_subdirectory(src/truth_controller)
+#add_subdirectory(src/truth_controller)
 
 
 ###########

--- a/subt_example/CMakeLists.txt
+++ b/subt_example/CMakeLists.txt
@@ -46,8 +46,6 @@ add_executable(teleop_node src/teleop_node.cc)
 add_dependencies(teleop_node ${catkin_EXPORTED_TARGETS})
 target_link_libraries(teleop_node ${catkin_LIBRARIES})
 
-#add_subdirectory(src/truth_controller)
-
 
 ###########
 ## Tests ##


### PR DESCRIPTION
When I was using the `citadel` branch for communications visualization, the build failed on `subt_example` due to what appears to be an extra `add_subdirectory` call in [subt_example/CMakeLists.txt](https://github.com/osrf/subt/blob/c02b75337495e4e22851683a450a076cac9c086e/subt_example/CMakeLists.txt#L49). I have removed this call to fix the build - it looks like the `master` branch [doesn't use this `add_subdirectory` call](https://github.com/osrf/subt/blob/master/subt_example/CMakeLists.txt) either.

Signed-off-by: Ashton Larkin <ashton@openrobotics.org>