### PR TITLE
VLP-16 horizontal resolution and rate on submitted models

### DIFF
--- a/submitted_models/cerberus_anymal_b_sensor_config_1/model.sdf
+++ b/submitted_models/cerberus_anymal_b_sensor_config_1/model.sdf
@@ -304,9 +304,7 @@
         <lidar>
           <scan>
             <horizontal>
-              <!-- Resolution can't be above 16k, see
-              https://bitbucket.org/ignitionrobotics/ign-sensors/issues/8 -->
-              <samples>10000</samples>
+              <samples>1800</samples>
               <resolution>0.1</resolution>
               <min_angle>-3.1459</min_angle>
               <max_angle>3.1459</max_angle>

--- a/submitted_models/cerberus_gagarin_sensor_config_1/model.sdf
+++ b/submitted_models/cerberus_gagarin_sensor_config_1/model.sdf
@@ -257,8 +257,6 @@
                 <lidar>
                     <scan>
                         <horizontal>
-                            <!-- Resolution can't be above 16k, see
-                            https://bitbucket.org/ignitionrobotics/ign-sensors/issues/8 -->
                             <samples>512</samples>
                             <resolution>1</resolution>
                             <min_angle>-3.14159</min_angle>

--- a/submitted_models/cerberus_m100_sensor_config_1/model.sdf
+++ b/submitted_models/cerberus_m100_sensor_config_1/model.sdf
@@ -258,9 +258,7 @@
                 <lidar>
                     <scan>
                         <horizontal>
-                            <!-- Resolution can't be above 16k, see
-                            https://bitbucket.org/ignitionrobotics/ign-sensors/issues/8 -->
-                            <samples>10000</samples>
+                            <samples>1800</samples>
                             <resolution>0.1</resolution>
                             <min_angle>-3.1459</min_angle>
                             <max_angle>3.1459</max_angle>

--- a/submitted_models/costar_husky_sensor_config_1/model.sdf
+++ b/submitted_models/costar_husky_sensor_config_1/model.sdf
@@ -286,9 +286,7 @@
         <lidar>
           <scan>
             <horizontal>
-              <!-- Resolution can't be above 16k, see
-              https://bitbucket.org/ignitionrobotics/ign-sensors/issues/8 -->
-              <samples>10000</samples>
+              <samples>1800</samples>
               <resolution>0.1</resolution>
               <min_angle>-3.1459</min_angle>
               <max_angle>3.1459</max_angle>

--- a/submitted_models/costar_husky_sensor_config_2/model.sdf
+++ b/submitted_models/costar_husky_sensor_config_2/model.sdf
@@ -286,9 +286,7 @@
         <lidar>
           <scan>
             <horizontal>
-              <!-- Resolution can't be above 16k, see
-              https://bitbucket.org/ignitionrobotics/ign-sensors/issues/8 -->
-              <samples>10000</samples>
+              <samples>1800</samples>
               <resolution>0.1</resolution>
               <min_angle>-3.1459</min_angle>
               <max_angle>3.1459</max_angle>

--- a/submitted_models/explorer_ds1_sensor_config_1/model.sdf
+++ b/submitted_models/explorer_ds1_sensor_config_1/model.sdf
@@ -578,11 +578,11 @@
             <sensor name="front_laser" type="gpu_lidar">
                 <pose>0.18 0 0.284 5e-06 0 0 -0 0</pose>
                 <always_on>1</always_on>
-                <update_rate>15</update_rate>
+                <update_rate>10</update_rate>
                 <ray>
                     <scan>
                         <horizontal>
-                        <samples>10000</samples>
+                        <samples>1800</samples>
                         <resolution>0.1</resolution>
                         <min_angle>-3.14159</min_angle>
                         <max_angle>3.14159</max_angle>

--- a/submitted_models/explorer_r2_sensor_config_1/model.sdf
+++ b/submitted_models/explorer_r2_sensor_config_1/model.sdf
@@ -190,11 +190,11 @@
       <sensor name="front_laser" type="gpu_lidar">
         <pose>0.37 0 0.55 0 0 0</pose>
         <always_on>1</always_on>
-        <update_rate>15</update_rate>
+        <update_rate>10</update_rate>
         <ray>
           <scan>
             <horizontal>
-              <samples>10000</samples>
+              <samples>1800</samples>
               <resolution>0.1</resolution>
               <min_angle>-3.14159</min_angle>
               <max_angle>3.14159</max_angle>

--- a/submitted_models/explorer_x1_sensor_config_1/model.sdf
+++ b/submitted_models/explorer_x1_sensor_config_1/model.sdf
@@ -571,13 +571,11 @@
       </sensor>
       <gravity>1</gravity>
       <sensor name="front_laser" type="gpu_lidar">
-        <update_rate>15</update_rate>
+        <update_rate>10</update_rate>
         <lidar>
           <scan>
             <horizontal>
-              <!-- Resolution can't be above 16k, see
-              https://bitbucket.org/ignitionrobotics/ign-sensors/issues/8 -->
-              <samples>10000</samples>
+              <samples>1800</samples>
               <resolution>0.1</resolution>
               <min_angle>-3.14159</min_angle>
               <max_angle>3.14159</max_angle>

