### PR TITLE
Fix world files to follow SDF spec

### DIFF
--- a/submitted_models/marble_hd2_sensor_config_1/model.sdf
+++ b/submitted_models/marble_hd2_sensor_config_1/model.sdf
@@ -329,7 +329,7 @@
                           <stddev>0.03</stddev>
                         </noise>
                       </lidar>
-                      <pose frame="">0.403 0 0.36 0 -0 </pose>
+                      <pose frame="">0.403 0 0.36 0 -0 0</pose>
                     </sensor>
                     <sensor name="imu_sensor" type="imu">
                       <always_on>1</always_on>

--- a/subt_ign/worlds/cave_circuit/04/cave_circuit_04.sdf
+++ b/subt_ign/worlds/cave_circuit/04/cave_circuit_04.sdf
@@ -175,12 +175,6 @@
     <gravity>0 0 -9.8</gravity>
     <magnetic_field>6e-06 2.3e-05 -4.2e-05</magnetic_field>
     <atmosphere type='adiabatic'/>
-    <plugin name='ignition::gazebo::systems::LogRecord' filename='libignition-gazebo2-log-system.so'>
-      <path>/tmp/ign/logs</path>
-      <record_resources>0</record_resources>
-      <compress>0</compress>
-      <compress_path/>
-    </plugin>
     <include>
       <uri>https://fuel.ignitionrobotics.org/1.0/OpenRobotics/models/Cave Starting Area Type B</uri>
       <name>staging_area</name>

--- a/subt_ign/worlds/cave_circuit/07/cave_circuit_07.sdf
+++ b/subt_ign/worlds/cave_circuit/07/cave_circuit_07.sdf
@@ -548,7 +548,7 @@
 
     <include>
       <name>backpack_1</name>
-      <pose>137.575000 3.746030 24.923800</pose>
+      <pose>137.575000 3.746030 24.923800 0 0 0</pose>
       <uri>https://fuel.ignitionrobotics.org/1.0/OpenRobotics/models/JanSport Backpack Red</uri>
     </include>
     <include>

--- a/subt_ign/worlds/cave_circuit_practice_02.sdf
+++ b/subt_ign/worlds/cave_circuit_practice_02.sdf
@@ -79,7 +79,7 @@
     <!--Performer detector at Rock Fall #2 in tile_8-->
     <model name="performer_detector_rockfall_2">
       <static>true</static>
-      <pose>785.201000 -25.106900 -47.35 0.0 0.0</pose>
+      <pose>785.201000 -25.106900 -47.35 0.0 0.0 0.0</pose>
       <!-- Uncomment to visualize performer detector-->
       <!--<link name='body'>
         <visual name="v1">

--- a/subt_ign/worlds/simple_cave_03.sdf
+++ b/subt_ign/worlds/simple_cave_03.sdf
@@ -75,7 +75,7 @@
     <include>
       <name>phone_2</name>
       <uri>https://fuel.ignitionrobotics.org/1.0/OpenRobotics/models/Samsung J8 Black</uri>
-      <pose>181.653811 -135.754 -29.8343 -1.71650 0.000000</pose>
+      <pose>181.653811 -135.754 -29.8343 -1.71650 0.000000 0.0</pose>
     </include>
 
     <include>


### PR DESCRIPTION
A few world files had missing pose elements. Cave circuit 04 world had an plugin that can be removed.

Signed-off-by: Nate Koenig <nate@openrobotics.org>