### PR TITLE
Publish ground truth robot position as dynamic TF

### DIFF
--- a/ign_migration_scripts/launch/preview.ign
+++ b/ign_migration_scripts/launch/preview.ign
@@ -209,10 +209,20 @@
             <publish_sensor_pose>true</publish_sensor_pose>
             <publish_collision_pose>false</publish_collision_pose>
             <publish_visual_pose>false</publish_visual_pose>
-            <publish_nested_model_pose>#{$enableGroundTruth}</publish_nested_model_pose>
+            <publish_nested_model_pose>false</publish_nested_model_pose>
             <use_pose_vector_msg>true</use_pose_vector_msg>
             <static_publisher>true</static_publisher>
             <static_update_frequency>1</static_update_frequency>
+          </plugin>
+          <plugin filename="libignition-gazebo-pose-publisher-system.so"
+            name="ignition::gazebo::systems::PosePublisher">
+            <publish_link_pose>false</publish_link_pose>
+            <publish_sensor_pose>false</publish_sensor_pose>
+            <publish_collision_pose>false</publish_collision_pose>
+            <publish_visual_pose>false</publish_visual_pose>
+            <publish_nested_model_pose>#{$enableGroundTruth}</publish_nested_model_pose>
+            <use_pose_vector_msg>true</use_pose_vector_msg>
+            <static_publisher>false</static_publisher>
           </plugin>
           <!-- Battery plugin -->
         </include>
@@ -258,10 +268,20 @@
             <publish_sensor_pose>true</publish_sensor_pose>
             <publish_collision_pose>false</publish_collision_pose>
             <publish_visual_pose>false</publish_visual_pose>
-            <publish_nested_model_pose>#{$enableGroundTruth}</publish_nested_model_pose>
+            <publish_nested_model_pose>false</publish_nested_model_pose>
             <use_pose_vector_msg>true</use_pose_vector_msg>
             <static_publisher>true</static_publisher>
             <static_update_frequency>1</static_update_frequency>
+          </plugin>
+          <plugin filename="libignition-gazebo-pose-publisher-system.so"
+            name="ignition::gazebo::systems::PosePublisher">
+            <publish_link_pose>false</publish_link_pose>
+            <publish_sensor_pose>false</publish_sensor_pose>
+            <publish_collision_pose>false</publish_collision_pose>
+            <publish_visual_pose>false</publish_visual_pose>
+            <publish_nested_model_pose>#{$enableGroundTruth}</publish_nested_model_pose>
+            <use_pose_vector_msg>true</use_pose_vector_msg>
+            <static_publisher>false</static_publisher>
           </plugin>
           <plugin filename="libignition-gazebo-multicopter-motor-model-system.so"
             name="ignition::gazebo::systems::MulticopterMotorModel">

--- a/ign_migration_scripts/scripts/spawn_preview_model.py
+++ b/ign_migration_scripts/scripts/spawn_preview_model.py
@@ -73,10 +73,22 @@ def spawn_preview_model(args):
     etree.SubElement(plugin, 'publish_sensor_pose').text = 'true'
     etree.SubElement(plugin, 'publish_collision_pose').text = 'false'
     etree.SubElement(plugin, 'publish_visual_pose').text = 'false'
-    etree.SubElement(plugin, 'publish_nested_model_pose').text = 'true'
+    etree.SubElement(plugin, 'publish_nested_model_pose').text = 'false'
     etree.SubElement(plugin, 'use_pose_vector_msg').text = 'true'
     etree.SubElement(plugin, 'static_publisher').text = 'true'
     etree.SubElement(plugin, 'static_update_frequency').text = '1'
+
+    plugin = etree.SubElement(model, 'plugin',
+                    filename='libignition-gazebo-pose-publisher-system.so',
+                    name='ignition::gazebo::systems::PosePublisher')
+
+    etree.SubElement(plugin, 'publish_link_pose').text = 'false'
+    etree.SubElement(plugin, 'publish_sensor_pose').text = 'false'
+    etree.SubElement(plugin, 'publish_collision_pose').text = 'false'
+    etree.SubElement(plugin, 'publish_visual_pose').text = 'false'
+    etree.SubElement(plugin, 'publish_nested_model_pose').text = 'true'
+    etree.SubElement(plugin, 'use_pose_vector_msg').text = 'true'
+    etree.SubElement(plugin, 'static_publisher').text = 'false'
 
     sdf_esc = etree.tostring(sdf, encoding="unicode",
                              with_tail=False).replace('"', r'\"').replace('\n', '')

--- a/submitted_models/cerberus_anymal_b_sensor_config_1/launch/spawner.rb
+++ b/submitted_models/cerberus_anymal_b_sensor_config_1/launch/spawner.rb
@@ -45,10 +45,20 @@ def spawner(_name, _modelURI, _worldName, _x, _y, _z, _roll, _pitch, _yaw)
         <publish_sensor_pose>true</publish_sensor_pose>
         <publish_collision_pose>false</publish_collision_pose>
         <publish_visual_pose>false</publish_visual_pose>
-        <publish_nested_model_pose>#{$enableGroundTruth}</publish_nested_model_pose>
+        <publish_nested_model_pose>false</publish_nested_model_pose>
         <use_pose_vector_msg>true</use_pose_vector_msg>
         <static_publisher>true</static_publisher>
         <static_update_frequency>1</static_update_frequency>
+      </plugin>
+      <plugin filename="libignition-gazebo-pose-publisher-system.so"
+        name="ignition::gazebo::systems::PosePublisher">
+        <publish_link_pose>false</publish_link_pose>
+        <publish_sensor_pose>false</publish_sensor_pose>
+        <publish_collision_pose>false</publish_collision_pose>
+        <publish_visual_pose>false</publish_visual_pose>
+        <publish_nested_model_pose>#{$enableGroundTruth}</publish_nested_model_pose>
+        <use_pose_vector_msg>true</use_pose_vector_msg>
+        <static_publisher>false</static_publisher>
       </plugin>
       <plugin filename="libignition-gazebo-joint-state-publisher-system.so"
         name="ignition::gazebo::systems::JointStatePublisher">

--- a/submitted_models/cerberus_anymal_b_sensor_config_2/launch/spawner.rb
+++ b/submitted_models/cerberus_anymal_b_sensor_config_2/launch/spawner.rb
@@ -45,10 +45,20 @@ def spawner(_name, _modelURI, _worldName, _x, _y, _z, _roll, _pitch, _yaw)
         <publish_sensor_pose>true</publish_sensor_pose>
         <publish_collision_pose>false</publish_collision_pose>
         <publish_visual_pose>false</publish_visual_pose>
-        <publish_nested_model_pose>#{$enableGroundTruth}</publish_nested_model_pose>
+        <publish_nested_model_pose>false</publish_nested_model_pose>
         <use_pose_vector_msg>true</use_pose_vector_msg>
         <static_publisher>true</static_publisher>
         <static_update_frequency>1</static_update_frequency>
+      </plugin>
+      <plugin filename="libignition-gazebo-pose-publisher-system.so"
+        name="ignition::gazebo::systems::PosePublisher">
+        <publish_link_pose>false</publish_link_pose>
+        <publish_sensor_pose>false</publish_sensor_pose>
+        <publish_collision_pose>false</publish_collision_pose>
+        <publish_visual_pose>false</publish_visual_pose>
+        <publish_nested_model_pose>#{$enableGroundTruth}</publish_nested_model_pose>
+        <use_pose_vector_msg>true</use_pose_vector_msg>
+        <static_publisher>false</static_publisher>
       </plugin>
       <plugin filename="libignition-gazebo-joint-state-publisher-system.so"
         name="ignition::gazebo::systems::JointStatePublisher">

--- a/submitted_models/cerberus_gagarin_sensor_config_1/launch/spawner.rb
+++ b/submitted_models/cerberus_gagarin_sensor_config_1/launch/spawner.rb
@@ -17,10 +17,20 @@ def spawner(_name, _modelURI, _worldName, _x, _y, _z, _roll, _pitch, _yaw)
           <publish_sensor_pose>true</publish_sensor_pose>
           <publish_collision_pose>false</publish_collision_pose>
           <publish_visual_pose>false</publish_visual_pose>
-          <publish_nested_model_pose>#{$enableGroundTruth}</publish_nested_model_pose>
+          <publish_nested_model_pose>false</publish_nested_model_pose>
           <use_pose_vector_msg>true</use_pose_vector_msg>
           <static_publisher>true</static_publisher>
           <static_update_frequency>1</static_update_frequency>
+        </plugin>
+        <plugin filename="libignition-gazebo-pose-publisher-system.so"
+          name="ignition::gazebo::systems::PosePublisher">
+          <publish_link_pose>false</publish_link_pose>
+          <publish_sensor_pose>false</publish_sensor_pose>
+          <publish_collision_pose>false</publish_collision_pose>
+          <publish_visual_pose>false</publish_visual_pose>
+          <publish_nested_model_pose>#{$enableGroundTruth}</publish_nested_model_pose>
+          <use_pose_vector_msg>true</use_pose_vector_msg>
+          <static_publisher>false</static_publisher>
         </plugin>
         <plugin filename="libignition-gazebo-multicopter-motor-model-system.so"
           name="ignition::gazebo::systems::MulticopterMotorModel">

--- a/submitted_models/cerberus_m100_sensor_config_1/launch/spawner.rb
+++ b/submitted_models/cerberus_m100_sensor_config_1/launch/spawner.rb
@@ -42,10 +42,20 @@ def spawner(_name, _modelURI, _worldName, _x, _y, _z, _roll, _pitch, _yaw)
           <publish_sensor_pose>true</publish_sensor_pose>
           <publish_collision_pose>false</publish_collision_pose>
           <publish_visual_pose>false</publish_visual_pose>
-          <publish_nested_model_pose>#{$enableGroundTruth}</publish_nested_model_pose>
+          <publish_nested_model_pose>false</publish_nested_model_pose>
           <use_pose_vector_msg>true</use_pose_vector_msg>
           <static_publisher>true</static_publisher>
           <static_update_frequency>1</static_update_frequency>
+        </plugin>
+        <plugin filename="libignition-gazebo-pose-publisher-system.so"
+          name="ignition::gazebo::systems::PosePublisher">
+          <publish_link_pose>false</publish_link_pose>
+          <publish_sensor_pose>false</publish_sensor_pose>
+          <publish_collision_pose>false</publish_collision_pose>
+          <publish_visual_pose>false</publish_visual_pose>
+          <publish_nested_model_pose>#{$enableGroundTruth}</publish_nested_model_pose>
+          <use_pose_vector_msg>true</use_pose_vector_msg>
+          <static_publisher>false</static_publisher>
         </plugin>
         <plugin filename="libignition-gazebo-multicopter-motor-model-system.so"
           name="ignition::gazebo::systems::MulticopterMotorModel">

--- a/submitted_models/costar_husky_sensor_config_1/launch/spawner.rb
+++ b/submitted_models/costar_husky_sensor_config_1/launch/spawner.rb
@@ -32,10 +32,20 @@ def spawner(_name, _modelURI, _worldName, _x, _y, _z, _roll, _pitch, _yaw)
         <publish_sensor_pose>true</publish_sensor_pose>
         <publish_collision_pose>false</publish_collision_pose>
         <publish_visual_pose>false</publish_visual_pose>
-        <publish_nested_model_pose>#{$enableGroundTruth}</publish_nested_model_pose>
+        <publish_nested_model_pose>false</publish_nested_model_pose>
         <use_pose_vector_msg>true</use_pose_vector_msg>
         <static_publisher>true</static_publisher>
         <static_update_frequency>1</static_update_frequency>
+      </plugin>
+      <plugin filename="libignition-gazebo-pose-publisher-system.so"
+        name="ignition::gazebo::systems::PosePublisher">
+        <publish_link_pose>false</publish_link_pose>
+        <publish_sensor_pose>false</publish_sensor_pose>
+        <publish_collision_pose>false</publish_collision_pose>
+        <publish_visual_pose>false</publish_visual_pose>
+        <publish_nested_model_pose>#{$enableGroundTruth}</publish_nested_model_pose>
+        <use_pose_vector_msg>true</use_pose_vector_msg>
+        <static_publisher>false</static_publisher>
       </plugin>
       <!-- Battery plugin -->
       <plugin filename="libignition-gazebo-linearbatteryplugin-system.so"

