### PR TITLE
Better support running from a local catkin workspace

### DIFF
--- a/subt_ign/launch/cloudsim_sim.ign
+++ b/subt_ign/launch/cloudsim_sim.ign
@@ -46,6 +46,12 @@
   else
     $circuit = circuit
   end
+
+  if !defined?(logPath) || logPath == nil || logPath.empty?
+    $logPath = '/tmp/ign/logs'
+  else
+    $logPath = logPath
+  end
 %>
 
 <%
@@ -340,7 +346,7 @@
     <record>
       <enabled>true</enabled>
       <!-- This path is used by cloudsim, please do not change -->
-      <path>/tmp/ign/logs</path>
+      <path><%= $logPath %></path>
       <overwrite>true</overwrite>
     </record>
     <%if defined?(seed) && seed != nil && !seed.empty?%>
@@ -401,7 +407,7 @@
       <logging>
         <!-- Use the <path> element to control where to record the log file.
              The HOME path is used by default -->
-        <path>/tmp/ign/logs</path>
+        <path><%= $logPath %></path>
         <filename_prefix>subt_<%= $circuit %></filename_prefix>
         <elevation_step_size>5</elevation_step_size>
       </logging>

--- a/subt_ign/src/GameLogicPlugin.cc
+++ b/subt_ign/src/GameLogicPlugin.cc
@@ -696,7 +696,8 @@ void GameLogicPlugin::Configure(const ignition::gazebo::Entity & /*_entity*/,
       // Setup a ros bag recorder.
       rosbag::RecorderOptions recorderOptions;
       recorderOptions.append_date=false;
-      recorderOptions.prefix="/tmp/ign/logs/cloudsim";
+      recorderOptions.prefix = ignition::common::joinPaths(
+        this->dataPtr->logPath, "cloudsim");
       recorderOptions.regex=true;
       recorderOptions.topics.push_back("/subt/.*");
 

--- a/subt_ros/src/SubtRosRelay.cc
+++ b/subt_ros/src/SubtRosRelay.cc
@@ -240,7 +240,17 @@ SubtRosRelay::SubtRosRelay()
   // http://docs.ros.org/en/noetic/api/rosbag/html/c++/record_8cpp_source.html
   recorderOptions.max_size=1048576 * 1000;
 
+  // Prefix the rosbag file(s) name with a prefix composed of robot_data, the
+  // IGN_PARTITION (if set), and the list of robots that generate this data.
+  // This allows running multiple simulations of multiple robots even on
+  // local catkin workspace.
+  std::string part;
+  ignition::common::env("IGN_PARTITION", part);
   recorderOptions.prefix="robot_data";
+  if (!part.empty())
+    recorderOptions.prefix += "_" + part;
+  recorderOptions.prefix += "_" + stringNames;
+
   recorderOptions.regex=true;
   recorderOptions.topics.push_back("/robot_data(.*)");
 


### PR DESCRIPTION
Currently, running a multirobot simulation (or multiple simulations) directly from local catkin workspace has its quirks. This PR addresses them.

1. robot_data bag files need to have a different name for different robots (and simulation partitions)... otherwise, all robots try to record to `~/.ros/robot_data_0.bag`, and only one of them obviously succeeds.
2. ignition log files (currently hardcoded to `/tmp/ign/logs`) need a configurable location, so that multiple simultaneous simulations do not write into the same folder.
3. The "simulator rosbag" needs to respect the path set in point 2. (currently, it hard-codes `/tmp/ign/logs` regardless of the `<path>` setting of GameLogicPlugin)

I think I saw some initiative towards 2. somewhere (passing a CLI arg with the path instead of having it hardcoded in the launch file), but I can't remember where it was.

Also, the parametrization of ign launch files with the log path would need to modify all of the provided files. I modified just cloudsim_sim.ign, and when we agree whether it's a good approach, I'd modify all of them.

The renaming of robot rosbags might break backwards compatibility for Docker users - the names of the files would change. I'm not sure if this is acceptable or not, but I can imagine some workarounds that would keep the original name if Docker environment is detected (e.g. matching `$USERNAME == developer`, or checking for nonempty `IGN_PARTITION`). Local catkin workspace users would also be affected, but as they were using broken logic anyways, it shouldn't actually hurt them.