### PR TITLE
Update position of lights on side of Explorer X1 robot models

### DIFF
--- a/submitted_models/explorer_x1_sensor_config_1/model.sdf
+++ b/submitted_models/explorer_x1_sensor_config_1/model.sdf
@@ -708,7 +708,7 @@
         <cast_shadows>1</cast_shadows>
       </light>
       <light name="lateral_left_front_headlight_body_light_source_light" type="spot">
-        <pose frame="">0.2499796936688763 0.334 0.155 3.14159 1.56859 1.5715899999999998</pose>
+        <pose frame="">0.2499796936688763 0.36 0.155 3.14159 1.56859 1.5715899999999998</pose>
         <attenuation>
           <range>50</range>
           <linear>0</linear>
@@ -726,7 +726,7 @@
         <cast_shadows>1</cast_shadows>
       </light>
       <light name="lateral_left_rear_headlight_body_light_source_light" type="spot">
-        <pose frame="">-0.2500203063311236 0.334 0.155 3.14159 1.56859 1.5715899999999998</pose>
+        <pose frame="">-0.2500203063311236 0.36 0.155 3.14159 1.56859 1.5715899999999998</pose>
         <attenuation>
           <range>50</range>
           <linear>0</linear>
@@ -744,7 +744,7 @@
         <cast_shadows>1</cast_shadows>
       </light>
       <light name="lateral_right_front_headlight_body_light_source_light" type="spot">
-        <pose frame="">0.2499796936688763 -0.334 0.155 3.14159 1.56859 -1.5715953071795865</pose>
+        <pose frame="">0.2499796936688763 -0.36 0.155 3.14159 1.56859 -1.5715953071795865</pose>
         <attenuation>
           <range>50</range>
           <linear>0</linear>
@@ -762,7 +762,7 @@
         <cast_shadows>1</cast_shadows>
       </light>
       <light name="lateral_right_rear_headlight_body_light_source_light" type="spot">
-        <pose frame="">-0.2500203063311236 -0.334 0.155 3.14159 1.56859 -1.5715953071795865</pose>
+        <pose frame="">-0.2500203063311236 -0.36 0.155 3.14159 1.56859 -1.5715953071795865</pose>
         <attenuation>
           <range>50</range>
           <linear>0</linear>

--- a/submitted_models/explorer_x1_sensor_config_2/model.sdf
+++ b/submitted_models/explorer_x1_sensor_config_2/model.sdf
@@ -708,7 +708,7 @@
         <cast_shadows>1</cast_shadows>
       </light>
       <light name="lateral_left_front_headlight_body_light_source_light" type="spot">
-        <pose frame="">0.2499796936688763 0.334 0.155 3.14159 1.56859 1.5715899999999998</pose>
+        <pose frame="">0.2499796936688763 0.36 0.155 3.14159 1.56859 1.5715899999999998</pose>
         <attenuation>
           <range>50</range>
           <linear>0</linear>
@@ -726,7 +726,7 @@
         <cast_shadows>1</cast_shadows>
       </light>
       <light name="lateral_left_rear_headlight_body_light_source_light" type="spot">
-        <pose frame="">-0.2500203063311236 0.334 0.155 3.14159 1.56859 1.5715899999999998</pose>
+        <pose frame="">-0.2500203063311236 0.36 0.155 3.14159 1.56859 1.5715899999999998</pose>
         <attenuation>
           <range>50</range>
           <linear>0</linear>
@@ -744,7 +744,7 @@
         <cast_shadows>1</cast_shadows>
       </light>
       <light name="lateral_right_front_headlight_body_light_source_light" type="spot">
-        <pose frame="">0.2499796936688763 -0.334 0.155 3.14159 1.56859 -1.5715953071795865</pose>
+        <pose frame="">0.2499796936688763 -0.36 0.155 3.14159 1.56859 -1.5715953071795865</pose>
         <attenuation>
           <range>50</range>
           <linear>0</linear>
@@ -762,7 +762,7 @@
         <cast_shadows>1</cast_shadows>
       </light>
       <light name="lateral_right_rear_headlight_body_light_source_light" type="spot">
-        <pose frame="">-0.2500203063311236 -0.334 0.155 3.14159 1.56859 -1.5715953071795865</pose>
+        <pose frame="">-0.2500203063311236 -0.36 0.155 3.14159 1.56859 -1.5715953071795865</pose>
         <attenuation>
           <range>50</range>
           <linear>0</linear>


### PR DESCRIPTION
The lateral lights on Explorer X1 models are found to be embedded inside the wheels. At certain camera viewing angles, the rendering engine thinks the lights are completely occluded and so the lights become disabled. This fix is to move the lights slightly outside the wheels so it does not get occluded. 

The red cubes in the screenshot below represent old pose of lights on the side of the robot:

![explorer_light_pose](https://user-images.githubusercontent.com/4000684/98047185-5d4ae000-1de0-11eb-90c5-2a020f74c5a1.png)

It was found that the issue is mostly in the GUI camera. As shown in the screenshot below, the light is not visible in the GUI camera but appears fine in the left camera sensor view:

![explorer_x1_camera_sensor_view](https://user-images.githubusercontent.com/4000684/98047440-be72b380-1de0-11eb-9f17-b2e98442b887.png)

Once this is merged, we'll also need to update the models on Fuel

Signed-off-by: Ian Chen <ichen@osrfoundation.org>