--- a/submitted_models/costar_husky_sensor_config_2/launch/spawner.rb
+++ b/submitted_models/costar_husky_sensor_config_2/launch/spawner.rb
@@ -32,10 +32,20 @@ def spawner(_name, _modelURI, _worldName, _x, _y, _z, _roll, _pitch, _yaw)
         <publish_sensor_pose>true</publish_sensor_pose>
         <publish_collision_pose>false</publish_collision_pose>
         <publish_visual_pose>false</publish_visual_pose>
-        <publish_nested_model_pose>#{$enableGroundTruth}</publish_nested_model_pose>
+        <publish_nested_model_pose>false</publish_nested_model_pose>
         <use_pose_vector_msg>true</use_pose_vector_msg>
         <static_publisher>true</static_publisher>
         <static_update_frequency>1</static_update_frequency>
+      </plugin>
+      <plugin filename="libignition-gazebo-pose-publisher-system.so"
+        name="ignition::gazebo::systems::PosePublisher">
+        <publish_link_pose>false</publish_link_pose>
+        <publish_sensor_pose>false</publish_sensor_pose>
+        <publish_collision_pose>false</publish_collision_pose>
+        <publish_visual_pose>false</publish_visual_pose>
+        <publish_nested_model_pose>#{$enableGroundTruth}</publish_nested_model_pose>
+        <use_pose_vector_msg>true</use_pose_vector_msg>
+        <static_publisher>false</static_publisher>
       </plugin>
       <!-- Battery plugin -->
       <plugin filename="libignition-gazebo-linearbatteryplugin-system.so"

--- a/submitted_models/csiro_data61_ozbot_atr_sensor_config_1/launch/spawner.rb
+++ b/submitted_models/csiro_data61_ozbot_atr_sensor_config_1/launch/spawner.rb
@@ -64,10 +64,20 @@ def spawner(_name, _modelURI, _worldName, _x, _y, _z, _roll, _pitch, _yaw)
         <publish_sensor_pose>true</publish_sensor_pose>
         <publish_collision_pose>false</publish_collision_pose>
         <publish_visual_pose>false</publish_visual_pose>
-        <publish_nested_model_pose>#{$enableGroundTruth}</publish_nested_model_pose>
+        <publish_nested_model_pose>false</publish_nested_model_pose>
         <use_pose_vector_msg>true</use_pose_vector_msg>
         <static_pose_publisher>true</static_pose_publisher>
         <static_pose_update_frequency>1</static_pose_update_frequency>
+      </plugin>
+      <plugin filename="libignition-gazebo-pose-publisher-system.so"
+        name="ignition::gazebo::systems::PosePublisher">
+        <publish_link_pose>false</publish_link_pose>
+        <publish_sensor_pose>false</publish_sensor_pose>
+        <publish_collision_pose>false</publish_collision_pose>
+        <publish_visual_pose>false</publish_visual_pose>
+        <publish_nested_model_pose>#{$enableGroundTruth}</publish_nested_model_pose>
+        <use_pose_vector_msg>true</use_pose_vector_msg>
+        <static_publisher>false</static_publisher>
       </plugin>
 
       <!-- Battery plugin -->

--- a/submitted_models/csiro_data61_ozbot_atr_sensor_config_2/launch/spawner.rb
+++ b/submitted_models/csiro_data61_ozbot_atr_sensor_config_2/launch/spawner.rb
@@ -64,10 +64,20 @@ def spawner(_name, _modelURI, _worldName, _x, _y, _z, _roll, _pitch, _yaw)
         <publish_sensor_pose>true</publish_sensor_pose>
         <publish_collision_pose>false</publish_collision_pose>
         <publish_visual_pose>false</publish_visual_pose>
-        <publish_nested_model_pose>#{$enableGroundTruth}</publish_nested_model_pose>
+        <publish_nested_model_pose>false</publish_nested_model_pose>
         <use_pose_vector_msg>true</use_pose_vector_msg>
         <static_pose_publisher>true</static_pose_publisher>
         <static_pose_update_frequency>1</static_pose_update_frequency>
+      </plugin>
+      <plugin filename="libignition-gazebo-pose-publisher-system.so"
+        name="ignition::gazebo::systems::PosePublisher">
+        <publish_link_pose>false</publish_link_pose>
+        <publish_sensor_pose>false</publish_sensor_pose>
+        <publish_collision_pose>false</publish_collision_pose>
+        <publish_visual_pose>false</publish_visual_pose>
+        <publish_nested_model_pose>#{$enableGroundTruth}</publish_nested_model_pose>
+        <use_pose_vector_msg>true</use_pose_vector_msg>
+        <static_publisher>false</static_publisher>
       </plugin>
 
       <!-- Battery plugin -->

--- a/submitted_models/ctu_cras_norlab_absolem_sensor_config_1/launch/spawner.rb
+++ b/submitted_models/ctu_cras_norlab_absolem_sensor_config_1/launch/spawner.rb
@@ -104,10 +104,20 @@ def spawner(_name, _modelURI, _worldName, _x, _y, _z, _roll, _pitch, _yaw)
         <publish_sensor_pose>true</publish_sensor_pose>
         <publish_collision_pose>false</publish_collision_pose>
         <publish_visual_pose>false</publish_visual_pose>
-        <publish_nested_model_pose>#{$enableGroundTruth}</publish_nested_model_pose>
+        <publish_nested_model_pose>false</publish_nested_model_pose>
         <use_pose_vector_msg>true</use_pose_vector_msg>
         <static_publisher>true</static_publisher>
         <static_update_frequency>1</static_update_frequency>
+      </plugin>
+      <plugin filename="libignition-gazebo-pose-publisher-system.so"
+        name="ignition::gazebo::systems::PosePublisher">
+        <publish_link_pose>false</publish_link_pose>
+        <publish_sensor_pose>false</publish_sensor_pose>
+        <publish_collision_pose>false</publish_collision_pose>
+        <publish_visual_pose>false</publish_visual_pose>
+        <publish_nested_model_pose>#{$enableGroundTruth}</publish_nested_model_pose>
+        <use_pose_vector_msg>true</use_pose_vector_msg>
+        <static_publisher>false</static_publisher>
       </plugin>
       <!-- Battery plugin -->
       <plugin filename="libignition-gazebo-linearbatteryplugin-system.so"

--- a/submitted_models/ctu_cras_norlab_absolem_sensor_config_2/launch/spawner.rb
+++ b/submitted_models/ctu_cras_norlab_absolem_sensor_config_2/launch/spawner.rb
@@ -104,10 +104,20 @@ def spawner(_name, _modelURI, _worldName, _x, _y, _z, _roll, _pitch, _yaw)
         <publish_sensor_pose>true</publish_sensor_pose>
         <publish_collision_pose>false</publish_collision_pose>
         <publish_visual_pose>false</publish_visual_pose>
-        <publish_nested_model_pose>#{$enableGroundTruth}</publish_nested_model_pose>
+        <publish_nested_model_pose>false</publish_nested_model_pose>
         <use_pose_vector_msg>true</use_pose_vector_msg>
         <static_publisher>true</static_publisher>
         <static_update_frequency>1</static_update_frequency>
+      </plugin>
+      <plugin filename="libignition-gazebo-pose-publisher-system.so"
+        name="ignition::gazebo::systems::PosePublisher">
+        <publish_link_pose>false</publish_link_pose>
+        <publish_sensor_pose>false</publish_sensor_pose>
+        <publish_collision_pose>false</publish_collision_pose>
+        <publish_visual_pose>false</publish_visual_pose>
+        <publish_nested_model_pose>#{$enableGroundTruth}</publish_nested_model_pose>
+        <use_pose_vector_msg>true</use_pose_vector_msg>
+        <static_publisher>false</static_publisher>
       </plugin>
       <!-- Battery plugin -->
       <plugin filename="libignition-gazebo-linearbatteryplugin-system.so"

--- a/submitted_models/explorer_ds1_sensor_config_1/launch/spawner.rb
+++ b/submitted_models/explorer_ds1_sensor_config_1/launch/spawner.rb
@@ -17,10 +17,20 @@ def spawner(_name, _modelURI, _worldName, _x, _y, _z, _roll, _pitch, _yaw)
         <publish_sensor_pose>true</publish_sensor_pose>
         <publish_collision_pose>false</publish_collision_pose>
         <publish_visual_pose>false</publish_visual_pose>
-        <publish_nested_model_pose>#{$enableGroundTruth}</publish_nested_model_pose>
+        <publish_nested_model_pose>false</publish_nested_model_pose>
         <use_pose_vector_msg>true</use_pose_vector_msg>
         <static_publisher>true</static_publisher>
         <static_update_frequency>1</static_update_frequency>
+      </plugin>
+      <plugin filename="libignition-gazebo-pose-publisher-system.so"
+        name="ignition::gazebo::systems::PosePublisher">
+        <publish_link_pose>false</publish_link_pose>
+        <publish_sensor_pose>false</publish_sensor_pose>
+        <publish_collision_pose>false</publish_collision_pose>
+        <publish_visual_pose>false</publish_visual_pose>
+        <publish_nested_model_pose>#{$enableGroundTruth}</publish_nested_model_pose>
+        <use_pose_vector_msg>true</use_pose_vector_msg>
+        <static_publisher>false</static_publisher>
       </plugin>
       <plugin filename="libignition-gazebo-multicopter-motor-model-system.so"
         name="ignition::gazebo::systems::MulticopterMotorModel">

--- a/submitted_models/explorer_r2_sensor_config_1/launch/spawner.rb
+++ b/submitted_models/explorer_r2_sensor_config_1/launch/spawner.rb
@@ -32,10 +32,20 @@ def spawner(_name, _modelURI, _worldName, _x, _y, _z, _roll, _pitch, _yaw)
         <publish_sensor_pose>true</publish_sensor_pose>
         <publish_collision_pose>false</publish_collision_pose>
         <publish_visual_pose>false</publish_visual_pose>
-        <publish_nested_model_pose>#{$enableGroundTruth}</publish_nested_model_pose>
+        <publish_nested_model_pose>false</publish_nested_model_pose>
         <use_pose_vector_msg>true</use_pose_vector_msg>
         <static_publisher>true</static_publisher>
         <static_update_frequency>1</static_update_frequency>
+      </plugin>
+      <plugin filename="libignition-gazebo-pose-publisher-system.so"
+        name="ignition::gazebo::systems::PosePublisher">
+        <publish_link_pose>false</publish_link_pose>
+        <publish_sensor_pose>false</publish_sensor_pose>
+        <publish_collision_pose>false</publish_collision_pose>
+        <publish_visual_pose>false</publish_visual_pose>
+        <publish_nested_model_pose>#{$enableGroundTruth}</publish_nested_model_pose>
+        <use_pose_vector_msg>true</use_pose_vector_msg>
+        <static_publisher>false</static_publisher>
       </plugin>
       <!-- Battery plugin -->
       <plugin filename="libignition-gazebo-linearbatteryplugin-system.so"

--- a/submitted_models/explorer_r2_sensor_config_2/launch/spawner.rb
+++ b/submitted_models/explorer_r2_sensor_config_2/launch/spawner.rb
@@ -32,10 +32,20 @@ def spawner(_name, _modelURI, _worldName, _x, _y, _z, _roll, _pitch, _yaw)
         <publish_sensor_pose>true</publish_sensor_pose>
         <publish_collision_pose>false</publish_collision_pose>
         <publish_visual_pose>false</publish_visual_pose>
-        <publish_nested_model_pose>#{$enableGroundTruth}</publish_nested_model_pose>
+        <publish_nested_model_pose>false</publish_nested_model_pose>
         <use_pose_vector_msg>true</use_pose_vector_msg>
         <static_publisher>true</static_publisher>
         <static_update_frequency>1</static_update_frequency>
