### PR TITLE
Support aws cli 2.0

### DIFF
--- a/subt_ign/scripts/subt_docker_list.bash
+++ b/subt_ign/scripts/subt_docker_list.bash
@@ -25,7 +25,15 @@ fi
 
 # Log into docker
 echo "Logging into docker"
-$(aws ecr get-login --no-include-email --region us-east-1)
+awsVersion=`aws --version`
+if [[ "$awsVersion" == *"aws-cli/1"* ]]; then
+  $(aws ecr get-login --no-include-email --region us-east-1)
+elif [[ "$awsVersion" == *"aws-cli/2"* ]]; then
+  aws ecr get-login-password --region us-east-1 | docker login --username AWS --password-stdin 200670743174.dkr.ecr.us-east-1.amazonaws.com
+else
+    echo "Unsupported aws cli version $awsVersion"
+  exit
+fi
 
 if [ $? != 0 ]; then
   echo "Failed to log into docker. Check your AWS credentials."


### PR DESCRIPTION
This should support both aws CLI 1.0 and 2.0.

Signed-off-by: Nate Koenig <nate@openrobotics.org>