### PR TITLE
More space-efficient subt_models Dockerfile

### DIFF
--- a/docker/subt_models/Dockerfile
+++ b/docker/subt_models/Dockerfile
@@ -20,12 +20,6 @@ RUN /bin/sh -c 'echo "deb [trusted=yes] http://packages.osrfoundation.org/gazebo
  && /bin/sh -c 'wget http://packages.osrfoundation.org/gazebo.key -O - | apt-key add -' \
  && /bin/sh -c 'apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-key C1CF6E31E6BADE8868B172B4F42ED6FBAB17C654'
 
-# install ign-dome
-RUN apt-get update \
-&&  apt-get install -y \
-    ignition-dome \
- && apt-get clean
-
 # Add a user with the same user_id as the user outside the container
 # Requires a docker build argument `user_id`
 ARG user_id
@@ -41,9 +35,11 @@ USER $USERNAME
 # When running a container start in the developer's home folder
 WORKDIR /home/$USERNAME
 
-# Download the public models
-RUN ign fuel download -v 4 -j 8 --type model -u "https://fuel.ignitionrobotics.org/OpenRobotics/collections/SubT Tech Repo"
-
-# Cleanup ignition
-RUN sudo apt-get remove ignition-dome -y \
+# install ign-dome, download the public models, and uninstall ign-dome again to keep the image smaller
+RUN sudo apt-get update \
+ && sudo apt-get install -y \
+    libignition-fuel-tools5-dev \
+ && ign fuel download -v 4 -j 8 --type model -u "https://fuel.ignitionrobotics.org/OpenRobotics/collections/SubT Tech Repo" \
+ && sudo apt-get remove libignition-fuel-tools5-dev -y \
+ && sudo apt-get autoremove -y \
  && sudo apt-get clean


### PR DESCRIPTION
This just moves all the space-wasting operations into a single Docker layer so that we do not needlessly store a layer with files which just get deleted a few steps further.

It also speeds up the installation by just installing ign-fuel-tools instead of whole ignition-dome.

Last, `apt-get autoremove` is called after uninstalling the temporary package, because otherwise, all of the packages installed as dependencies remain, which is probably unwanted.

This PR decreases total size of the models image from 5.5 GB to 4.5 GB. Taken into account that it is based on a 400 MB opengl image and downloads 3.6 GB of model data, the overhead is just 500 MB (most of which is an install of gcc-7 which is somehow pulled in but not uninstalled by autoremove... I didn't want to explicitly touch it).