+      </plugin>
+      <plugin filename="libignition-gazebo-pose-publisher-system.so"
+        name="ignition::gazebo::systems::PosePublisher">
+        <publish_link_pose>false</publish_link_pose>
+        <publish_sensor_pose>false</publish_sensor_pose>
+        <publish_collision_pose>false</publish_collision_pose>
+        <publish_visual_pose>false</publish_visual_pose>
+        <publish_nested_model_pose>#{$enableGroundTruth}</publish_nested_model_pose>
+        <use_pose_vector_msg>true</use_pose_vector_msg>
+        <static_publisher>false</static_publisher>
       </plugin>
       <!-- Battery plugin -->
       <plugin filename="libignition-gazebo-linearbatteryplugin-system.so"

--- a/submitted_models/explorer_x1_sensor_config_1/launch/spawner.rb
+++ b/submitted_models/explorer_x1_sensor_config_1/launch/spawner.rb
@@ -32,10 +32,20 @@ def spawner(_name, _modelURI, _worldName, _x, _y, _z, _roll, _pitch, _yaw)
         <publish_sensor_pose>true</publish_sensor_pose>
         <publish_collision_pose>false</publish_collision_pose>
         <publish_visual_pose>false</publish_visual_pose>
-        <publish_nested_model_pose>#{$enableGroundTruth}</publish_nested_model_pose>
+        <publish_nested_model_pose>false</publish_nested_model_pose>
         <use_pose_vector_msg>true</use_pose_vector_msg>
         <static_publisher>true</static_publisher>
         <static_update_frequency>1</static_update_frequency>
+      </plugin>
+      <plugin filename="libignition-gazebo-pose-publisher-system.so"
+        name="ignition::gazebo::systems::PosePublisher">
+        <publish_link_pose>false</publish_link_pose>
+        <publish_sensor_pose>false</publish_sensor_pose>
+        <publish_collision_pose>false</publish_collision_pose>
+        <publish_visual_pose>false</publish_visual_pose>
+        <publish_nested_model_pose>#{$enableGroundTruth}</publish_nested_model_pose>
+        <use_pose_vector_msg>true</use_pose_vector_msg>
+        <static_publisher>false</static_publisher>
       </plugin>
       <!-- Battery plugin -->
       <plugin filename="libignition-gazebo-linearbatteryplugin-system.so"

--- a/submitted_models/explorer_x1_sensor_config_2/launch/spawner.rb
+++ b/submitted_models/explorer_x1_sensor_config_2/launch/spawner.rb
@@ -32,10 +32,20 @@ def spawner(_name, _modelURI, _worldName, _x, _y, _z, _roll, _pitch, _yaw)
         <publish_sensor_pose>true</publish_sensor_pose>
         <publish_collision_pose>false</publish_collision_pose>
         <publish_visual_pose>false</publish_visual_pose>
-        <publish_nested_model_pose>#{$enableGroundTruth}</publish_nested_model_pose>
+        <publish_nested_model_pose>false</publish_nested_model_pose>
         <use_pose_vector_msg>true</use_pose_vector_msg>
         <static_publisher>true</static_publisher>
         <static_update_frequency>1</static_update_frequency>
+      </plugin>
+      <plugin filename="libignition-gazebo-pose-publisher-system.so"
+        name="ignition::gazebo::systems::PosePublisher">
+        <publish_link_pose>false</publish_link_pose>
+        <publish_sensor_pose>false</publish_sensor_pose>
+        <publish_collision_pose>false</publish_collision_pose>
+        <publish_visual_pose>false</publish_visual_pose>
+        <publish_nested_model_pose>#{$enableGroundTruth}</publish_nested_model_pose>
+        <use_pose_vector_msg>true</use_pose_vector_msg>
+        <static_publisher>false</static_publisher>
       </plugin>
       <!-- Battery plugin -->
       <plugin filename="libignition-gazebo-linearbatteryplugin-system.so"

--- a/submitted_models/marble_hd2_sensor_config_1/launch/spawner.rb
+++ b/submitted_models/marble_hd2_sensor_config_1/launch/spawner.rb
@@ -36,10 +36,20 @@ def spawner(_name, _modelURI, _worldName, _x, _y, _z, _roll, _pitch, _yaw)
         <publish_sensor_pose>true</publish_sensor_pose>
         <publish_collision_pose>false</publish_collision_pose>
         <publish_visual_pose>false</publish_visual_pose>
-        <publish_nested_model_pose>#{$enableGroundTruth}</publish_nested_model_pose>
+        <publish_nested_model_pose>false</publish_nested_model_pose>
         <use_pose_vector_msg>true</use_pose_vector_msg>
         <static_publisher>true</static_publisher>
         <static_update_frequency>1</static_update_frequency>
+      </plugin>
+      <plugin filename="libignition-gazebo-pose-publisher-system.so"
+        name="ignition::gazebo::systems::PosePublisher">
+        <publish_link_pose>false</publish_link_pose>
+        <publish_sensor_pose>false</publish_sensor_pose>
+        <publish_collision_pose>false</publish_collision_pose>
+        <publish_visual_pose>false</publish_visual_pose>
+        <publish_nested_model_pose>#{$enableGroundTruth}</publish_nested_model_pose>
+        <use_pose_vector_msg>true</use_pose_vector_msg>
+        <static_publisher>false</static_publisher>
       </plugin>
       <!-- Battery plugin -->
       <plugin filename="libignition-gazebo-linearbatteryplugin-system.so"

--- a/submitted_models/marble_hd2_sensor_config_2/launch/spawner.rb
+++ b/submitted_models/marble_hd2_sensor_config_2/launch/spawner.rb
@@ -36,10 +36,20 @@ def spawner(_name, _modelURI, _worldName, _x, _y, _z, _roll, _pitch, _yaw)
         <publish_sensor_pose>true</publish_sensor_pose>
         <publish_collision_pose>false</publish_collision_pose>
         <publish_visual_pose>false</publish_visual_pose>
-        <publish_nested_model_pose>#{$enableGroundTruth}</publish_nested_model_pose>
+        <publish_nested_model_pose>false</publish_nested_model_pose>
         <use_pose_vector_msg>true</use_pose_vector_msg>
         <static_publisher>true</static_publisher>
         <static_update_frequency>1</static_update_frequency>
+      </plugin>
+      <plugin filename="libignition-gazebo-pose-publisher-system.so"
+        name="ignition::gazebo::systems::PosePublisher">
+        <publish_link_pose>false</publish_link_pose>
+        <publish_sensor_pose>false</publish_sensor_pose>
+        <publish_collision_pose>false</publish_collision_pose>
+        <publish_visual_pose>false</publish_visual_pose>
+        <publish_nested_model_pose>#{$enableGroundTruth}</publish_nested_model_pose>
+        <use_pose_vector_msg>true</use_pose_vector_msg>
+        <static_publisher>false</static_publisher>
       </plugin>
       <!-- Battery plugin -->
       <plugin filename="libignition-gazebo-linearbatteryplugin-system.so"

--- a/submitted_models/marble_husky_sensor_config_1/launch/spawner.rb
+++ b/submitted_models/marble_husky_sensor_config_1/launch/spawner.rb
@@ -32,10 +32,20 @@ def spawner(_name, _modelURI, _worldName, _x, _y, _z, _roll, _pitch, _yaw)
         <publish_sensor_pose>true</publish_sensor_pose>
         <publish_collision_pose>false</publish_collision_pose>
         <publish_visual_pose>false</publish_visual_pose>
-        <publish_nested_model_pose>#{$enableGroundTruth}</publish_nested_model_pose>
+        <publish_nested_model_pose>false</publish_nested_model_pose>
         <use_pose_vector_msg>true</use_pose_vector_msg>
         <static_publisher>true</static_publisher>
         <static_update_frequency>1</static_update_frequency>
+      </plugin>
+      <plugin filename="libignition-gazebo-pose-publisher-system.so"
+        name="ignition::gazebo::systems::PosePublisher">
+        <publish_link_pose>false</publish_link_pose>
+        <publish_sensor_pose>false</publish_sensor_pose>
+        <publish_collision_pose>false</publish_collision_pose>
+        <publish_visual_pose>false</publish_visual_pose>
+        <publish_nested_model_pose>#{$enableGroundTruth}</publish_nested_model_pose>
+        <use_pose_vector_msg>true</use_pose_vector_msg>
+        <static_publisher>false</static_publisher>
       </plugin>
       <!-- Battery plugin -->
       <plugin filename="libignition-gazebo-linearbatteryplugin-system.so"

--- a/submitted_models/marble_husky_sensor_config_2/launch/spawner.rb
+++ b/submitted_models/marble_husky_sensor_config_2/launch/spawner.rb
@@ -32,10 +32,20 @@ def spawner(_name, _modelURI, _worldName, _x, _y, _z, _roll, _pitch, _yaw)
         <publish_sensor_pose>true</publish_sensor_pose>
         <publish_collision_pose>false</publish_collision_pose>
         <publish_visual_pose>false</publish_visual_pose>
-        <publish_nested_model_pose>#{$enableGroundTruth}</publish_nested_model_pose>
+        <publish_nested_model_pose>false</publish_nested_model_pose>
         <use_pose_vector_msg>true</use_pose_vector_msg>
         <static_publisher>true</static_publisher>
         <static_update_frequency>1</static_update_frequency>
+      </plugin>
+      <plugin filename="libignition-gazebo-pose-publisher-system.so"
+        name="ignition::gazebo::systems::PosePublisher">
+        <publish_link_pose>false</publish_link_pose>
+        <publish_sensor_pose>false</publish_sensor_pose>
+        <publish_collision_pose>false</publish_collision_pose>
+        <publish_visual_pose>false</publish_visual_pose>
+        <publish_nested_model_pose>#{$enableGroundTruth}</publish_nested_model_pose>
+        <use_pose_vector_msg>true</use_pose_vector_msg>
+        <static_publisher>false</static_publisher>
       </plugin>
       <!-- Battery plugin -->
       <plugin filename="libignition-gazebo-linearbatteryplugin-system.so"

--- a/submitted_models/marble_qav500_sensor_config_1/launch/spawner.rb
+++ b/submitted_models/marble_qav500_sensor_config_1/launch/spawner.rb
@@ -17,10 +17,20 @@ def spawner(_name, _modelURI, _worldName, _x, _y, _z, _roll, _pitch, _yaw)
           <publish_sensor_pose>true</publish_sensor_pose>
           <publish_collision_pose>false</publish_collision_pose>
           <publish_visual_pose>false</publish_visual_pose>
-          <publish_nested_model_pose>#{$enableGroundTruth}</publish_nested_model_pose>
+          <publish_nested_model_pose>false</publish_nested_model_pose>
           <use_pose_vector_msg>true</use_pose_vector_msg>
           <static_publisher>true</static_publisher>
           <static_update_frequency>1</static_update_frequency>
+        </plugin>
+        <plugin filename="libignition-gazebo-pose-publisher-system.so"
+          name="ignition::gazebo::systems::PosePublisher">
+          <publish_link_pose>false</publish_link_pose>
+          <publish_sensor_pose>false</publish_sensor_pose>
+          <publish_collision_pose>false</publish_collision_pose>
+          <publish_visual_pose>false</publish_visual_pose>
+          <publish_nested_model_pose>#{$enableGroundTruth}</publish_nested_model_pose>
+          <use_pose_vector_msg>true</use_pose_vector_msg>
+          <static_publisher>false</static_publisher>
         </plugin>
         <plugin filename="libignition-gazebo-multicopter-motor-model-system.so"
         name="ignition::gazebo::systems::MulticopterMotorModel">

--- a/submitted_models/robotika_freyja_sensor_config_1/launch/spawner.rb
+++ b/submitted_models/robotika_freyja_sensor_config_1/launch/spawner.rb
@@ -32,10 +32,20 @@ def spawner(_name, _modelURI, _worldName, _x, _y, _z, _roll, _pitch, _yaw)
           <publish_sensor_pose>true</publish_sensor_pose>
           <publish_collision_pose>false</publish_collision_pose>
           <publish_visual_pose>false</publish_visual_pose>
-          <publish_nested_model_pose>#{$enableGroundTruth}</publish_nested_model_pose>
+          <publish_nested_model_pose>false</publish_nested_model_pose>
           <use_pose_vector_msg>true</use_pose_vector_msg>
           <static_publisher>true</static_publisher>
           <static_update_frequency>1</static_update_frequency>