--- a/submitted_models/explorer_x1_sensor_config_2/model.sdf
+++ b/submitted_models/explorer_x1_sensor_config_2/model.sdf
@@ -571,13 +571,11 @@
       </sensor>
       <gravity>1</gravity>
       <sensor name="front_laser" type="gpu_lidar">
-        <update_rate>15</update_rate>
+        <update_rate>10</update_rate>
         <lidar>
           <scan>
             <horizontal>
-              <!-- Resolution can't be above 16k, see
-              https://bitbucket.org/ignitionrobotics/ign-sensors/issues/8 -->
-              <samples>10000</samples>
+              <samples>1800</samples>
               <resolution>0.1</resolution>
               <min_angle>-3.14159</min_angle>
               <max_angle>3.14159</max_angle>

--- a/submitted_models/marble_hd2_sensor_config_1/model.sdf
+++ b/submitted_models/marble_hd2_sensor_config_1/model.sdf
@@ -304,8 +304,6 @@
         <lidar>
           <scan>
             <horizontal>
-              <!-- Resolution can't be above 16k, see
-              https://bitbucket.org/ignitionrobotics/ign-sensors/issues/8 -->
                             <samples>1024</samples>
                             <resolution>1</resolution>
                             <min_angle>-3.1459</min_angle>

--- a/submitted_models/marble_husky_sensor_config_1/model.sdf
+++ b/submitted_models/marble_husky_sensor_config_1/model.sdf
@@ -408,8 +408,6 @@
         <lidar>
           <scan>
             <horizontal>
-              <!-- Resolution can't be above 16k, see
-              https://bitbucket.org/ignitionrobotics/ign-sensors/issues/8 -->
               <samples>1024</samples>
               <resolution>1</resolution>
               <min_angle>-3.1459</min_angle>

--- a/submitted_models/marble_qav500_sensor_config_1/model.sdf
+++ b/submitted_models/marble_qav500_sensor_config_1/model.sdf
@@ -386,8 +386,6 @@
                 <lidar>
                     <scan>
                         <horizontal>
-                            <!-- Resolution can't be above 16k, see
-                            https://bitbucket.org/ignitionrobotics/ign-sensors/issues/8 -->
                             <samples>1024</samples>
                             <resolution>1</resolution>
                             <min_angle>-3.1459</min_angle>

--- a/submitted_models/ssci_x4_sensor_config_1/model.sdf
+++ b/submitted_models/ssci_x4_sensor_config_1/model.sdf
@@ -335,13 +335,11 @@
 					We believe this is based on a Velodyne Puck Lite 
 					which weighs 590 g -->
                 <pose>0 0 -0.05 0 0 0</pose>
-                <update_rate>15</update_rate>
+                <update_rate>10</update_rate>
                 <lidar>
                     <scan>
                         <horizontal>
-                            <!-- Resolution can't be above 16k, see
-                            https://bitbucket.org/ignitionrobotics/ign-sensors/issues/8 -->
-                            <samples>10000</samples>
+                            <samples>1800</samples>
                             <resolution>0.1</resolution>
                             <min_angle>-3.1459</min_angle>
                             <max_angle>3.1459</max_angle>

--- a/submitted_models/x1_sensor_config_6/model.sdf
+++ b/submitted_models/x1_sensor_config_6/model.sdf
@@ -365,13 +365,11 @@
             </visual>
             <sensor name="front_laser" type="gpu_ray">
                 <pose>0.08 0 0.394 0 0 0</pose>
-                <update_rate>15</update_rate>
+                <update_rate>10</update_rate>
                 <lidar>
                     <scan>
                         <horizontal>
-                            <!-- Resolution can't be above 16k, see
-                            https://bitbucket.org/ignitionrobotics/ign-sensors/issues/8 -->
-                            <samples>10000</samples>
+                            <samples>1800</samples>
                             <resolution>0.1</resolution>
                             <min_angle>-3.1459</min_angle>
                             <max_angle>3.1459</max_angle>

--- a/submitted_models/x2_sensor_config_7/model.sdf
+++ b/submitted_models/x2_sensor_config_7/model.sdf
@@ -279,13 +279,11 @@
             </visual>
             <sensor name="front_laser" type="gpu_ray">
                 <pose>0.0 0 0.27 0 -0 0</pose>
-                <update_rate>15</update_rate>
+                <update_rate>10</update_rate>
                 <lidar>
                     <scan>
                         <horizontal>
-                            <!-- Resolution can't be above 16k, see
-                            https://bitbucket.org/ignitionrobotics/ign-sensors/issues/8 -->
-                            <samples>10000</samples>
+                            <samples>1800</samples>
                             <resolution>0.1</resolution>
                             <min_angle>-3.1459</min_angle>
                             <max_angle>3.1459</max_angle>


### PR DESCRIPTION
These changes only apply to models in the `submitted_models` folder.

I tested all changes to LIDAR parameters by checking the `points` topic with `rostopic echo <topic_name> --noarr` and visual inspection in RViz.