### PR TITLE
Constrain the list of topics bridge_logger subscribes to to only those actually published by some vehicle_topics.launch file

### DIFF
--- a/subt_ros/CMakeLists.txt
+++ b/subt_ros/CMakeLists.txt
@@ -69,7 +69,12 @@ target_link_libraries(optical_frame_publisher
 
 add_executable(bridge_logger src/BridgeLogger.cc)
 add_dependencies(bridge_logger ${catkin_EXPORTED_TARGETS})
-target_link_libraries(bridge_logger ${catkin_LIBRARIES})
+target_link_libraries(bridge_logger
+  PUBLIC
+    ${catkin_LIBRARIES}
+  PRIVATE
+    ignition-common3::ignition-common3
+)
 
 add_executable(subt_ros_relay src/SubtRosRelay.cc)
 target_include_directories(subt_ros_relay

--- a/subt_ros/src/BridgeLogger.cc
+++ b/subt_ros/src/BridgeLogger.cc
@@ -126,15 +126,15 @@ void BridgeLogger::Update(const ros::TimerEvent &)
     {
       return std::find(parts.begin(), parts.end(), _part) != parts.end();
     };
-    if (EndsWith(info.name, "front_scan") ||
-        EndsWith(info.name, "points") ||
-        EndsWith(info.name, "image_raw") ||
-        EndsWith(info.name, "depth") ||
-        EndsWith(info.name, "depth/image") ||  // explorer_r2
+    if (EndsWith(info.name, "/front_scan") ||
+        EndsWith(info.name, "/points") ||
+        EndsWith(info.name, "/image_raw") ||
+        EndsWith(info.name, "/depth") ||
+        EndsWith(info.name, "/depth/image") ||  // explorer_r2
         (HasPart("imu") && HasPart("data")) ||
         HasPart("magnetic_field") ||
-        EndsWith(info.name, "air_pressure") ||
-        EndsWith(info.name, "battery_state"))
+        EndsWith(info.name, "/air_pressure") ||
+        EndsWith(info.name, "/battery_state"))
     {
       boost::function<
         void(const topic_tools::ShapeShifter::ConstPtr&)> callback;

--- a/subt_ros/src/BridgeLogger.cc
+++ b/subt_ros/src/BridgeLogger.cc
@@ -117,6 +117,10 @@ void BridgeLogger::Update(const ros::TimerEvent &)
     if (this->streams.find(info.name) != this->streams.end())
       continue;
 
+    // These data are recorded in a bagfile, so no need to log them here.
+    if (StartsWith(info.name, "/robot_data/"))
+      continue;
+
     const auto parts = Split(info.name, '/');
     auto HasPart = [&parts](const std::string& _part) -> bool
     {


### PR DESCRIPTION
If bridge_logger is meant to only record statistics for topics published from the bridge container (a.k.a. vehicle_topics.launch of some robot), it actually records more than that. This could be a possible performance problem. And it's very easy to run into it and make it even worse.

The basic problem is that BridgeLogger detects the topics of interest by plain substring matching:

https://github.com/osrf/subt/blob/2af07e82fd2e67f7bb6bca267f6a26bcf1d75084/subt_ros/src/BridgeLogger.cc#L124-L132

This matches too much. This is an example list of topics recorded on our EXPLORER_X1_SENSOR_CONFIG_2 robot (called X1):

```
$ ls bridge_logger--*
bridge_logger--X1-battery_state.log			  bridge_logger--X1-points_slow.log
bridge_logger--X1-front_rgbd-depth-image_raw.log	  bridge_logger--X1-points_slow_filtered.log
bridge_logger--X1-front_rgbd-depth-optical-image_raw.log  bridge_logger--X1-points_slow_filtered_planner.log
bridge_logger--X1-front_rgbd-image_raw.log		  bridge_logger--X1-rear_rgbd-depth-image_raw.log
bridge_logger--X1-front_rgbd-optical-image_raw.log	  bridge_logger--X1-rear_rgbd-depth-optical-image_raw.log
bridge_logger--X1-front_rgbd-points.log			  bridge_logger--X1-rear_rgbd-image_raw.log
bridge_logger--X1-front_rgbd-points_slow.log		  bridge_logger--X1-rear_rgbd-optical-image_raw.log
bridge_logger--X1-front_rgbd-points_slow_filtered.log	  bridge_logger--X1-rear_rgbd-points.log
bridge_logger--X1-imu-data.log				  bridge_logger--X1-rear_rgbd-points_slow.log
bridge_logger--X1-imu_pose.log				  bridge_logger--X1-rear_rgbd-points_slow_filtered.log
bridge_logger--X1-left_rgbd-depth-image_raw.log		  bridge_logger--X1-right_rgbd-depth-image_raw.log
bridge_logger--X1-left_rgbd-depth-optical-image_raw.log   bridge_logger--X1-right_rgbd-depth-optical-image_raw.log
bridge_logger--X1-left_rgbd-image_raw.log		  bridge_logger--X1-right_rgbd-image_raw.log
bridge_logger--X1-left_rgbd-optical-image_raw.log	  bridge_logger--X1-right_rgbd-optical-image_raw.log
bridge_logger--X1-left_rgbd-points.log			  bridge_logger--X1-right_rgbd-points.log
bridge_logger--X1-left_rgbd-points_slow.log		  bridge_logger--X1-right_rgbd-points_slow.log
bridge_logger--X1-left_rgbd-points_slow_filtered.log	  bridge_logger--X1-right_rgbd-points_slow_filtered.log
bridge_logger--X1-other_viewpoints.log			  bridge_logger--X1-viewpoints.log
bridge_logger--X1-points.log				  bridge_logger--robot_data-X1-points_slow_filtered_planner-draco.log
```

I see there our own internal topics `*_rgbd/points_slow[_filtered]`, `imu_pose`, `other_viewpoints`, `viewpoints` and `robot_data/X1/points_slow_filtered_planner/draco` (yes, even the `robot_data` namespace matches!). And if I run the simulation with our h264 image transport package, it even subscribes to the `*_rgbd/image_raw/h264` and `*_rgbd/depth/image_raw/h264` topics which is bad because they are pretty computationally intensive and we don't normally use them all the time.

So, instead of the generic substring matching, I rewrote the logger do the matching much more tightly - mostly using `EndsWith()` or `HasPart()` (which matches whole strings between slashes). This results in matching more closely just the sets of bridge-related topics.

To make sure no "proper" bridge topic gets lost, I went through all submitted models examining exactly what would the previous rules match, and making sure they would match them too with this PR. I did that by calling the following command in submitted_models folder for each of the substituted lines:

    find . -name '*.launch' -exec grep -Po 'to="\K[^"]*front_scan[^"]*(?=")' {} \; | sort -u

<details>
<summary>front_scan</summary>

```
front_scan
```

</details>

<details>
<summary>points</summary>

```
downward_realsense/points
front/depth/points
front_down_rgbd_camera/depth/points
front_facing_rgbd_camera/depth/points
front_laser/points
pan_tilt_rgbd_camera/depth/points
points
rgbd_camera/depth/points
rgbd_camera_down/depth/points
rgbd_camera_up/depth/points
rgbd_front/points
rgbd_rear/points
tof_bottom/depth/points
tof_top/depth/points
```

</details>

<details>
<summary>image_raw</summary>

```
back_left/image_raw
back_right/image_raw
camera_front/image_raw
camera_front/optical/image_raw
camera_left/image_raw
camera_rear/image_raw
camera_rear/optical/image_raw
camera_right/image_raw
depth/image_raw
depth/optical/image_raw
down/image_raw
down/optical/image_raw
downward_realsense/image_raw
downward_realsense/optical/image_raw
front_down/image_raw
front_down/optical/image_raw
front_facing/image_raw
front_facing/optical/image_raw
front/image_raw
front/left/image_raw
front/left/optical/image_raw
front/optical/image_raw
front/right/image_raw
front/right/optical/image_raw
image_raw
left/image_raw
left/optical/image_raw
omni/camera_0/image_raw
omni/camera_0/optical/image_raw
omni/camera_1/image_raw
omni/camera_1/optical/image_raw
omni/camera_2/image_raw
omni/camera_2/optical/image_raw
omni/camera_3/image_raw
omni/camera_3/optical/image_raw
omni/camera_4/image_raw
omni/camera_4/optical/image_raw
omni/camera_5/image_raw
omni/camera_5/optical/image_raw
optical/depth/image_raw
optical/image_raw
pan_tilt/image_raw
pan_tilt/optical/image_raw
rear/image_raw
rear/optical/image_raw
rgbd_front/image_raw
rgbd_front/optical/image_raw
rgbd_rear/image_raw
rgbd_rear/optical/image_raw
right/image_raw
right/optical/image_raw
up/image_raw
up/optical/image_raw
```

</details>

<details>
<summary>depth</summary>
Most of it gets covered by suffixes `points`, `depth` and `image_raw`. Just Explorer R2 has `depth/image` which is made a special case in this PR.

```
depth/camera_info
depth/image
depth/image_raw
depth/optical/image_raw
down/depth
down/optical/depth
downward_realsense/depth
downward_realsense/optical/depth
front/depth
front/depth/points
front_down/depth
front_down/optical/depth
front_down_rgbd_camera/depth/points
front_facing/depth
front_facing/optical/depth
front_facing_rgbd_camera/depth/points
front/optical/depth
optical/depth/camera_info
optical/depth/image
optical/depth/image_raw
pan_tilt/depth
pan_tilt/optical/depth
pan_tilt_rgbd_camera/depth/points
rgbd_camera/depth/points
rgbd_camera_down/depth/points
rgbd_camera_up/depth/points
rgbd_front/depth
rgbd_front/optical/depth
rgbd_rear/depth
rgbd_rear/optical/depth
tof_bottom/depth
tof_bottom/depth/points
tof_bottom/optical/depth
tof_top/depth
tof_top/depth/points
tof_top/optical/depth
up/depth
up/optical/depth
```

</details>

<details>
<summary>imu</summary>

```
imu/data
imu/front/data
imu/rear/data
```

</details>

<details>
<summary>magnetic_field</summary>

```
magnetic_field
magnetic_field/front
magnetic_field/rear
```

</details>

<details>
<summary>air_pressure</summary>

```
air_pressure
```

</details>

<details>
<summary>battery_state</summary>

```
battery_state
```

</details>

The previous implementation also matched a few camera_info topics, but as `OnSensorMsg` doesn't have a CameraInfo handler, they got ignored anyways (but subscribed). I chose to ignore them, but it's easy to add these to the bridge logger, too.

I also removed the whole section of code that ignored topics like `parameter_updates` etc. - it's no longer needed.

This PR solves #595 (as a side-effect).