### PR TITLE
Call rosdep install from cloudsim dockerfiles

### DIFF
--- a/docker/cloudsim_bridge/Dockerfile
+++ b/docker/cloudsim_bridge/Dockerfile
@@ -90,14 +90,19 @@ RUN mkdir ~/workspaces ~/other
 # When running a container start in the developer's home folder
 WORKDIR /home/$USERNAME
 
-RUN rosdep update
-
 # Clone all the subt models so that you don't download them every time
 # docker is run
 RUN mkdir -p subt_ws/src \
  && cd subt_ws/src \
  && git config --global http.postBuffer 1048576000 \
  && git clone https://github.com/osrf/subt
+
+# Install dependencies
+RUN . /opt/ros/melodic/setup.sh \
+ && rosdep update \
+ && sudo apt-get update \
+ && rosdep install -y --from-paths . --ignore-src -r \
+ && sudo apt-get clean -qq
 
 WORKDIR /home/$USERNAME/subt_ws
 

--- a/docker/cloudsim_sim/Dockerfile
+++ b/docker/cloudsim_sim/Dockerfile
@@ -90,13 +90,18 @@ RUN mkdir ~/workspaces ~/other
 # When running a container start in the developer's home folder
 WORKDIR /home/$USERNAME
 
-RUN rosdep update
-
 # Install subt sim
 RUN mkdir -p subt_ws/src \
  && cd subt_ws/src \
  && git config --global http.postBuffer 1048576000 \
  && git clone https://github.com/osrf/subt
+
+# Install dependencies
+RUN . /opt/ros/melodic/setup.sh \
+ && rosdep update \
+ && sudo apt-get update \
+ && rosdep install -y --from-paths . --ignore-src -r \
+ && sudo apt-get clean -qq
 
 WORKDIR /home/$USERNAME/subt_ws
 


### PR DESCRIPTION
I guess this is the way to get a catkin workspace correctly up and running. Not utilizing rosdep leads to manual management of several lists of packages, which is highly error-prone.

This IMHO offers a better solution to #731 than #732 (because somebody has already specified that `subt_ros` package depends on `compressed_image_transport` as an exec dependency).

I tried building the Dockerfiles and they both build fine.

In cloudsim_sim image, the rosdep call installs:

```
executing command [sudo -H apt-get install -y ros-melodic-joint-trajectory-controller]
executing command [sudo -H apt-get install -y ros-melodic-controller-manager]
executing command [sudo -H apt-get install -y ros-melodic-diff-drive-controller]
executing command [sudo -H apt-get install -y ros-melodic-multimaster-launch]
executing command [sudo -H apt-get install -y ros-melodic-interactive-marker-twist-server]
executing command [sudo -H apt-get install -y ros-melodic-lms1xx]
executing command [sudo -H apt-get install -y ros-melodic-teleop-twist-joy]
executing command [sudo -H apt-get install -y ros-melodic-joint-state-controller]
```

In cloudsim_bridge, it installs:

```
executing command [sudo -H apt-get install -y ros-melodic-joint-trajectory-controller]
executing command [sudo -H apt-get install -y ros-melodic-controller-manager]
executing command [sudo -H apt-get install -y ros-melodic-diff-drive-controller]
executing command [sudo -H apt-get install -y ros-melodic-multimaster-launch]
executing command [sudo -H apt-get install -y ros-melodic-interactive-marker-twist-server]
executing command [sudo -H apt-get install -y ros-melodic-lms1xx]
executing command [sudo -H apt-get install -y ros-melodic-teleop-twist-joy]
executing command [sudo -H apt-get install -y ros-melodic-joint-state-controller]
```