+        </plugin>
+        <plugin filename=\"libignition-gazebo-pose-publisher-system.so\"
+          name="ignition::gazebo::systems::PosePublisher">
+          <publish_link_pose>false</publish_link_pose>
+          <publish_sensor_pose>false</publish_sensor_pose>
+          <publish_collision_pose>false</publish_collision_pose>
+          <publish_visual_pose>false</publish_visual_pose>
+          <publish_nested_model_pose>#{$enableGroundTruth}</publish_nested_model_pose>
+          <use_pose_vector_msg>true</use_pose_vector_msg>
+          <static_publisher>false</static_publisher>
         </plugin>
         <!-- Battery plugin -->
         <plugin filename=\"libignition-gazebo-linearbatteryplugin-system.so\"

--- a/submitted_models/robotika_freyja_sensor_config_2/launch/spawner.rb
+++ b/submitted_models/robotika_freyja_sensor_config_2/launch/spawner.rb
@@ -32,10 +32,20 @@ def spawner(_name, _modelURI, _worldName, _x, _y, _z, _roll, _pitch, _yaw)
           <publish_sensor_pose>true</publish_sensor_pose>
           <publish_collision_pose>false</publish_collision_pose>
           <publish_visual_pose>false</publish_visual_pose>
-          <publish_nested_model_pose>#{$enableGroundTruth}</publish_nested_model_pose>
+          <publish_nested_model_pose>false</publish_nested_model_pose>
           <use_pose_vector_msg>true</use_pose_vector_msg>
           <static_publisher>true</static_publisher>
           <static_update_frequency>1</static_update_frequency>
+        </plugin>
+        <plugin filename=\"libignition-gazebo-pose-publisher-system.so\"
+          name="ignition::gazebo::systems::PosePublisher">
+          <publish_link_pose>false</publish_link_pose>
+          <publish_sensor_pose>false</publish_sensor_pose>
+          <publish_collision_pose>false</publish_collision_pose>
+          <publish_visual_pose>false</publish_visual_pose>
+          <publish_nested_model_pose>#{$enableGroundTruth}</publish_nested_model_pose>
+          <use_pose_vector_msg>true</use_pose_vector_msg>
+          <static_publisher>false</static_publisher>
         </plugin>
         <!-- Battery plugin -->
         <plugin filename=\"libignition-gazebo-linearbatteryplugin-system.so\"

--- a/submitted_models/robotika_kloubak_sensor_config_1/launch/spawner.rb
+++ b/submitted_models/robotika_kloubak_sensor_config_1/launch/spawner.rb
@@ -45,10 +45,20 @@ def spawner(_name, _modelURI, _worldName, _x, _y, _z, _roll, _pitch, _yaw)
           <publish_sensor_pose>true</publish_sensor_pose>
           <publish_collision_pose>false</publish_collision_pose>
           <publish_visual_pose>false</publish_visual_pose>
-          <publish_nested_model_pose>#{$enableGroundTruth}</publish_nested_model_pose>
+          <publish_nested_model_pose>false</publish_nested_model_pose>
           <use_pose_vector_msg>true</use_pose_vector_msg>
           <static_publisher>true</static_publisher>
           <static_update_frequency>1</static_update_frequency>
+        </plugin>
+        <plugin filename=\"libignition-gazebo-pose-publisher-system.so\"
+          name="ignition::gazebo::systems::PosePublisher">
+          <publish_link_pose>false</publish_link_pose>
+          <publish_sensor_pose>false</publish_sensor_pose>
+          <publish_collision_pose>false</publish_collision_pose>
+          <publish_visual_pose>false</publish_visual_pose>
+          <publish_nested_model_pose>#{$enableGroundTruth}</publish_nested_model_pose>
+          <use_pose_vector_msg>true</use_pose_vector_msg>
+          <static_publisher>false</static_publisher>
         </plugin>
         <!-- Battery plugin -->
         <plugin filename=\"libignition-gazebo-linearbatteryplugin-system.so\"

--- a/submitted_models/robotika_kloubak_sensor_config_2/launch/spawner.rb
+++ b/submitted_models/robotika_kloubak_sensor_config_2/launch/spawner.rb
@@ -45,10 +45,20 @@ def spawner(_name, _modelURI, _worldName, _x, _y, _z, _roll, _pitch, _yaw)
           <publish_sensor_pose>true</publish_sensor_pose>
           <publish_collision_pose>false</publish_collision_pose>
           <publish_visual_pose>false</publish_visual_pose>
-          <publish_nested_model_pose>#{$enableGroundTruth}</publish_nested_model_pose>
+          <publish_nested_model_pose>false</publish_nested_model_pose>
           <use_pose_vector_msg>true</use_pose_vector_msg>
           <static_publisher>true</static_publisher>
           <static_update_frequency>1</static_update_frequency>
+        </plugin>
+        <plugin filename=\"libignition-gazebo-pose-publisher-system.so\"
+          name="ignition::gazebo::systems::PosePublisher">
+          <publish_link_pose>false</publish_link_pose>
+          <publish_sensor_pose>false</publish_sensor_pose>
+          <publish_collision_pose>false</publish_collision_pose>
+          <publish_visual_pose>false</publish_visual_pose>
+          <publish_nested_model_pose>#{$enableGroundTruth}</publish_nested_model_pose>
+          <use_pose_vector_msg>true</use_pose_vector_msg>
+          <static_publisher>false</static_publisher>
         </plugin>
         <!-- Battery plugin -->
         <plugin filename=\"libignition-gazebo-linearbatteryplugin-system.so\"

--- a/submitted_models/robotika_x2_sensor_config_1/launch/spawner.rb
+++ b/submitted_models/robotika_x2_sensor_config_1/launch/spawner.rb
@@ -32,10 +32,20 @@ def spawner(_name, _modelURI, _worldName, _x, _y, _z, _roll, _pitch, _yaw)
         <publish_sensor_pose>true</publish_sensor_pose>
         <publish_collision_pose>false</publish_collision_pose>
         <publish_visual_pose>false</publish_visual_pose>
-        <publish_nested_model_pose>#{$enableGroundTruth}</publish_nested_model_pose>
+        <publish_nested_model_pose>false</publish_nested_model_pose>
         <use_pose_vector_msg>true</use_pose_vector_msg>
         <static_publisher>true</static_publisher>
         <static_update_frequency>1</static_update_frequency>
+      </plugin>
+      <plugin filename="libignition-gazebo-pose-publisher-system.so"
+        name="ignition::gazebo::systems::PosePublisher">
+        <publish_link_pose>false</publish_link_pose>
+        <publish_sensor_pose>false</publish_sensor_pose>
+        <publish_collision_pose>false</publish_collision_pose>
+        <publish_visual_pose>false</publish_visual_pose>
+        <publish_nested_model_pose>#{$enableGroundTruth}</publish_nested_model_pose>
+        <use_pose_vector_msg>true</use_pose_vector_msg>
+        <static_publisher>false</static_publisher>
       </plugin>
       <!-- Battery plugin -->
       <plugin filename="libignition-gazebo-linearbatteryplugin-system.so"

--- a/submitted_models/sophisticated_engineering_x2_sensor_config_1/launch/spawner.rb
+++ b/submitted_models/sophisticated_engineering_x2_sensor_config_1/launch/spawner.rb
@@ -34,10 +34,20 @@ def spawner(_name, _modelURI, _worldName, _x, _y, _z, _roll, _pitch, _yaw)
         <publish_sensor_pose>true</publish_sensor_pose>
         <publish_collision_pose>false</publish_collision_pose>
         <publish_visual_pose>false</publish_visual_pose>
-        <publish_nested_model_pose>#{$enableGroundTruth}</publish_nested_model_pose>
+        <publish_nested_model_pose>false</publish_nested_model_pose>
         <use_pose_vector_msg>true</use_pose_vector_msg>
         <static_publisher>true</static_publisher>
         <static_update_frequency>1</static_update_frequency>
+      </plugin>
+      <plugin filename="libignition-gazebo-pose-publisher-system.so"
+        name="ignition::gazebo::systems::PosePublisher">
+        <publish_link_pose>false</publish_link_pose>
+        <publish_sensor_pose>false</publish_sensor_pose>
+        <publish_collision_pose>false</publish_collision_pose>
+        <publish_visual_pose>false</publish_visual_pose>
+        <publish_nested_model_pose>#{$enableGroundTruth}</publish_nested_model_pose>
+        <use_pose_vector_msg>true</use_pose_vector_msg>
+        <static_publisher>false</static_publisher>
       </plugin>
       <!-- Battery plugin -->
       <plugin filename="libignition-gazebo-linearbatteryplugin-system.so"

--- a/submitted_models/sophisticated_engineering_x4_sensor_config_1/launch/spawner.rb
+++ b/submitted_models/sophisticated_engineering_x4_sensor_config_1/launch/spawner.rb
@@ -19,10 +19,20 @@ def spawner(_name, _modelURI, _worldName, _x, _y, _z, _roll, _pitch, _yaw)
         <publish_sensor_pose>true</publish_sensor_pose>
         <publish_collision_pose>false</publish_collision_pose>
         <publish_visual_pose>false</publish_visual_pose>
-        <publish_nested_model_pose>#{$enableGroundTruth}</publish_nested_model_pose>
+        <publish_nested_model_pose>false</publish_nested_model_pose>
         <use_pose_vector_msg>true</use_pose_vector_msg>
         <static_publisher>true</static_publisher>
         <static_update_frequency>1</static_update_frequency>
+      </plugin>
+      <plugin filename="libignition-gazebo-pose-publisher-system.so"
+        name="ignition::gazebo::systems::PosePublisher">
+        <publish_link_pose>false</publish_link_pose>
+        <publish_sensor_pose>false</publish_sensor_pose>
+        <publish_collision_pose>false</publish_collision_pose>
+        <publish_visual_pose>false</publish_visual_pose>
+        <publish_nested_model_pose>#{$enableGroundTruth}</publish_nested_model_pose>
+        <use_pose_vector_msg>true</use_pose_vector_msg>
+        <static_publisher>false</static_publisher>
       </plugin>
       <plugin filename="libignition-gazebo-multicopter-motor-model-system.so"
         name="ignition::gazebo::systems::MulticopterMotorModel">

--- a/submitted_models/ssci_x2_sensor_config_1/launch/spawner.rb
+++ b/submitted_models/ssci_x2_sensor_config_1/launch/spawner.rb
@@ -46,10 +46,20 @@ def spawner(_name, _modelURI, _worldName, _x, _y, _z, _roll, _pitch, _yaw)
           <publish_sensor_pose>true</publish_sensor_pose>
           <publish_collision_pose>false</publish_collision_pose>
           <publish_visual_pose>false</publish_visual_pose>
-          <publish_nested_model_pose>#{$enableGroundTruth}</publish_nested_model_pose>
+          <publish_nested_model_pose>false</publish_nested_model_pose>
           <use_pose_vector_msg>true</use_pose_vector_msg>
           <static_publisher>true</static_publisher>
           <static_update_frequency>1</static_update_frequency>
+        </plugin>
+        <plugin filename=\"libignition-gazebo-pose-publisher-system.so\"
+          name="ignition::gazebo::systems::PosePublisher">
+          <publish_link_pose>false</publish_link_pose>
+          <publish_sensor_pose>false</publish_sensor_pose>
+          <publish_collision_pose>false</publish_collision_pose>
+          <publish_visual_pose>false</publish_visual_pose>
+          <publish_nested_model_pose>#{$enableGroundTruth}</publish_nested_model_pose>
+          <use_pose_vector_msg>true</use_pose_vector_msg>
+          <static_publisher>false</static_publisher>
         </plugin>
         <!-- Battery plugin -->
         <plugin filename=\"libignition-gazebo-linearbatteryplugin-system.so\"

--- a/submitted_models/ssci_x4_sensor_config_1/launch/spawner.rb
+++ b/submitted_models/ssci_x4_sensor_config_1/launch/spawner.rb
@@ -41,10 +41,20 @@ def spawner(_name, _modelURI, _worldName, _x, _y, _z, _roll, _pitch, _yaw)
           <publish_sensor_pose>true</publish_sensor_pose>
           <publish_collision_pose>false</publish_collision_pose>
           <publish_visual_pose>false</publish_visual_pose>
