### PR TITLE
BridgeLogger: Fix while(ros::ok) error.

### DIFF
--- a/subt_ros/src/BridgeLogger.cc
+++ b/subt_ros/src/BridgeLogger.cc
@@ -248,7 +248,7 @@ void BridgeLogger::CheckHeartbeat()
   // check heartbeat
   using namespace std::chrono_literals;
   double heartbeatCheckPeriod = 5.0;
-  while (ros::ok)
+  while (ros::ok())
   {
     std::this_thread::sleep_for(5s);
     auto systemTime = std::chrono::steady_clock::now();


### PR DESCRIPTION
There's a coding bug in 

https://github.com/osrf/subt/blob/2af07e82fd2e67f7bb6bca267f6a26bcf1d75084/subt_ros/src/BridgeLogger.cc#L251

it checks that the address of function `ros::ok` is non-zero (which it is always). It should instead call the function.