### PR TITLE
Remove the model database from cloudsim_bridge image because it doesn't need it for anything.

### DIFF
--- a/docker/cloudsim_bridge/Dockerfile
+++ b/docker/cloudsim_bridge/Dockerfile
@@ -1,5 +1,33 @@
 # Ubuntu 18.04 with nvidia-docker2 beta opengl support
-FROM osrf/subt-virtual-testbed:models_latest
+#FROM osrf/subt-virtual-testbed:models_latest
+FROM nvidia/opengl:1.0-glvnd-devel-ubuntu18.04
+
+RUN export DEBIAN_FRONTEND=noninteractive \
+ && apt-get update \
+ && apt-get install --no-install-recommends -y \
+    tzdata \
+    sudo \
+    wget \
+    gnupg \
+    lsb-release \
+ && ln -fs /usr/share/zoneinfo/America/Los_Angeles /etc/localtime \
+ && dpkg-reconfigure --frontend noninteractive tzdata \
+ && apt-get clean
+
+# Add a user with the same user_id as the user outside the container
+# Requires a docker build argument `user_id`
+ARG user_id
+ENV USERNAME developer
+RUN useradd -U --uid ${user_id} -ms /bin/bash $USERNAME \
+ && echo "$USERNAME:$USERNAME" | chpasswd \
+ && adduser $USERNAME sudo \
+ && echo "$USERNAME ALL=NOPASSWD: ALL" >> /etc/sudoers.d/$USERNAME
+
+# Commands below run as the developer user
+USER $USERNAME
+
+# When running a container start in the developer's home folder
+WORKDIR /home/$USERNAME
 
 # Tools I find useful during development
 RUN sudo apt-get update -qq \


### PR DESCRIPTION
This will get the overall size of bridge image down to 8 GB (from 12 GB). Smaller images are said to be faster in Docker (not sure about the newest versions, though).

As the models are only actually needed in the cloudsim_sim image (if I'm not missing something), the bridge container could then become the suggested base of solution images (and e.g. subt_hello_world images).

This is another take at #700. It can be combined with #749 to further decrease size of the image.