-          <publish_nested_model_pose>#{$enableGroundTruth}</publish_nested_model_pose>
+          <publish_nested_model_pose>false</publish_nested_model_pose>
           <use_pose_vector_msg>true</use_pose_vector_msg>
           <static_publisher>true</static_publisher>
           <static_update_frequency>1</static_update_frequency>
+        </plugin>
+        <plugin filename="libignition-gazebo-pose-publisher-system.so"
+          name="ignition::gazebo::systems::PosePublisher">
+          <publish_link_pose>false</publish_link_pose>
+          <publish_sensor_pose>false</publish_sensor_pose>
+          <publish_collision_pose>false</publish_collision_pose>
+          <publish_visual_pose>false</publish_visual_pose>
+          <publish_nested_model_pose>#{$enableGroundTruth}</publish_nested_model_pose>
+          <use_pose_vector_msg>true</use_pose_vector_msg>
+          <static_publisher>false</static_publisher>
         </plugin>
         <plugin filename="libignition-gazebo-multicopter-motor-model-system.so"
           name="ignition::gazebo::systems::MulticopterMotorModel">

--- a/submitted_models/ssci_x4_sensor_config_2/launch/spawner.rb
+++ b/submitted_models/ssci_x4_sensor_config_2/launch/spawner.rb
@@ -36,10 +36,20 @@ def spawner(_name, _modelURI, _worldName, _x, _y, _z, _roll, _pitch, _yaw)
           <publish_sensor_pose>true</publish_sensor_pose>
           <publish_collision_pose>false</publish_collision_pose>
           <publish_visual_pose>false</publish_visual_pose>
-          <publish_nested_model_pose>#{$enableGroundTruth}</publish_nested_model_pose>
+          <publish_nested_model_pose>false</publish_nested_model_pose>
           <use_pose_vector_msg>true</use_pose_vector_msg>
           <static_publisher>true</static_publisher>
           <static_update_frequency>1</static_update_frequency>
+        </plugin>
+        <plugin filename="libignition-gazebo-pose-publisher-system.so"
+          name="ignition::gazebo::systems::PosePublisher">
+          <publish_link_pose>false</publish_link_pose>
+          <publish_sensor_pose>false</publish_sensor_pose>
+          <publish_collision_pose>false</publish_collision_pose>
+          <publish_visual_pose>false</publish_visual_pose>
+          <publish_nested_model_pose>#{$enableGroundTruth}</publish_nested_model_pose>
+          <use_pose_vector_msg>true</use_pose_vector_msg>
+          <static_publisher>false</static_publisher>
         </plugin>
         <plugin filename="libignition-gazebo-multicopter-motor-model-system.so"
           name="ignition::gazebo::systems::MulticopterMotorModel">

--- a/submitted_models/x1_sensor_config_6/launch/spawner.rb
+++ b/submitted_models/x1_sensor_config_6/launch/spawner.rb
@@ -32,10 +32,20 @@ def spawner(_name, _modelURI, _worldName, _x, _y, _z, _roll, _pitch, _yaw)
         <publish_sensor_pose>true</publish_sensor_pose>
         <publish_collision_pose>false</publish_collision_pose>
         <publish_visual_pose>false</publish_visual_pose>
-        <publish_nested_model_pose>#{$enableGroundTruth}</publish_nested_model_pose>
+        <publish_nested_model_pose>false</publish_nested_model_pose>
         <use_pose_vector_msg>true</use_pose_vector_msg>
         <static_publisher>true</static_publisher>
         <static_update_frequency>1</static_update_frequency>
+      </plugin>
+      <plugin filename="libignition-gazebo-pose-publisher-system.so"
+        name="ignition::gazebo::systems::PosePublisher">
+        <publish_link_pose>false</publish_link_pose>
+        <publish_sensor_pose>false</publish_sensor_pose>
+        <publish_collision_pose>false</publish_collision_pose>
+        <publish_visual_pose>false</publish_visual_pose>
+        <publish_nested_model_pose>#{$enableGroundTruth}</publish_nested_model_pose>
+        <use_pose_vector_msg>true</use_pose_vector_msg>
+        <static_publisher>false</static_publisher>
       </plugin>
       <!-- Battery plugin -->
       <plugin filename="libignition-gazebo-linearbatteryplugin-system.so"

--- a/submitted_models/x2_sensor_config_7/launch/spawner.rb
+++ b/submitted_models/x2_sensor_config_7/launch/spawner.rb
@@ -32,10 +32,20 @@ def spawner(_name, _modelURI, _worldName, _x, _y, _z, _roll, _pitch, _yaw)
         <publish_sensor_pose>true</publish_sensor_pose>
         <publish_collision_pose>false</publish_collision_pose>
         <publish_visual_pose>false</publish_visual_pose>
-        <publish_nested_model_pose>#{$enableGroundTruth}</publish_nested_model_pose>
+        <publish_nested_model_pose>false</publish_nested_model_pose>
         <use_pose_vector_msg>true</use_pose_vector_msg>
         <static_publisher>true</static_publisher>
         <static_update_frequency>1</static_update_frequency>
+      </plugin>
+      <plugin filename="libignition-gazebo-pose-publisher-system.so"
+        name="ignition::gazebo::systems::PosePublisher">
+        <publish_link_pose>false</publish_link_pose>
+        <publish_sensor_pose>false</publish_sensor_pose>
+        <publish_collision_pose>false</publish_collision_pose>
+        <publish_visual_pose>false</publish_visual_pose>
+        <publish_nested_model_pose>#{$enableGroundTruth}</publish_nested_model_pose>
+        <use_pose_vector_msg>true</use_pose_vector_msg>
+        <static_publisher>false</static_publisher>
       </plugin>
       <!-- Battery plugin -->
       <plugin filename="libignition-gazebo-linearbatteryplugin-system.so"

--- a/submitted_models/x3_sensor_config_5/launch/spawner.rb
+++ b/submitted_models/x3_sensor_config_5/launch/spawner.rb
@@ -17,10 +17,20 @@ def spawner(_name, _modelURI, _worldName, _x, _y, _z, _roll, _pitch, _yaw)
         <publish_sensor_pose>true</publish_sensor_pose>
         <publish_collision_pose>false</publish_collision_pose>
         <publish_visual_pose>false</publish_visual_pose>
-        <publish_nested_model_pose>#{$enableGroundTruth}</publish_nested_model_pose>
+        <publish_nested_model_pose>false</publish_nested_model_pose>
         <use_pose_vector_msg>true</use_pose_vector_msg>
         <static_publisher>true</static_publisher>
         <static_update_frequency>1</static_update_frequency>
+      </plugin>
+      <plugin filename="libignition-gazebo-pose-publisher-system.so"
+        name="ignition::gazebo::systems::PosePublisher">
+        <publish_link_pose>false</publish_link_pose>
+        <publish_sensor_pose>false</publish_sensor_pose>
+        <publish_collision_pose>false</publish_collision_pose>
+        <publish_visual_pose>false</publish_visual_pose>
+        <publish_nested_model_pose>#{$enableGroundTruth}</publish_nested_model_pose>
+        <use_pose_vector_msg>true</use_pose_vector_msg>
+        <static_publisher>false</static_publisher>
       </plugin>
       <plugin filename="libignition-gazebo-multicopter-motor-model-system.so"
         name="ignition::gazebo::systems::MulticopterMotorModel">

--- a/submitted_models/x4_sensor_config_6/launch/spawner.rb
+++ b/submitted_models/x4_sensor_config_6/launch/spawner.rb
@@ -17,10 +17,20 @@ def spawner(_name, _modelURI, _worldName, _x, _y, _z, _roll, _pitch, _yaw)
           <publish_sensor_pose>true</publish_sensor_pose>
           <publish_collision_pose>false</publish_collision_pose>
           <publish_visual_pose>false</publish_visual_pose>
-          <publish_nested_model_pose>#{$enableGroundTruth}</publish_nested_model_pose>
+          <publish_nested_model_pose>false</publish_nested_model_pose>
           <use_pose_vector_msg>true</use_pose_vector_msg>
           <static_publisher>true</static_publisher>
           <static_update_frequency>1</static_update_frequency>
+        </plugin>
+        <plugin filename="libignition-gazebo-pose-publisher-system.so"
+          name="ignition::gazebo::systems::PosePublisher">
+          <publish_link_pose>false</publish_link_pose>
+          <publish_sensor_pose>false</publish_sensor_pose>
+          <publish_collision_pose>false</publish_collision_pose>
+          <publish_visual_pose>false</publish_visual_pose>
+          <publish_nested_model_pose>#{$enableGroundTruth}</publish_nested_model_pose>
+          <use_pose_vector_msg>true</use_pose_vector_msg>
+          <static_publisher>false</static_publisher>
         </plugin>
         <plugin filename="libignition-gazebo-multicopter-motor-model-system.so"
           name="ignition::gazebo::systems::MulticopterMotorModel">

--- a/subt_ign/launch/cave_circuit.ign
+++ b/subt_ign/launch/cave_circuit.ign
@@ -707,10 +707,20 @@
             <publish_sensor_pose>true</publish_sensor_pose>
             <publish_collision_pose>false</publish_collision_pose>
             <publish_visual_pose>false</publish_visual_pose>
-            <publish_nested_model_pose>#{$enableGroundTruth}</publish_nested_model_pose>
+            <publish_nested_model_pose>false</publish_nested_model_pose>
             <use_pose_vector_msg>true</use_pose_vector_msg>
             <static_publisher>true</static_publisher>
             <static_update_frequency>1</static_update_frequency>
+          </plugin>
+          <plugin filename="libignition-gazebo-pose-publisher-system.so"
+            name="ignition::gazebo::systems::PosePublisher">
+            <publish_link_pose>false</publish_link_pose>
+            <publish_sensor_pose>false</publish_sensor_pose>
+            <publish_collision_pose>false</publish_collision_pose>
+            <publish_visual_pose>false</publish_visual_pose>
+            <publish_nested_model_pose>#{$enableGroundTruth}</publish_nested_model_pose>
+            <use_pose_vector_msg>true</use_pose_vector_msg>
+            <static_publisher>false</static_publisher>
           </plugin>
           <!-- Battery plugin -->
           <plugin filename="libignition-gazebo-linearbatteryplugin-system.so"
@@ -849,10 +859,20 @@
             <publish_sensor_pose>true</publish_sensor_pose>
             <publish_collision_pose>false</publish_collision_pose>
             <publish_visual_pose>false</publish_visual_pose>
-            <publish_nested_model_pose>#{$enableGroundTruth}</publish_nested_model_pose>
+            <publish_nested_model_pose>false</publish_nested_model_pose>
             <use_pose_vector_msg>true</use_pose_vector_msg>
             <static_publisher>true</static_publisher>
             <static_update_frequency>1</static_update_frequency>
+          </plugin>
+          <plugin filename="libignition-gazebo-pose-publisher-system.so"
+            name="ignition::gazebo::systems::PosePublisher">
+            <publish_link_pose>false</publish_link_pose>
+            <publish_sensor_pose>false</publish_sensor_pose>
+            <publish_collision_pose>false</publish_collision_pose>
+            <publish_visual_pose>false</publish_visual_pose>
+            <publish_nested_model_pose>#{$enableGroundTruth}</publish_nested_model_pose>
+            <use_pose_vector_msg>true</use_pose_vector_msg>
+            <static_publisher>false</static_publisher>
           </plugin>
           <!-- Battery plugin -->
           <plugin filename="libignition-gazebo-linearbatteryplugin-system.so"

--- a/subt_ign/launch/cloudsim_sim.ign
+++ b/subt_ign/launch/cloudsim_sim.ign
@@ -584,10 +584,20 @@
             <publish_sensor_pose>true</publish_sensor_pose>
             <publish_collision_pose>false</publish_collision_pose>
             <publish_visual_pose>false</publish_visual_pose>
-            <publish_nested_model_pose>#{$enableGroundTruth}</publish_nested_model_pose>
+            <publish_nested_model_pose>false</publish_nested_model_pose>
             <use_pose_vector_msg>true</use_pose_vector_msg>
             <static_publisher>true</static_publisher>
             <static_update_frequency>1</static_update_frequency>
