### PR TITLE
Robotika Kloubak K2 - fix lights

### DIFF
--- a/submitted_models/robotika_kloubak_sensor_config_1/model.sdf
+++ b/submitted_models/robotika_kloubak_sensor_config_1/model.sdf
@@ -222,7 +222,7 @@
             </geometry>
         </collision>
         <light name="light_front" type="spot">
-            <pose>0.16 0 0.29 0 0 0</pose>
+            <pose>0.16 0 0.29 0 -1.5707963267948966 0</pose>
             <attenuation>
                 <range>25</range>
                 <linear>0</linear>
@@ -547,7 +547,7 @@
             </geometry>
         </collision>
        <light name="light_back" type="spot">
-            <pose>-0.17 0 0.35 0 0 3.1415927</pose>
+            <pose>-0.17 0 0.35 0 1.5707963267948966 0</pose>
             <attenuation>
                 <range>25</range>
                 <linear>0</linear>


### PR DESCRIPTION
This is a fix of lights for Robotika robot Kloubak. There was the same copy and paste error as for robot Freyja (#588).
thank you
   Martin/Robotika Team
p.s. current view from robot camera on CloudSim is this:

![saveX-0000](https://user-images.githubusercontent.com/5664353/97033588-df771100-1563-11eb-9870-361d2418e52a.jpg)