+          </plugin>
+          <plugin filename="libignition-gazebo-pose-publisher-system.so"
+            name="ignition::gazebo::systems::PosePublisher">
+            <publish_link_pose>false</publish_link_pose>
+            <publish_sensor_pose>false</publish_sensor_pose>
+            <publish_collision_pose>false</publish_collision_pose>
+            <publish_visual_pose>false</publish_visual_pose>
+            <publish_nested_model_pose>#{$enableGroundTruth}</publish_nested_model_pose>
+            <use_pose_vector_msg>true</use_pose_vector_msg>
+            <static_publisher>false</static_publisher>
           </plugin>
           <!-- Battery plugin -->
           <plugin filename="libignition-gazebo-linearbatteryplugin-system.so"
@@ -726,10 +736,20 @@
             <publish_sensor_pose>true</publish_sensor_pose>
             <publish_collision_pose>false</publish_collision_pose>
             <publish_visual_pose>false</publish_visual_pose>
-            <publish_nested_model_pose>#{$enableGroundTruth}</publish_nested_model_pose>
+            <publish_nested_model_pose>false</publish_nested_model_pose>
             <use_pose_vector_msg>true</use_pose_vector_msg>
             <static_publisher>true</static_publisher>
             <static_update_frequency>1</static_update_frequency>
+          </plugin>
+          <plugin filename="libignition-gazebo-pose-publisher-system.so"
+            name="ignition::gazebo::systems::PosePublisher">
+            <publish_link_pose>false</publish_link_pose>
+            <publish_sensor_pose>false</publish_sensor_pose>
+            <publish_collision_pose>false</publish_collision_pose>
+            <publish_visual_pose>false</publish_visual_pose>
+            <publish_nested_model_pose>#{$enableGroundTruth}</publish_nested_model_pose>
+            <use_pose_vector_msg>true</use_pose_vector_msg>
+            <static_publisher>false</static_publisher>
           </plugin>
           <!-- Battery plugin -->
           <plugin filename="libignition-gazebo-linearbatteryplugin-system.so"

--- a/subt_ign/launch/competition.ign
+++ b/subt_ign/launch/competition.ign
@@ -508,10 +508,20 @@
             <publish_sensor_pose>true</publish_sensor_pose>
             <publish_collision_pose>false</publish_collision_pose>
             <publish_visual_pose>false</publish_visual_pose>
-            <publish_nested_model_pose>#{$enableGroundTruth}</publish_nested_model_pose>
+            <publish_nested_model_pose>false</publish_nested_model_pose>
             <use_pose_vector_msg>true</use_pose_vector_msg>
             <static_publisher>true</static_publisher>
             <static_update_frequency>1</static_update_frequency>
+          </plugin>
+          <plugin filename="libignition-gazebo-pose-publisher-system.so"
+            name="ignition::gazebo::systems::PosePublisher">
+            <publish_link_pose>false</publish_link_pose>
+            <publish_sensor_pose>false</publish_sensor_pose>
+            <publish_collision_pose>false</publish_collision_pose>
+            <publish_visual_pose>false</publish_visual_pose>
+            <publish_nested_model_pose>#{$enableGroundTruth}</publish_nested_model_pose>
+            <use_pose_vector_msg>true</use_pose_vector_msg>
+            <static_publisher>false</static_publisher>
           </plugin>
           <!-- Battery plugin -->
           <plugin filename="libignition-gazebo-linearbatteryplugin-system.so"
@@ -650,10 +660,20 @@
             <publish_sensor_pose>true</publish_sensor_pose>
             <publish_collision_pose>false</publish_collision_pose>
             <publish_visual_pose>false</publish_visual_pose>
-            <publish_nested_model_pose>#{$enableGroundTruth}</publish_nested_model_pose>
+            <publish_nested_model_pose>false</publish_nested_model_pose>
             <use_pose_vector_msg>true</use_pose_vector_msg>
             <static_publisher>true</static_publisher>
             <static_update_frequency>1</static_update_frequency>
+          </plugin>
+          <plugin filename="libignition-gazebo-pose-publisher-system.so"
+            name="ignition::gazebo::systems::PosePublisher">
+            <publish_link_pose>false</publish_link_pose>
+            <publish_sensor_pose>false</publish_sensor_pose>
+            <publish_collision_pose>false</publish_collision_pose>
+            <publish_visual_pose>false</publish_visual_pose>
+            <publish_nested_model_pose>#{$enableGroundTruth}</publish_nested_model_pose>
+            <use_pose_vector_msg>true</use_pose_vector_msg>
+            <static_publisher>false</static_publisher>
           </plugin>
           <!-- Battery plugin -->
           <plugin filename="libignition-gazebo-linearbatteryplugin-system.so"

--- a/subt_ign/launch/competition_no_ros.ign
+++ b/subt_ign/launch/competition_no_ros.ign
@@ -430,10 +430,20 @@
     "      <publish_sensor_pose>true</publish_sensor_pose>\n"\
     "      <publish_collision_pose>false</publish_collision_pose>\n"\
     "      <publish_visual_pose>false</publish_visual_pose>\n"\
-    "      <publish_nested_model_pose>#{$enableGroundTruth}</publish_nested_model_pose>\n"\
+    "      <publish_nested_model_pose>false</publish_nested_model_pose>\n"\
     "      <use_pose_vector_msg>true</use_pose_vector_msg>\n"\
     "      <static_publisher>true</static_publisher>\n"\
     "      <static_update_frequency>1</static_update_frequency>\n"\
+    "    </plugin>\n"\
+    "    <plugin filename=\"libignition-gazebo-pose-publisher-system.so\"\n"\
+    "      name=\"ignition::gazebo::systems::PosePublisher\">\n"\
+    "      <publish_link_pose>false</publish_link_pose>\n"\
+    "      <publish_sensor_pose>false</publish_sensor_pose>\n"\
+    "      <publish_collision_pose>false</publish_collision_pose>\n"\
+    "      <publish_visual_pose>false</publish_visual_pose>\n"\
+    "      <publish_nested_model_pose>#{$enableGroundTruth}</publish_nested_model_pose>\n"\
+    "      <use_pose_vector_msg>true</use_pose_vector_msg>\n"\
+    "      <static_publisher>false</static_publisher>\n"\
     "    </plugin>\n"\
     "    <!-- Battery plugin -->\n"\
     "    <plugin filename=\"libignition-gazebo-linearbatteryplugin-system.so\"\n"\
@@ -497,10 +507,20 @@
     "      <publish_sensor_pose>true</publish_sensor_pose>\n"\
     "      <publish_collision_pose>false</publish_collision_pose>\n"\
     "      <publish_visual_pose>false</publish_visual_pose>\n"\
-    "      <publish_nested_model_pose>#{$enableGroundTruth}</publish_nested_model_pose>\n"\
+    "      <publish_nested_model_pose>false</publish_nested_model_pose>\n"\
     "      <use_pose_vector_msg>true</use_pose_vector_msg>\n"\
     "      <static_publisher>true</static_publisher>\n"\
     "      <static_update_frequency>1</static_update_frequency>\n"\
+    "    </plugin>\n"\
+    "    <plugin filename=\"libignition-gazebo-pose-publisher-system.so\"\n"\
+    "      name=\"ignition::gazebo::systems::PosePublisher\">\n"\
+    "      <publish_link_pose>false</publish_link_pose>\n"\
+    "      <publish_sensor_pose>false</publish_sensor_pose>\n"\
+    "      <publish_collision_pose>false</publish_collision_pose>\n"\
+    "      <publish_visual_pose>false</publish_visual_pose>\n"\
+    "      <publish_nested_model_pose>#{$enableGroundTruth}</publish_nested_model_pose>\n"\
+    "      <use_pose_vector_msg>true</use_pose_vector_msg>\n"\
+    "      <static_publisher>false</static_publisher>\n"\
     "    </plugin>\n"\
     "    <!-- Battery plugin -->\n"\
     "    <plugin filename=\"libignition-gazebo-linearbatteryplugin-system.so\"\n"\
@@ -550,10 +570,20 @@
     "      <publish_sensor_pose>true</publish_sensor_pose>\n"\
     "      <publish_collision_pose>false</publish_collision_pose>\n"\
     "      <publish_visual_pose>false</publish_visual_pose>\n"\
-    "      <publish_nested_model_pose>#{$enableGroundTruth}</publish_nested_model_pose>\n"\
+    "      <publish_nested_model_pose>false</publish_nested_model_pose>\n"\
     "      <use_pose_vector_msg>true</use_pose_vector_msg>\n"\
     "      <static_publisher>true</static_publisher>\n"\
     "      <static_update_frequency>1</static_update_frequency>\n"\
+    "    </plugin>\n"\
+    "    <plugin filename=\"libignition-gazebo-pose-publisher-system.so\"\n"\
+    "      name=\"ignition::gazebo::systems::PosePublisher\">\n"\
+    "      <publish_link_pose>false</publish_link_pose>\n"\
+    "      <publish_sensor_pose>false</publish_sensor_pose>\n"\
+    "      <publish_collision_pose>false</publish_collision_pose>\n"\
+    "      <publish_visual_pose>false</publish_visual_pose>\n"\
+    "      <publish_nested_model_pose>#{$enableGroundTruth}</publish_nested_model_pose>\n"\
+    "      <use_pose_vector_msg>true</use_pose_vector_msg>\n"\
+    "      <static_publisher>false</static_publisher>\n"\
     "    </plugin>\n"\
     "    <plugin filename=\"libignition-gazebo-multicopter-motor-model-system.so\"\n"\
     "      name=\"ignition::gazebo::systems::MulticopterMotorModel\">\n"\
@@ -733,10 +763,20 @@
     "      <publish_sensor_pose>true</publish_sensor_pose>\n"\
     "      <publish_collision_pose>false</publish_collision_pose>\n"\
     "      <publish_visual_pose>false</publish_visual_pose>\n"\
-    "      <publish_nested_model_pose>#{$enableGroundTruth}</publish_nested_model_pose>\n"\
+    "      <publish_nested_model_pose>false</publish_nested_model_pose>\n"\
     "      <use_pose_vector_msg>true</use_pose_vector_msg>\n"\
     "      <static_publisher>true</static_publisher>\n"\
     "      <static_update_frequency>1</static_update_frequency>\n"\
+    "    </plugin>\n"\
+    "    <plugin filename=\"libignition-gazebo-pose-publisher-system.so\"\n"\
+    "      name=\"ignition::gazebo::systems::PosePublisher\">\n"\
+    "      <publish_link_pose>false</publish_link_pose>\n"\
+    "      <publish_sensor_pose>false</publish_sensor_pose>\n"\
+    "      <publish_collision_pose>false</publish_collision_pose>\n"\
+    "      <publish_visual_pose>false</publish_visual_pose>\n"\
+    "      <publish_nested_model_pose>#{$enableGroundTruth}</publish_nested_model_pose>\n"\
+    "      <use_pose_vector_msg>true</use_pose_vector_msg>\n"\
+    "      <static_publisher>false</static_publisher>\n"\
     "    </plugin>\n"\
     "    <plugin filename=\"libignition-gazebo-multicopter-motor-model-system.so\"\n"\
     "      name=\"ignition::gazebo::systems::MulticopterMotorModel\">\n"\

--- a/subt_ign/launch/tunnel_circuit_practice.ign
+++ b/subt_ign/launch/tunnel_circuit_practice.ign
@@ -511,10 +511,20 @@
             <publish_sensor_pose>true</publish_sensor_pose>
             <publish_collision_pose>false</publish_collision_pose>
             <publish_visual_pose>false</publish_visual_pose>
-            <publish_nested_model_pose>#{$enableGroundTruth}</publish_nested_model_pose>
+            <publish_nested_model_pose>false</publish_nested_model_pose>
             <use_pose_vector_msg>true</use_pose_vector_msg>
             <static_publisher>true</static_publisher>
             <static_update_frequency>1</static_update_frequency>
+          </plugin>
+          <plugin filename="libignition-gazebo-pose-publisher-system.so"
+            name="ignition::gazebo::systems::PosePublisher">
+            <publish_link_pose>false</publish_link_pose>
+            <publish_sensor_pose>false</publish_sensor_pose>
+            <publish_collision_pose>false</publish_collision_pose>
+            <publish_visual_pose>false</publish_visual_pose>
+            <publish_nested_model_pose>#{$enableGroundTruth}</publish_nested_model_pose>
+            <use_pose_vector_msg>true</use_pose_vector_msg>
+            <static_publisher>false</static_publisher>
           </plugin>
           <!-- Battery plugin -->
           <plugin filename="libignition-gazebo-linearbatteryplugin-system.so"
@@ -653,10 +663,20 @@
             <publish_sensor_pose>true</publish_sensor_pose>
             <publish_collision_pose>false</publish_collision_pose>
             <publish_visual_pose>false</publish_visual_pose>
-            <publish_nested_model_pose>#{$enableGroundTruth}</publish_nested_model_pose>
+            <publish_nested_model_pose>false</publish_nested_model_pose>
             <use_pose_vector_msg>true</use_pose_vector_msg>
             <static_publisher>true</static_publisher>
             <static_update_frequency>1</static_update_frequency>
+          </plugin>
+          <plugin filename="libignition-gazebo-pose-publisher-system.so"
+            name="ignition::gazebo::systems::PosePublisher">
+            <publish_link_pose>false</publish_link_pose>
+            <publish_sensor_pose>false</publish_sensor_pose>
+            <publish_collision_pose>false</publish_collision_pose>
+            <publish_visual_pose>false</publish_visual_pose>
+            <publish_nested_model_pose>#{$enableGroundTruth}</publish_nested_model_pose>
+            <use_pose_vector_msg>true</use_pose_vector_msg>
+            <static_publisher>false</static_publisher>
           </plugin>
           <!-- Battery plugin -->
           <plugin filename="libignition-gazebo-linearbatteryplugin-system.so"

--- a/subt_ign/launch/urban_circuit.ign
+++ b/subt_ign/launch/urban_circuit.ign
@@ -511,10 +511,20 @@
             <publish_sensor_pose>true</publish_sensor_pose>
             <publish_collision_pose>false</publish_collision_pose>
             <publish_visual_pose>false</publish_visual_pose>
-            <publish_nested_model_pose>#{$enableGroundTruth}</publish_nested_model_pose>
+            <publish_nested_model_pose>false</publish_nested_model_pose>
             <use_pose_vector_msg>true</use_pose_vector_msg>
             <static_publisher>true</static_publisher>
             <static_update_frequency>1</static_update_frequency>
+          </plugin>
+          <plugin filename="libignition-gazebo-pose-publisher-system.so"
+            name="ignition::gazebo::systems::PosePublisher">
+            <publish_link_pose>false</publish_link_pose>
+            <publish_sensor_pose>false</publish_sensor_pose>
+            <publish_collision_pose>false</publish_collision_pose>
+            <publish_visual_pose>false</publish_visual_pose>
+            <publish_nested_model_pose>#{$enableGroundTruth}</publish_nested_model_pose>
+            <use_pose_vector_msg>true</use_pose_vector_msg>
+            <static_publisher>false</static_publisher>
           </plugin>
           <!-- Battery plugin -->
           <plugin filename="libignition-gazebo-linearbatteryplugin-system.so"
@@ -653,10 +663,20 @@
             <publish_sensor_pose>true</publish_sensor_pose>
             <publish_collision_pose>false</publish_collision_pose>
             <publish_visual_pose>false</publish_visual_pose>
-            <publish_nested_model_pose>#{$enableGroundTruth}</publish_nested_model_pose>
+            <publish_nested_model_pose>false</publish_nested_model_pose>
             <use_pose_vector_msg>true</use_pose_vector_msg>
             <static_publisher>true</static_publisher>
             <static_update_frequency>1</static_update_frequency>
+          </plugin>
+          <plugin filename="libignition-gazebo-pose-publisher-system.so"
+            name="ignition::gazebo::systems::PosePublisher">
+            <publish_link_pose>false</publish_link_pose>
+            <publish_sensor_pose>false</publish_sensor_pose>
+            <publish_collision_pose>false</publish_collision_pose>
+            <publish_visual_pose>false</publish_visual_pose>
+            <publish_nested_model_pose>#{$enableGroundTruth}</publish_nested_model_pose>
+            <use_pose_vector_msg>true</use_pose_vector_msg>
+            <static_publisher>false</static_publisher>
           </plugin>
           <!-- Battery plugin -->
           <plugin filename="libignition-gazebo-linearbatteryplugin-system.so"

--- a/subt_ign/launch/virtual_stix.ign
+++ b/subt_ign/launch/virtual_stix.ign
@@ -395,10 +395,20 @@
     "      <publish_sensor_pose>true</publish_sensor_pose>\n"\
     "      <publish_collision_pose>false</publish_collision_pose>\n"\
     "      <publish_visual_pose>false</publish_visual_pose>\n"\
-    "      <publish_nested_model_pose>#{$enableGroundTruth}</publish_nested_model_pose>\n"\
+    "      <publish_nested_model_pose>false</publish_nested_model_pose>\n"\
     "      <use_pose_vector_msg>true</use_pose_vector_msg>\n"\
     "      <static_publisher>true</static_publisher>\n"\
     "      <static_update_frequency>1</static_update_frequency>\n"\
+    "    </plugin>\n"\
+    "    <plugin filename=\"libignition-gazebo-pose-publisher-system.so\"\n"\
+    "      name=\"ignition::gazebo::systems::PosePublisher\">\n"\
+    "      <publish_link_pose>false</publish_link_pose>\n"\
+    "      <publish_sensor_pose>false</publish_sensor_pose>\n"\
+    "      <publish_collision_pose>false</publish_collision_pose>\n"\
+    "      <publish_visual_pose>false</publish_visual_pose>\n"\
+    "      <publish_nested_model_pose>#{$enableGroundTruth}</publish_nested_model_pose>\n"\
+    "      <use_pose_vector_msg>true</use_pose_vector_msg>\n"\
+    "      <static_publisher>false</static_publisher>\n"\
     "    </plugin>\n"\
     "    <!-- Battery plugin -->\n"\
     "    <plugin filename=\"libignition-gazebo-linearbatteryplugin-system.so\"\n"\
@@ -468,10 +478,20 @@
     "      <publish_sensor_pose>true</publish_sensor_pose>\n"\
     "      <publish_collision_pose>false</publish_collision_pose>\n"\
     "      <publish_visual_pose>false</publish_visual_pose>\n"\
-    "      <publish_nested_model_pose>#{$enableGroundTruth}</publish_nested_model_pose>\n"\
+    "      <publish_nested_model_pose>false</publish_nested_model_pose>\n"\
     "      <use_pose_vector_msg>true</use_pose_vector_msg>\n"\
     "      <static_publisher>true</static_publisher>\n"\
     "      <static_update_frequency>1</static_update_frequency>\n"\
+    "    </plugin>\n"\
+    "    <plugin filename=\"libignition-gazebo-pose-publisher-system.so\"\n"\
+    "      name=\"ignition::gazebo::systems::PosePublisher\">\n"\
+    "      <publish_link_pose>false</publish_link_pose>\n"\
+    "      <publish_sensor_pose>false</publish_sensor_pose>\n"\
+    "      <publish_collision_pose>false</publish_collision_pose>\n"\
+    "      <publish_visual_pose>false</publish_visual_pose>\n"\
+    "      <publish_nested_model_pose>#{$enableGroundTruth}</publish_nested_model_pose>\n"\
+    "      <use_pose_vector_msg>true</use_pose_vector_msg>\n"\
+    "      <static_publisher>false</static_publisher>\n"\
     "    </plugin>\n"\
     "    <!-- Battery plugin -->\n"\
     "    <plugin filename=\"libignition-gazebo-linearbatteryplugin-system.so\"\n"\
@@ -527,10 +547,20 @@
     "      <publish_sensor_pose>true</publish_sensor_pose>\n"\
     "      <publish_collision_pose>false</publish_collision_pose>\n"\
     "      <publish_visual_pose>false</publish_visual_pose>\n"\
-    "      <publish_nested_model_pose>#{$enableGroundTruth}</publish_nested_model_pose>\n"\
+    "      <publish_nested_model_pose>false</publish_nested_model_pose>\n"\
     "      <use_pose_vector_msg>true</use_pose_vector_msg>\n"\
     "      <static_publisher>true</static_publisher>\n"\
     "      <static_update_frequency>1</static_update_frequency>\n"\
+    "    </plugin>\n"\
+    "    <plugin filename=\"libignition-gazebo-pose-publisher-system.so\"\n"\
+    "      name=\"ignition::gazebo::systems::PosePublisher\">\n"\
+    "      <publish_link_pose>false</publish_link_pose>\n"\
+    "      <publish_sensor_pose>false</publish_sensor_pose>\n"\
+    "      <publish_collision_pose>false</publish_collision_pose>\n"\
+    "      <publish_visual_pose>false</publish_visual_pose>\n"\
+    "      <publish_nested_model_pose>#{$enableGroundTruth}</publish_nested_model_pose>\n"\
+    "      <use_pose_vector_msg>true</use_pose_vector_msg>\n"\
+    "      <static_publisher>false</static_publisher>\n"\
     "    </plugin>\n"\
     "    <plugin filename=\"libignition-gazebo-multicopter-motor-model-system.so\"\n"\
     "      name=\"ignition::gazebo::systems::MulticopterMotorModel\">\n"\
@@ -716,10 +746,20 @@
     "      <publish_sensor_pose>true</publish_sensor_pose>\n"\
     "      <publish_collision_pose>false</publish_collision_pose>\n"\
     "      <publish_visual_pose>false</publish_visual_pose>\n"\
-    "      <publish_nested_model_pose>#{$enableGroundTruth}</publish_nested_model_pose>\n"\
+    "      <publish_nested_model_pose>false</publish_nested_model_pose>\n"\
     "      <use_pose_vector_msg>true</use_pose_vector_msg>\n"\
     "      <static_publisher>true</static_publisher>\n"\
     "      <static_update_frequency>1</static_update_frequency>\n"\
+    "    </plugin>\n"\
+    "    <plugin filename=\"libignition-gazebo-pose-publisher-system.so\"\n"\
+    "      name=\"ignition::gazebo::systems::PosePublisher\">\n"\
+    "      <publish_link_pose>false</publish_link_pose>\n"\
+    "      <publish_sensor_pose>false</publish_sensor_pose>\n"\
+    "      <publish_collision_pose>false</publish_collision_pose>\n"\
+    "      <publish_visual_pose>false</publish_visual_pose>\n"\
+    "      <publish_nested_model_pose>#{$enableGroundTruth}</publish_nested_model_pose>\n"\
+    "      <use_pose_vector_msg>true</use_pose_vector_msg>\n"\
+    "      <static_publisher>false</static_publisher>\n"\
     "    </plugin>\n"\
     "    <plugin filename=\"libignition-gazebo-multicopter-motor-model-system.so\"\n"\
     "      name=\"ignition::gazebo::systems::MulticopterMotorModel\">\n"\

--- a/subt_ign/launch/virtual_stix_headless.ign
+++ b/subt_ign/launch/virtual_stix_headless.ign
@@ -305,10 +305,20 @@
     "      <publish_sensor_pose>true</publish_sensor_pose>\n"\
     "      <publish_collision_pose>false</publish_collision_pose>\n"\
     "      <publish_visual_pose>false</publish_visual_pose>\n"\
-    "      <publish_nested_model_pose>#{$enableGroundTruth}</publish_nested_model_pose>\n"\
+    "      <publish_nested_model_pose>false</publish_nested_model_pose>\n"\
     "      <use_pose_vector_msg>true</use_pose_vector_msg>\n"\
     "      <static_publisher>true</static_publisher>\n"\
     "      <static_update_frequency>1</static_update_frequency>\n"\
+    "    </plugin>\n"\
+    "    <plugin filename=\"libignition-gazebo-pose-publisher-system.so\"\n"\
+    "      name=\"ignition::gazebo::systems::PosePublisher\">\n"\
+    "      <publish_link_pose>false</publish_link_pose>\n"\
+    "      <publish_sensor_pose>false</publish_sensor_pose>\n"\
+    "      <publish_collision_pose>false</publish_collision_pose>\n"\
+    "      <publish_visual_pose>false</publish_visual_pose>\n"\
+    "      <publish_nested_model_pose>#{$enableGroundTruth}</publish_nested_model_pose>\n"\
+    "      <use_pose_vector_msg>true</use_pose_vector_msg>\n"\
+    "      <static_publisher>false</static_publisher>\n"\
     "    </plugin>\n"\
     "    <!-- Battery plugin -->\n"\
     "    <plugin filename=\"libignition-gazebo-linearbatteryplugin-system.so\"\n"\
@@ -378,10 +388,20 @@
     "      <publish_sensor_pose>true</publish_sensor_pose>\n"\
     "      <publish_collision_pose>false</publish_collision_pose>\n"\
     "      <publish_visual_pose>false</publish_visual_pose>\n"\
-    "      <publish_nested_model_pose>#{$enableGroundTruth}</publish_nested_model_pose>\n"\
+    "      <publish_nested_model_pose>false</publish_nested_model_pose>\n"\
     "      <use_pose_vector_msg>true</use_pose_vector_msg>\n"\
     "      <static_publisher>true</static_publisher>\n"\
     "      <static_update_frequency>1</static_update_frequency>\n"\
+    "    </plugin>\n"\
+    "    <plugin filename=\"libignition-gazebo-pose-publisher-system.so\"\n"\
+    "      name=\"ignition::gazebo::systems::PosePublisher\">\n"\
+    "      <publish_link_pose>false</publish_link_pose>\n"\
+    "      <publish_sensor_pose>false</publish_sensor_pose>\n"\
+    "      <publish_collision_pose>false</publish_collision_pose>\n"\
+    "      <publish_visual_pose>false</publish_visual_pose>\n"\
+    "      <publish_nested_model_pose>#{$enableGroundTruth}</publish_nested_model_pose>\n"\
+    "      <use_pose_vector_msg>true</use_pose_vector_msg>\n"\
+    "      <static_publisher>false</static_publisher>\n"\
     "    </plugin>\n"\
     "    <!-- Battery plugin -->\n"\
     "    <plugin filename=\"libignition-gazebo-linearbatteryplugin-system.so\"\n"\
@@ -437,10 +457,20 @@
     "      <publish_sensor_pose>true</publish_sensor_pose>\n"\
     "      <publish_collision_pose>false</publish_collision_pose>\n"\
     "      <publish_visual_pose>false</publish_visual_pose>\n"\
-    "      <publish_nested_model_pose>#{$enableGroundTruth}</publish_nested_model_pose>\n"\
+    "      <publish_nested_model_pose>false</publish_nested_model_pose>\n"\
     "      <use_pose_vector_msg>true</use_pose_vector_msg>\n"\
     "      <static_publisher>true</static_publisher>\n"\
     "      <static_update_frequency>1</static_update_frequency>\n"\
+    "    </plugin>\n"\
+    "    <plugin filename=\"libignition-gazebo-pose-publisher-system.so\"\n"\
+    "      name=\"ignition::gazebo::systems::PosePublisher\">\n"\
+    "      <publish_link_pose>false</publish_link_pose>\n"\
+    "      <publish_sensor_pose>false</publish_sensor_pose>\n"\
+    "      <publish_collision_pose>false</publish_collision_pose>\n"\
+    "      <publish_visual_pose>false</publish_visual_pose>\n"\
+    "      <publish_nested_model_pose>#{$enableGroundTruth}</publish_nested_model_pose>\n"\
+    "      <use_pose_vector_msg>true</use_pose_vector_msg>\n"\
+    "      <static_publisher>false</static_publisher>\n"\
     "    </plugin>\n"\
     "    <plugin filename=\"libignition-gazebo-multicopter-motor-model-system.so\"\n"\
     "      name=\"ignition::gazebo::systems::MulticopterMotorModel\">\n"\
@@ -626,10 +656,20 @@
     "      <publish_sensor_pose>true</publish_sensor_pose>\n"\
     "      <publish_collision_pose>false</publish_collision_pose>\n"\
     "      <publish_visual_pose>false</publish_visual_pose>\n"\
-    "      <publish_nested_model_pose>#{$enableGroundTruth}</publish_nested_model_pose>\n"\
+    "      <publish_nested_model_pose>false</publish_nested_model_pose>\n"\
     "      <use_pose_vector_msg>true</use_pose_vector_msg>\n"\
     "      <static_publisher>true</static_publisher>\n"\
     "      <static_update_frequency>1</static_update_frequency>\n"\
+    "    </plugin>\n"\
+    "    <plugin filename=\"libignition-gazebo-pose-publisher-system.so\"\n"\
+    "      name=\"ignition::gazebo::systems::PosePublisher\">\n"\
+    "      <publish_link_pose>false</publish_link_pose>\n"\
+    "      <publish_sensor_pose>false</publish_sensor_pose>\n"\
+    "      <publish_collision_pose>false</publish_collision_pose>\n"\
+    "      <publish_visual_pose>false</publish_visual_pose>\n"\
+    "      <publish_nested_model_pose>#{$enableGroundTruth}</publish_nested_model_pose>\n"\
+    "      <use_pose_vector_msg>true</use_pose_vector_msg>\n"\
+    "      <static_publisher>false</static_publisher>\n"\
     "    </plugin>\n"\
     "    <plugin filename=\"libignition-gazebo-multicopter-motor-model-system.so\"\n"\
     "      name=\"ignition::gazebo::systems::MulticopterMotorModel\">\n"\

--- a/subt_ign/test/test.ign
+++ b/subt_ign/test/test.ign
@@ -324,10 +324,20 @@
     "      <publish_sensor_pose>true</publish_sensor_pose>\n"\
     "      <publish_collision_pose>false</publish_collision_pose>\n"\
     "      <publish_visual_pose>false</publish_visual_pose>\n"\
-    "      <publish_nested_model_pose>#{$enableGroundTruth}</publish_nested_model_pose>\n"\
+    "      <publish_nested_model_pose>false</publish_nested_model_pose>\n"\
     "      <use_pose_vector_msg>true</use_pose_vector_msg>\n"\
     "      <static_publisher>true</static_publisher>\n"\
     "      <static_update_frequency>1</static_update_frequency>\n"\
+    "    </plugin>\n"\
+    "    <plugin filename=\"libignition-gazebo-pose-publisher-system.so\"\n"\
+    "      name=\"ignition::gazebo::systems::PosePublisher\">\n"\
+    "      <publish_link_pose>false</publish_link_pose>\n"\
+    "      <publish_sensor_pose>false</publish_sensor_pose>\n"\
+    "      <publish_collision_pose>false</publish_collision_pose>\n"\
+    "      <publish_visual_pose>false</publish_visual_pose>\n"\
+    "      <publish_nested_model_pose>#{$enableGroundTruth}</publish_nested_model_pose>\n"\
+    "      <use_pose_vector_msg>true</use_pose_vector_msg>\n"\
+    "      <static_publisher>false</static_publisher>\n"\
     "    </plugin>\n"\
     "    <!-- Battery plugin -->\n"\
     "    <plugin filename=\"libignition-gazebo-linearbatteryplugin-system.so\"\n"\
@@ -390,10 +400,20 @@
     "      <publish_sensor_pose>true</publish_sensor_pose>\n"\
     "      <publish_collision_pose>false</publish_collision_pose>\n"\
     "      <publish_visual_pose>false</publish_visual_pose>\n"\
-    "      <publish_nested_model_pose>#{$enableGroundTruth}</publish_nested_model_pose>\n"\
+    "      <publish_nested_model_pose>false</publish_nested_model_pose>\n"\
     "      <use_pose_vector_msg>true</use_pose_vector_msg>\n"\
     "      <static_publisher>true</static_publisher>\n"\
     "      <static_update_frequency>1</static_update_frequency>\n"\
+    "    </plugin>\n"\
+    "    <plugin filename=\"libignition-gazebo-pose-publisher-system.so\"\n"\
+    "      name=\"ignition::gazebo::systems::PosePublisher\">\n"\
+    "      <publish_link_pose>false</publish_link_pose>\n"\
+    "      <publish_sensor_pose>false</publish_sensor_pose>\n"\
+    "      <publish_collision_pose>false</publish_collision_pose>\n"\
+    "      <publish_visual_pose>false</publish_visual_pose>\n"\
+    "      <publish_nested_model_pose>#{$enableGroundTruth}</publish_nested_model_pose>\n"\
+    "      <use_pose_vector_msg>true</use_pose_vector_msg>\n"\
+    "      <static_publisher>false</static_publisher>\n"\
     "    </plugin>\n"\
     "    <!-- Battery plugin -->\n"\
     "    <plugin filename=\"libignition-gazebo-linearbatteryplugin-system.so\"\n"\
@@ -442,10 +462,20 @@
     "      <publish_sensor_pose>true</publish_sensor_pose>\n"\
     "      <publish_collision_pose>false</publish_collision_pose>\n"\
     "      <publish_visual_pose>false</publish_visual_pose>\n"\
-    "      <publish_nested_model_pose>#{$enableGroundTruth}</publish_nested_model_pose>\n"\
+    "      <publish_nested_model_pose>false</publish_nested_model_pose>\n"\
     "      <use_pose_vector_msg>true</use_pose_vector_msg>\n"\
     "      <static_publisher>true</static_publisher>\n"\
     "      <static_update_frequency>1</static_update_frequency>\n"\
+    "    </plugin>\n"\
+    "    <plugin filename=\"libignition-gazebo-pose-publisher-system.so\"\n"\
+    "      name=\"ignition::gazebo::systems::PosePublisher\">\n"\
+    "      <publish_link_pose>false</publish_link_pose>\n"\
+    "      <publish_sensor_pose>false</publish_sensor_pose>\n"\
+    "      <publish_collision_pose>false</publish_collision_pose>\n"\
+    "      <publish_visual_pose>false</publish_visual_pose>\n"\
+    "      <publish_nested_model_pose>#{$enableGroundTruth}</publish_nested_model_pose>\n"\
+    "      <use_pose_vector_msg>true</use_pose_vector_msg>\n"\
+    "      <static_publisher>false</static_publisher>\n"\
     "    </plugin>\n"\
     "    <plugin filename=\"libignition-gazebo-multicopter-motor-model-system.so\"\n"\
     "      name=\"ignition::gazebo::systems::MulticopterMotorModel\">\n"\
@@ -573,10 +603,20 @@
     "      <publish_sensor_pose>true</publish_sensor_pose>\n"\
     "      <publish_collision_pose>false</publish_collision_pose>\n"\
     "      <publish_visual_pose>false</publish_visual_pose>\n"\
-    "      <publish_nested_model_pose>#{$enableGroundTruth}</publish_nested_model_pose>\n"\
+    "      <publish_nested_model_pose>false</publish_nested_model_pose>\n"\
     "      <use_pose_vector_msg>true</use_pose_vector_msg>\n"\
     "      <static_publisher>true</static_publisher>\n"\
     "      <static_update_frequency>1</static_update_frequency>\n"\
+    "    </plugin>\n"\
+    "    <plugin filename=\"libignition-gazebo-pose-publisher-system.so\"\n"\
+    "      name=\"ignition::gazebo::systems::PosePublisher\">\n"\
+    "      <publish_link_pose>false</publish_link_pose>\n"\
+    "      <publish_sensor_pose>false</publish_sensor_pose>\n"\
+    "      <publish_collision_pose>false</publish_collision_pose>\n"\
+    "      <publish_visual_pose>false</publish_visual_pose>\n"\
+    "      <publish_nested_model_pose>#{$enableGroundTruth}</publish_nested_model_pose>\n"\
+    "      <use_pose_vector_msg>true</use_pose_vector_msg>\n"\
+    "      <static_publisher>false</static_publisher>\n"\
     "    </plugin>\n"\
     "    <plugin filename=\"libignition-gazebo-multicopter-motor-model-system.so\"\n"\
     "      name=\"ignition::gazebo::systems::MulticopterMotorModel\">\n"\


### PR DESCRIPTION
Solves #659 and #607. I hope I got all the places where ground truth publishing might be controlled.

Isn't there really a way to just `<include>` some common file defining all these common definitions for all robots? This approach seems pretty awkward to me...