### PR TITLE
Publish ground truth data to /<name>/pose instead of /<name>/pose_static

### DIFF
--- a/submitted_models/cerberus_anymal_b_sensor_config_1/launch/spawner.rb
+++ b/submitted_models/cerberus_anymal_b_sensor_config_1/launch/spawner.rb
@@ -45,10 +45,21 @@ def spawner(_name, _modelURI, _worldName, _x, _y, _z, _roll, _pitch, _yaw)
         <publish_sensor_pose>true</publish_sensor_pose>
         <publish_collision_pose>false</publish_collision_pose>
         <publish_visual_pose>false</publish_visual_pose>
-        <publish_nested_model_pose>#{$enableGroundTruth}</publish_nested_model_pose>
+        <publish_nested_model_pose>false</publish_nested_model_pose>
         <use_pose_vector_msg>true</use_pose_vector_msg>
         <static_publisher>true</static_publisher>
         <static_update_frequency>1</static_update_frequency>
+      </plugin>
+      <!-- Publish ground truth information if specified by user -->
+      <plugin filename="libignition-gazebo-pose-publisher-system.so"
+        name="ignition::gazebo::systems::PosePublisher">
+        <publish_link_pose>false</publish_link_pose>
+        <publish_sensor_pose>false</publish_sensor_pose>
+        <publish_collision_pose>false</publish_collision_pose>
+        <publish_visual_pose>false</publish_visual_pose>
+        <publish_nested_model_pose>#{$enableGroundTruth}</publish_nested_model_pose>
+        <use_pose_vector_msg>true</use_pose_vector_msg>
+        <static_publisher>false</static_publisher>
       </plugin>
       <plugin filename="libignition-gazebo-joint-state-publisher-system.so"
         name="ignition::gazebo::systems::JointStatePublisher">

--- a/submitted_models/cerberus_anymal_b_sensor_config_2/launch/spawner.rb
+++ b/submitted_models/cerberus_anymal_b_sensor_config_2/launch/spawner.rb
@@ -45,10 +45,21 @@ def spawner(_name, _modelURI, _worldName, _x, _y, _z, _roll, _pitch, _yaw)
         <publish_sensor_pose>true</publish_sensor_pose>
         <publish_collision_pose>false</publish_collision_pose>
         <publish_visual_pose>false</publish_visual_pose>
-        <publish_nested_model_pose>#{$enableGroundTruth}</publish_nested_model_pose>
+        <publish_nested_model_pose>false</publish_nested_model_pose>
         <use_pose_vector_msg>true</use_pose_vector_msg>
         <static_publisher>true</static_publisher>
         <static_update_frequency>1</static_update_frequency>
+      </plugin>
+      <!-- Publish ground truth information if specified by user -->
+      <plugin filename="libignition-gazebo-pose-publisher-system.so"
+        name="ignition::gazebo::systems::PosePublisher">
+        <publish_link_pose>false</publish_link_pose>
+        <publish_sensor_pose>false</publish_sensor_pose>
+        <publish_collision_pose>false</publish_collision_pose>
+        <publish_visual_pose>false</publish_visual_pose>
+        <publish_nested_model_pose>#{$enableGroundTruth}</publish_nested_model_pose>
+        <use_pose_vector_msg>true</use_pose_vector_msg>
+        <static_publisher>false</static_publisher>
       </plugin>
       <plugin filename="libignition-gazebo-joint-state-publisher-system.so"
         name="ignition::gazebo::systems::JointStatePublisher">

--- a/submitted_models/cerberus_gagarin_sensor_config_1/launch/spawner.rb
+++ b/submitted_models/cerberus_gagarin_sensor_config_1/launch/spawner.rb
@@ -17,10 +17,21 @@ def spawner(_name, _modelURI, _worldName, _x, _y, _z, _roll, _pitch, _yaw)
           <publish_sensor_pose>true</publish_sensor_pose>
           <publish_collision_pose>false</publish_collision_pose>
           <publish_visual_pose>false</publish_visual_pose>
-          <publish_nested_model_pose>#{$enableGroundTruth}</publish_nested_model_pose>
+          <publish_nested_model_pose>false</publish_nested_model_pose>
           <use_pose_vector_msg>true</use_pose_vector_msg>
           <static_publisher>true</static_publisher>
           <static_update_frequency>1</static_update_frequency>
+        </plugin>
+        <!-- Publish ground truth information if specified by user -->
+        <plugin filename="libignition-gazebo-pose-publisher-system.so"
+          name="ignition::gazebo::systems::PosePublisher">
+          <publish_link_pose>false</publish_link_pose>
+          <publish_sensor_pose>false</publish_sensor_pose>
+          <publish_collision_pose>false</publish_collision_pose>
+          <publish_visual_pose>false</publish_visual_pose>
+          <publish_nested_model_pose>#{$enableGroundTruth}</publish_nested_model_pose>
+          <use_pose_vector_msg>true</use_pose_vector_msg>
+          <static_publisher>false</static_publisher>
         </plugin>
         <plugin filename="libignition-gazebo-multicopter-motor-model-system.so"
           name="ignition::gazebo::systems::MulticopterMotorModel">

--- a/submitted_models/cerberus_m100_sensor_config_1/launch/spawner.rb
+++ b/submitted_models/cerberus_m100_sensor_config_1/launch/spawner.rb
@@ -42,10 +42,21 @@ def spawner(_name, _modelURI, _worldName, _x, _y, _z, _roll, _pitch, _yaw)
           <publish_sensor_pose>true</publish_sensor_pose>
           <publish_collision_pose>false</publish_collision_pose>
           <publish_visual_pose>false</publish_visual_pose>
-          <publish_nested_model_pose>#{$enableGroundTruth}</publish_nested_model_pose>
+          <publish_nested_model_pose>false</publish_nested_model_pose>
           <use_pose_vector_msg>true</use_pose_vector_msg>
           <static_publisher>true</static_publisher>
           <static_update_frequency>1</static_update_frequency>
+        </plugin>
+        <!-- Publish ground truth information if specified by user -->
+        <plugin filename="libignition-gazebo-pose-publisher-system.so"
+          name="ignition::gazebo::systems::PosePublisher">
+          <publish_link_pose>false</publish_link_pose>
+          <publish_sensor_pose>false</publish_sensor_pose>
+          <publish_collision_pose>false</publish_collision_pose>
+          <publish_visual_pose>false</publish_visual_pose>
+          <publish_nested_model_pose>#{$enableGroundTruth}</publish_nested_model_pose>
+          <use_pose_vector_msg>true</use_pose_vector_msg>
+          <static_publisher>false</static_publisher>
         </plugin>
         <plugin filename="libignition-gazebo-multicopter-motor-model-system.so"
           name="ignition::gazebo::systems::MulticopterMotorModel">

--- a/submitted_models/costar_husky_sensor_config_1/launch/spawner.rb
+++ b/submitted_models/costar_husky_sensor_config_1/launch/spawner.rb
@@ -32,10 +32,21 @@ def spawner(_name, _modelURI, _worldName, _x, _y, _z, _roll, _pitch, _yaw)
         <publish_sensor_pose>true</publish_sensor_pose>
         <publish_collision_pose>false</publish_collision_pose>
         <publish_visual_pose>false</publish_visual_pose>
-        <publish_nested_model_pose>#{$enableGroundTruth}</publish_nested_model_pose>
+        <publish_nested_model_pose>false</publish_nested_model_pose>
         <use_pose_vector_msg>true</use_pose_vector_msg>
         <static_publisher>true</static_publisher>
         <static_update_frequency>1</static_update_frequency>
+      </plugin>
+      <!-- Publish ground truth information if specified by user -->
+      <plugin filename="libignition-gazebo-pose-publisher-system.so"
+        name="ignition::gazebo::systems::PosePublisher">
+        <publish_link_pose>false</publish_link_pose>
+        <publish_sensor_pose>false</publish_sensor_pose>
+        <publish_collision_pose>false</publish_collision_pose>
+        <publish_visual_pose>false</publish_visual_pose>
+        <publish_nested_model_pose>#{$enableGroundTruth}</publish_nested_model_pose>
+        <use_pose_vector_msg>true</use_pose_vector_msg>
+        <static_publisher>false</static_publisher>
       </plugin>
       <!-- Battery plugin -->
       <plugin filename="libignition-gazebo-linearbatteryplugin-system.so"

--- a/submitted_models/costar_husky_sensor_config_2/launch/spawner.rb
+++ b/submitted_models/costar_husky_sensor_config_2/launch/spawner.rb
@@ -32,10 +32,21 @@ def spawner(_name, _modelURI, _worldName, _x, _y, _z, _roll, _pitch, _yaw)
         <publish_sensor_pose>true</publish_sensor_pose>
         <publish_collision_pose>false</publish_collision_pose>
         <publish_visual_pose>false</publish_visual_pose>
-        <publish_nested_model_pose>#{$enableGroundTruth}</publish_nested_model_pose>
+        <publish_nested_model_pose>false</publish_nested_model_pose>
         <use_pose_vector_msg>true</use_pose_vector_msg>
         <static_publisher>true</static_publisher>
         <static_update_frequency>1</static_update_frequency>
+      </plugin>
+      <!-- Publish ground truth information if specified by user -->
+      <plugin filename="libignition-gazebo-pose-publisher-system.so"
+        name="ignition::gazebo::systems::PosePublisher">
+        <publish_link_pose>false</publish_link_pose>
+        <publish_sensor_pose>false</publish_sensor_pose>
+        <publish_collision_pose>false</publish_collision_pose>
+        <publish_visual_pose>false</publish_visual_pose>
+        <publish_nested_model_pose>#{$enableGroundTruth}</publish_nested_model_pose>
+        <use_pose_vector_msg>true</use_pose_vector_msg>
+        <static_publisher>false</static_publisher>
       </plugin>
       <!-- Battery plugin -->
       <plugin filename="libignition-gazebo-linearbatteryplugin-system.so"

--- a/submitted_models/csiro_data61_ozbot_atr_sensor_config_1/launch/spawner.rb
+++ b/submitted_models/csiro_data61_ozbot_atr_sensor_config_1/launch/spawner.rb
@@ -64,10 +64,21 @@ def spawner(_name, _modelURI, _worldName, _x, _y, _z, _roll, _pitch, _yaw)
         <publish_sensor_pose>true</publish_sensor_pose>
         <publish_collision_pose>false</publish_collision_pose>
         <publish_visual_pose>false</publish_visual_pose>
+        <publish_nested_model_pose>false</publish_nested_model_pose>
+        <use_pose_vector_msg>true</use_pose_vector_msg>
+        <static_publisher>true</static_publisher>
+        <static_update_frequency>1</static_update_frequency>
+      </plugin>
+      <!-- Publish ground truth information if specified by user -->
+      <plugin filename="libignition-gazebo-pose-publisher-system.so"
+        name="ignition::gazebo::systems::PosePublisher">
+        <publish_link_pose>false</publish_link_pose>
+        <publish_sensor_pose>false</publish_sensor_pose>
+        <publish_collision_pose>false</publish_collision_pose>
+        <publish_visual_pose>false</publish_visual_pose>
         <publish_nested_model_pose>#{$enableGroundTruth}</publish_nested_model_pose>
         <use_pose_vector_msg>true</use_pose_vector_msg>
-        <static_pose_publisher>true</static_pose_publisher>
-        <static_pose_update_frequency>1</static_pose_update_frequency>
+        <static_publisher>false</static_publisher>
       </plugin>
 
       <!-- Battery plugin -->

--- a/submitted_models/csiro_data61_ozbot_atr_sensor_config_2/launch/spawner.rb
+++ b/submitted_models/csiro_data61_ozbot_atr_sensor_config_2/launch/spawner.rb
@@ -64,10 +64,21 @@ def spawner(_name, _modelURI, _worldName, _x, _y, _z, _roll, _pitch, _yaw)
         <publish_sensor_pose>true</publish_sensor_pose>
         <publish_collision_pose>false</publish_collision_pose>
         <publish_visual_pose>false</publish_visual_pose>
+        <publish_nested_model_pose>false</publish_nested_model_pose>
+        <use_pose_vector_msg>true</use_pose_vector_msg>
+        <static_publisher>true</static_publisher>
+        <static_update_frequency>1</static_update_frequency>
+      </plugin>
+      <!-- Publish ground truth information if specified by user -->
+      <plugin filename="libignition-gazebo-pose-publisher-system.so"
+        name="ignition::gazebo::systems::PosePublisher">
+        <publish_link_pose>false</publish_link_pose>
+        <publish_sensor_pose>false</publish_sensor_pose>
+        <publish_collision_pose>false</publish_collision_pose>
+        <publish_visual_pose>false</publish_visual_pose>
         <publish_nested_model_pose>#{$enableGroundTruth}</publish_nested_model_pose>
         <use_pose_vector_msg>true</use_pose_vector_msg>
-        <static_pose_publisher>true</static_pose_publisher>
-        <static_pose_update_frequency>1</static_pose_update_frequency>
+        <static_publisher>false</static_publisher>
       </plugin>
 
       <!-- Battery plugin -->

--- a/submitted_models/ctu_cras_norlab_absolem_sensor_config_1/launch/spawner.rb
+++ b/submitted_models/ctu_cras_norlab_absolem_sensor_config_1/launch/spawner.rb
@@ -104,10 +104,21 @@ def spawner(_name, _modelURI, _worldName, _x, _y, _z, _roll, _pitch, _yaw)
         <publish_sensor_pose>true</publish_sensor_pose>
         <publish_collision_pose>false</publish_collision_pose>
         <publish_visual_pose>false</publish_visual_pose>
-        <publish_nested_model_pose>#{$enableGroundTruth}</publish_nested_model_pose>
+        <publish_nested_model_pose>false</publish_nested_model_pose>
         <use_pose_vector_msg>true</use_pose_vector_msg>
         <static_publisher>true</static_publisher>
         <static_update_frequency>1</static_update_frequency>
+      </plugin>
+      <!-- Publish ground truth information if specified by user -->
+      <plugin filename="libignition-gazebo-pose-publisher-system.so"
+        name="ignition::gazebo::systems::PosePublisher">
+        <publish_link_pose>false</publish_link_pose>
+        <publish_sensor_pose>false</publish_sensor_pose>
+        <publish_collision_pose>false</publish_collision_pose>
+        <publish_visual_pose>false</publish_visual_pose>
+        <publish_nested_model_pose>#{$enableGroundTruth}</publish_nested_model_pose>
+        <use_pose_vector_msg>true</use_pose_vector_msg>
+        <static_publisher>false</static_publisher>
       </plugin>
       <!-- Battery plugin -->
       <plugin filename="libignition-gazebo-linearbatteryplugin-system.so"

--- a/submitted_models/ctu_cras_norlab_absolem_sensor_config_2/launch/spawner.rb
+++ b/submitted_models/ctu_cras_norlab_absolem_sensor_config_2/launch/spawner.rb
@@ -104,10 +104,21 @@ def spawner(_name, _modelURI, _worldName, _x, _y, _z, _roll, _pitch, _yaw)
         <publish_sensor_pose>true</publish_sensor_pose>
         <publish_collision_pose>false</publish_collision_pose>
         <publish_visual_pose>false</publish_visual_pose>
-        <publish_nested_model_pose>#{$enableGroundTruth}</publish_nested_model_pose>
+        <publish_nested_model_pose>false</publish_nested_model_pose>
         <use_pose_vector_msg>true</use_pose_vector_msg>
         <static_publisher>true</static_publisher>
         <static_update_frequency>1</static_update_frequency>
+      </plugin>
+      <!-- Publish ground truth information if specified by user -->
+      <plugin filename="libignition-gazebo-pose-publisher-system.so"
+        name="ignition::gazebo::systems::PosePublisher">
+        <publish_link_pose>false</publish_link_pose>
+        <publish_sensor_pose>false</publish_sensor_pose>
+        <publish_collision_pose>false</publish_collision_pose>
+        <publish_visual_pose>false</publish_visual_pose>
+        <publish_nested_model_pose>#{$enableGroundTruth}</publish_nested_model_pose>
+        <use_pose_vector_msg>true</use_pose_vector_msg>
+        <static_publisher>false</static_publisher>
       </plugin>
       <!-- Battery plugin -->
       <plugin filename="libignition-gazebo-linearbatteryplugin-system.so"

--- a/submitted_models/explorer_ds1_sensor_config_1/launch/spawner.rb
+++ b/submitted_models/explorer_ds1_sensor_config_1/launch/spawner.rb
@@ -17,10 +17,21 @@ def spawner(_name, _modelURI, _worldName, _x, _y, _z, _roll, _pitch, _yaw)
         <publish_sensor_pose>true</publish_sensor_pose>
         <publish_collision_pose>false</publish_collision_pose>
         <publish_visual_pose>false</publish_visual_pose>
-        <publish_nested_model_pose>#{$enableGroundTruth}</publish_nested_model_pose>
+        <publish_nested_model_pose>false</publish_nested_model_pose>
         <use_pose_vector_msg>true</use_pose_vector_msg>
         <static_publisher>true</static_publisher>
         <static_update_frequency>1</static_update_frequency>
+      </plugin>
+      <!-- Publish ground truth information if specified by user -->
+      <plugin filename="libignition-gazebo-pose-publisher-system.so"
+        name="ignition::gazebo::systems::PosePublisher">
+        <publish_link_pose>false</publish_link_pose>
+        <publish_sensor_pose>false</publish_sensor_pose>
+        <publish_collision_pose>false</publish_collision_pose>
+        <publish_visual_pose>false</publish_visual_pose>
+        <publish_nested_model_pose>#{$enableGroundTruth}</publish_nested_model_pose>
+        <use_pose_vector_msg>true</use_pose_vector_msg>
+        <static_publisher>false</static_publisher>
       </plugin>
       <plugin filename="libignition-gazebo-multicopter-motor-model-system.so"
         name="ignition::gazebo::systems::MulticopterMotorModel">

--- a/submitted_models/explorer_r2_sensor_config_1/launch/spawner.rb
+++ b/submitted_models/explorer_r2_sensor_config_1/launch/spawner.rb
@@ -32,10 +32,21 @@ def spawner(_name, _modelURI, _worldName, _x, _y, _z, _roll, _pitch, _yaw)
         <publish_sensor_pose>true</publish_sensor_pose>
         <publish_collision_pose>false</publish_collision_pose>
         <publish_visual_pose>false</publish_visual_pose>
-        <publish_nested_model_pose>#{$enableGroundTruth}</publish_nested_model_pose>
+        <publish_nested_model_pose>false</publish_nested_model_pose>
         <use_pose_vector_msg>true</use_pose_vector_msg>
         <static_publisher>true</static_publisher>
         <static_update_frequency>1</static_update_frequency>
+      </plugin>
+      <!-- Publish ground truth information if specified by user -->
+      <plugin filename="libignition-gazebo-pose-publisher-system.so"
+        name="ignition::gazebo::systems::PosePublisher">
+        <publish_link_pose>false</publish_link_pose>
+        <publish_sensor_pose>false</publish_sensor_pose>
+        <publish_collision_pose>false</publish_collision_pose>
+        <publish_visual_pose>false</publish_visual_pose>
+        <publish_nested_model_pose>#{$enableGroundTruth}</publish_nested_model_pose>
+        <use_pose_vector_msg>true</use_pose_vector_msg>
+        <static_publisher>false</static_publisher>
       </plugin>
       <!-- Battery plugin -->
       <plugin filename="libignition-gazebo-linearbatteryplugin-system.so"

--- a/submitted_models/explorer_r2_sensor_config_2/launch/spawner.rb
+++ b/submitted_models/explorer_r2_sensor_config_2/launch/spawner.rb
@@ -22,8 +22,8 @@ def spawner(_name, _modelURI, _worldName, _x, _y, _z, _roll, _pitch, _yaw)
         <topic>/model/#{_name}/cmd_vel_relay</topic>
         <min_velocity>-1</min_velocity>
         <max_velocity>1</max_velocity>
-	<min_acceleration>-1.24</min_acceleration>
-	<max_acceleration>1.16</max_acceleration>
+        <min_acceleration>-1.24</min_acceleration>
+        <max_acceleration>1.16</max_acceleration>
       </plugin>
       <!-- Publish robot state information -->
       <plugin filename="libignition-gazebo-pose-publisher-system.so"
@@ -32,10 +32,21 @@ def spawner(_name, _modelURI, _worldName, _x, _y, _z, _roll, _pitch, _yaw)
         <publish_sensor_pose>true</publish_sensor_pose>
         <publish_collision_pose>false</publish_collision_pose>
         <publish_visual_pose>false</publish_visual_pose>
-        <publish_nested_model_pose>#{$enableGroundTruth}</publish_nested_model_pose>
+        <publish_nested_model_pose>false</publish_nested_model_pose>
         <use_pose_vector_msg>true</use_pose_vector_msg>
         <static_publisher>true</static_publisher>
         <static_update_frequency>1</static_update_frequency>
+      </plugin>
+      <!-- Publish ground truth information if specified by user -->
+      <plugin filename="libignition-gazebo-pose-publisher-system.so"
+        name="ignition::gazebo::systems::PosePublisher">
+        <publish_link_pose>false</publish_link_pose>
+        <publish_sensor_pose>false</publish_sensor_pose>
+        <publish_collision_pose>false</publish_collision_pose>
+        <publish_visual_pose>false</publish_visual_pose>
+        <publish_nested_model_pose>#{$enableGroundTruth}</publish_nested_model_pose>
+        <use_pose_vector_msg>true</use_pose_vector_msg>
+        <static_publisher>false</static_publisher>
       </plugin>
       <!-- Battery plugin -->
       <plugin filename="libignition-gazebo-linearbatteryplugin-system.so"

--- a/submitted_models/explorer_x1_sensor_config_1/launch/spawner.rb
+++ b/submitted_models/explorer_x1_sensor_config_1/launch/spawner.rb
@@ -32,10 +32,21 @@ def spawner(_name, _modelURI, _worldName, _x, _y, _z, _roll, _pitch, _yaw)
         <publish_sensor_pose>true</publish_sensor_pose>
         <publish_collision_pose>false</publish_collision_pose>
         <publish_visual_pose>false</publish_visual_pose>
-        <publish_nested_model_pose>#{$enableGroundTruth}</publish_nested_model_pose>
+        <publish_nested_model_pose>false</publish_nested_model_pose>
         <use_pose_vector_msg>true</use_pose_vector_msg>
         <static_publisher>true</static_publisher>
         <static_update_frequency>1</static_update_frequency>
+      </plugin>
+      <!-- Publish ground truth information if specified by user -->
+      <plugin filename="libignition-gazebo-pose-publisher-system.so"
+        name="ignition::gazebo::systems::PosePublisher">
+        <publish_link_pose>false</publish_link_pose>
+        <publish_sensor_pose>false</publish_sensor_pose>
+        <publish_collision_pose>false</publish_collision_pose>
+        <publish_visual_pose>false</publish_visual_pose>
+        <publish_nested_model_pose>#{$enableGroundTruth}</publish_nested_model_pose>
+        <use_pose_vector_msg>true</use_pose_vector_msg>
+        <static_publisher>false</static_publisher>
       </plugin>
       <!-- Battery plugin -->
       <plugin filename="libignition-gazebo-linearbatteryplugin-system.so"

--- a/submitted_models/explorer_x1_sensor_config_2/launch/spawner.rb
+++ b/submitted_models/explorer_x1_sensor_config_2/launch/spawner.rb
@@ -32,10 +32,21 @@ def spawner(_name, _modelURI, _worldName, _x, _y, _z, _roll, _pitch, _yaw)
         <publish_sensor_pose>true</publish_sensor_pose>
         <publish_collision_pose>false</publish_collision_pose>
         <publish_visual_pose>false</publish_visual_pose>
-        <publish_nested_model_pose>#{$enableGroundTruth}</publish_nested_model_pose>
+        <publish_nested_model_pose>false</publish_nested_model_pose>
         <use_pose_vector_msg>true</use_pose_vector_msg>
         <static_publisher>true</static_publisher>
         <static_update_frequency>1</static_update_frequency>
+      </plugin>
+      <!-- Publish ground truth information if specified by user -->
+      <plugin filename="libignition-gazebo-pose-publisher-system.so"
+        name="ignition::gazebo::systems::PosePublisher">
+        <publish_link_pose>false</publish_link_pose>
+        <publish_sensor_pose>false</publish_sensor_pose>
+        <publish_collision_pose>false</publish_collision_pose>
+        <publish_visual_pose>false</publish_visual_pose>
+        <publish_nested_model_pose>#{$enableGroundTruth}</publish_nested_model_pose>
+        <use_pose_vector_msg>true</use_pose_vector_msg>
+        <static_publisher>false</static_publisher>
       </plugin>
       <!-- Battery plugin -->
       <plugin filename="libignition-gazebo-linearbatteryplugin-system.so"

--- a/submitted_models/marble_hd2_sensor_config_1/launch/spawner.rb
+++ b/submitted_models/marble_hd2_sensor_config_1/launch/spawner.rb
@@ -36,10 +36,21 @@ def spawner(_name, _modelURI, _worldName, _x, _y, _z, _roll, _pitch, _yaw)
         <publish_sensor_pose>true</publish_sensor_pose>
         <publish_collision_pose>false</publish_collision_pose>
         <publish_visual_pose>false</publish_visual_pose>
-        <publish_nested_model_pose>#{$enableGroundTruth}</publish_nested_model_pose>
+        <publish_nested_model_pose>false</publish_nested_model_pose>
         <use_pose_vector_msg>true</use_pose_vector_msg>
         <static_publisher>true</static_publisher>
         <static_update_frequency>1</static_update_frequency>
+      </plugin>
+      <!-- Publish ground truth information if specified by user -->
+      <plugin filename="libignition-gazebo-pose-publisher-system.so"
+        name="ignition::gazebo::systems::PosePublisher">
+        <publish_link_pose>false</publish_link_pose>
+        <publish_sensor_pose>false</publish_sensor_pose>
+        <publish_collision_pose>false</publish_collision_pose>
+        <publish_visual_pose>false</publish_visual_pose>
+        <publish_nested_model_pose>#{$enableGroundTruth}</publish_nested_model_pose>
+        <use_pose_vector_msg>true</use_pose_vector_msg>
+        <static_publisher>false</static_publisher>
       </plugin>
       <!-- Battery plugin -->
       <plugin filename="libignition-gazebo-linearbatteryplugin-system.so"

--- a/submitted_models/marble_hd2_sensor_config_2/launch/spawner.rb
+++ b/submitted_models/marble_hd2_sensor_config_2/launch/spawner.rb
@@ -36,10 +36,21 @@ def spawner(_name, _modelURI, _worldName, _x, _y, _z, _roll, _pitch, _yaw)
         <publish_sensor_pose>true</publish_sensor_pose>
         <publish_collision_pose>false</publish_collision_pose>
         <publish_visual_pose>false</publish_visual_pose>
-        <publish_nested_model_pose>#{$enableGroundTruth}</publish_nested_model_pose>
+        <publish_nested_model_pose>false</publish_nested_model_pose>
         <use_pose_vector_msg>true</use_pose_vector_msg>
         <static_publisher>true</static_publisher>
         <static_update_frequency>1</static_update_frequency>
+      </plugin>
+      <!-- Publish ground truth information if specified by user -->
+      <plugin filename="libignition-gazebo-pose-publisher-system.so"
+        name="ignition::gazebo::systems::PosePublisher">
+        <publish_link_pose>false</publish_link_pose>
+        <publish_sensor_pose>false</publish_sensor_pose>
+        <publish_collision_pose>false</publish_collision_pose>
+        <publish_visual_pose>false</publish_visual_pose>
+        <publish_nested_model_pose>#{$enableGroundTruth}</publish_nested_model_pose>
+        <use_pose_vector_msg>true</use_pose_vector_msg>
+        <static_publisher>false</static_publisher>
       </plugin>
       <!-- Battery plugin -->
       <plugin filename="libignition-gazebo-linearbatteryplugin-system.so"

--- a/submitted_models/marble_husky_sensor_config_1/launch/spawner.rb
+++ b/submitted_models/marble_husky_sensor_config_1/launch/spawner.rb
@@ -32,10 +32,21 @@ def spawner(_name, _modelURI, _worldName, _x, _y, _z, _roll, _pitch, _yaw)
         <publish_sensor_pose>true</publish_sensor_pose>
         <publish_collision_pose>false</publish_collision_pose>
         <publish_visual_pose>false</publish_visual_pose>
-        <publish_nested_model_pose>#{$enableGroundTruth}</publish_nested_model_pose>
+        <publish_nested_model_pose>false</publish_nested_model_pose>
         <use_pose_vector_msg>true</use_pose_vector_msg>
         <static_publisher>true</static_publisher>
         <static_update_frequency>1</static_update_frequency>
+      </plugin>
+      <!-- Publish ground truth information if specified by user -->
+      <plugin filename="libignition-gazebo-pose-publisher-system.so"
+        name="ignition::gazebo::systems::PosePublisher">
+        <publish_link_pose>false</publish_link_pose>
+        <publish_sensor_pose>false</publish_sensor_pose>
+        <publish_collision_pose>false</publish_collision_pose>
+        <publish_visual_pose>false</publish_visual_pose>
+        <publish_nested_model_pose>#{$enableGroundTruth}</publish_nested_model_pose>
+        <use_pose_vector_msg>true</use_pose_vector_msg>
+        <static_publisher>false</static_publisher>
       </plugin>
       <!-- Battery plugin -->
       <plugin filename="libignition-gazebo-linearbatteryplugin-system.so"

--- a/submitted_models/marble_husky_sensor_config_2/launch/spawner.rb
+++ b/submitted_models/marble_husky_sensor_config_2/launch/spawner.rb
@@ -32,10 +32,21 @@ def spawner(_name, _modelURI, _worldName, _x, _y, _z, _roll, _pitch, _yaw)
         <publish_sensor_pose>true</publish_sensor_pose>
         <publish_collision_pose>false</publish_collision_pose>
         <publish_visual_pose>false</publish_visual_pose>
-        <publish_nested_model_pose>#{$enableGroundTruth}</publish_nested_model_pose>
+        <publish_nested_model_pose>false</publish_nested_model_pose>
         <use_pose_vector_msg>true</use_pose_vector_msg>
         <static_publisher>true</static_publisher>
         <static_update_frequency>1</static_update_frequency>
+      </plugin>
+      <!-- Publish ground truth information if specified by user -->
+      <plugin filename="libignition-gazebo-pose-publisher-system.so"
+        name="ignition::gazebo::systems::PosePublisher">
+        <publish_link_pose>false</publish_link_pose>
+        <publish_sensor_pose>false</publish_sensor_pose>
+        <publish_collision_pose>false</publish_collision_pose>
+        <publish_visual_pose>false</publish_visual_pose>
+        <publish_nested_model_pose>#{$enableGroundTruth}</publish_nested_model_pose>
+        <use_pose_vector_msg>true</use_pose_vector_msg>
+        <static_publisher>false</static_publisher>
       </plugin>
       <!-- Battery plugin -->
       <plugin filename="libignition-gazebo-linearbatteryplugin-system.so"

--- a/submitted_models/marble_qav500_sensor_config_1/launch/spawner.rb
+++ b/submitted_models/marble_qav500_sensor_config_1/launch/spawner.rb
@@ -17,10 +17,21 @@ def spawner(_name, _modelURI, _worldName, _x, _y, _z, _roll, _pitch, _yaw)
           <publish_sensor_pose>true</publish_sensor_pose>
           <publish_collision_pose>false</publish_collision_pose>
           <publish_visual_pose>false</publish_visual_pose>
-          <publish_nested_model_pose>#{$enableGroundTruth}</publish_nested_model_pose>
+          <publish_nested_model_pose>false</publish_nested_model_pose>
           <use_pose_vector_msg>true</use_pose_vector_msg>
           <static_publisher>true</static_publisher>
           <static_update_frequency>1</static_update_frequency>
+        </plugin>
+        <!-- Publish ground truth information if specified by user -->
+        <plugin filename="libignition-gazebo-pose-publisher-system.so"
+          name="ignition::gazebo::systems::PosePublisher">
+          <publish_link_pose>false</publish_link_pose>
+          <publish_sensor_pose>false</publish_sensor_pose>
+          <publish_collision_pose>false</publish_collision_pose>
+          <publish_visual_pose>false</publish_visual_pose>
+          <publish_nested_model_pose>#{$enableGroundTruth}</publish_nested_model_pose>
+          <use_pose_vector_msg>true</use_pose_vector_msg>
+          <static_publisher>false</static_publisher>
         </plugin>
         <plugin filename="libignition-gazebo-multicopter-motor-model-system.so"
         name="ignition::gazebo::systems::MulticopterMotorModel">

--- a/submitted_models/robotika_freyja_sensor_config_1/launch/spawner.rb
+++ b/submitted_models/robotika_freyja_sensor_config_1/launch/spawner.rb
@@ -26,16 +26,27 @@ def spawner(_name, _modelURI, _worldName, _x, _y, _z, _roll, _pitch, _yaw)
           <max_acceleration>10.6</max_acceleration>
         </plugin>
         <!-- Publish robot state information -->
-        <plugin filename=\"libignition-gazebo-pose-publisher-system.so\"
-          name=\"ignition::gazebo::systems::PosePublisher\">
+        <plugin filename="libignition-gazebo-pose-publisher-system.so"
+          name="ignition::gazebo::systems::PosePublisher">
           <publish_link_pose>true</publish_link_pose>
           <publish_sensor_pose>true</publish_sensor_pose>
           <publish_collision_pose>false</publish_collision_pose>
           <publish_visual_pose>false</publish_visual_pose>
-          <publish_nested_model_pose>#{$enableGroundTruth}</publish_nested_model_pose>
+          <publish_nested_model_pose>false</publish_nested_model_pose>
           <use_pose_vector_msg>true</use_pose_vector_msg>
           <static_publisher>true</static_publisher>
           <static_update_frequency>1</static_update_frequency>
+        </plugin>
+        <!-- Publish ground truth information if specified by user -->
+        <plugin filename="libignition-gazebo-pose-publisher-system.so"
+          name="ignition::gazebo::systems::PosePublisher">
+          <publish_link_pose>false</publish_link_pose>
+          <publish_sensor_pose>false</publish_sensor_pose>
+          <publish_collision_pose>false</publish_collision_pose>
+          <publish_visual_pose>false</publish_visual_pose>
+          <publish_nested_model_pose>#{$enableGroundTruth}</publish_nested_model_pose>
+          <use_pose_vector_msg>true</use_pose_vector_msg>
+          <static_publisher>false</static_publisher>
         </plugin>
         <!-- Battery plugin -->
         <plugin filename=\"libignition-gazebo-linearbatteryplugin-system.so\"

--- a/submitted_models/robotika_freyja_sensor_config_2/launch/spawner.rb
+++ b/submitted_models/robotika_freyja_sensor_config_2/launch/spawner.rb
@@ -26,16 +26,27 @@ def spawner(_name, _modelURI, _worldName, _x, _y, _z, _roll, _pitch, _yaw)
           <max_acceleration>10.6</max_acceleration>
         </plugin>
         <!-- Publish robot state information -->
-        <plugin filename=\"libignition-gazebo-pose-publisher-system.so\"
-          name=\"ignition::gazebo::systems::PosePublisher\">
+        <plugin filename="libignition-gazebo-pose-publisher-system.so"
+          name="ignition::gazebo::systems::PosePublisher">
           <publish_link_pose>true</publish_link_pose>
           <publish_sensor_pose>true</publish_sensor_pose>
           <publish_collision_pose>false</publish_collision_pose>
           <publish_visual_pose>false</publish_visual_pose>
-          <publish_nested_model_pose>#{$enableGroundTruth}</publish_nested_model_pose>
+          <publish_nested_model_pose>false</publish_nested_model_pose>
           <use_pose_vector_msg>true</use_pose_vector_msg>
           <static_publisher>true</static_publisher>
           <static_update_frequency>1</static_update_frequency>
+        </plugin>
+        <!-- Publish ground truth information if specified by user -->
+        <plugin filename="libignition-gazebo-pose-publisher-system.so"
+          name="ignition::gazebo::systems::PosePublisher">
+          <publish_link_pose>false</publish_link_pose>
+          <publish_sensor_pose>false</publish_sensor_pose>
+          <publish_collision_pose>false</publish_collision_pose>
+          <publish_visual_pose>false</publish_visual_pose>
+          <publish_nested_model_pose>#{$enableGroundTruth}</publish_nested_model_pose>
+          <use_pose_vector_msg>true</use_pose_vector_msg>
+          <static_publisher>false</static_publisher>
         </plugin>
         <!-- Battery plugin -->
         <plugin filename=\"libignition-gazebo-linearbatteryplugin-system.so\"

--- a/submitted_models/robotika_kloubak_sensor_config_1/launch/spawner.rb
+++ b/submitted_models/robotika_kloubak_sensor_config_1/launch/spawner.rb
@@ -39,16 +39,27 @@ def spawner(_name, _modelURI, _worldName, _x, _y, _z, _roll, _pitch, _yaw)
           <max_acceleration>8.8</max_acceleration>
         </plugin>
         <!-- Publish robot state information -->
-        <plugin filename=\"libignition-gazebo-pose-publisher-system.so\"
-          name=\"ignition::gazebo::systems::PosePublisher\">
+        <plugin filename="libignition-gazebo-pose-publisher-system.so"
+          name="ignition::gazebo::systems::PosePublisher">
           <publish_link_pose>true</publish_link_pose>
           <publish_sensor_pose>true</publish_sensor_pose>
           <publish_collision_pose>false</publish_collision_pose>
           <publish_visual_pose>false</publish_visual_pose>
-          <publish_nested_model_pose>#{$enableGroundTruth}</publish_nested_model_pose>
+          <publish_nested_model_pose>false</publish_nested_model_pose>
           <use_pose_vector_msg>true</use_pose_vector_msg>
           <static_publisher>true</static_publisher>
           <static_update_frequency>1</static_update_frequency>
+        </plugin>
+        <!-- Publish ground truth information if specified by user -->
+        <plugin filename="libignition-gazebo-pose-publisher-system.so"
+          name="ignition::gazebo::systems::PosePublisher">
+          <publish_link_pose>false</publish_link_pose>
+          <publish_sensor_pose>false</publish_sensor_pose>
+          <publish_collision_pose>false</publish_collision_pose>
+          <publish_visual_pose>false</publish_visual_pose>
+          <publish_nested_model_pose>#{$enableGroundTruth}</publish_nested_model_pose>
+          <use_pose_vector_msg>true</use_pose_vector_msg>
+          <static_publisher>false</static_publisher>
         </plugin>
         <!-- Battery plugin -->
         <plugin filename=\"libignition-gazebo-linearbatteryplugin-system.so\"

--- a/submitted_models/robotika_kloubak_sensor_config_2/launch/spawner.rb
+++ b/submitted_models/robotika_kloubak_sensor_config_2/launch/spawner.rb
@@ -39,16 +39,27 @@ def spawner(_name, _modelURI, _worldName, _x, _y, _z, _roll, _pitch, _yaw)
           <max_acceleration>8.8</max_acceleration>
         </plugin>
         <!-- Publish robot state information -->
-        <plugin filename=\"libignition-gazebo-pose-publisher-system.so\"
-          name=\"ignition::gazebo::systems::PosePublisher\">
+        <plugin filename="libignition-gazebo-pose-publisher-system.so"
+          name="ignition::gazebo::systems::PosePublisher">
           <publish_link_pose>true</publish_link_pose>
           <publish_sensor_pose>true</publish_sensor_pose>
           <publish_collision_pose>false</publish_collision_pose>
           <publish_visual_pose>false</publish_visual_pose>
-          <publish_nested_model_pose>#{$enableGroundTruth}</publish_nested_model_pose>
+          <publish_nested_model_pose>false</publish_nested_model_pose>
           <use_pose_vector_msg>true</use_pose_vector_msg>
           <static_publisher>true</static_publisher>
           <static_update_frequency>1</static_update_frequency>
+        </plugin>
+        <!-- Publish ground truth information if specified by user -->
+        <plugin filename="libignition-gazebo-pose-publisher-system.so"
+          name="ignition::gazebo::systems::PosePublisher">
+          <publish_link_pose>false</publish_link_pose>
+          <publish_sensor_pose>false</publish_sensor_pose>
+          <publish_collision_pose>false</publish_collision_pose>
+          <publish_visual_pose>false</publish_visual_pose>
+          <publish_nested_model_pose>#{$enableGroundTruth}</publish_nested_model_pose>
+          <use_pose_vector_msg>true</use_pose_vector_msg>
+          <static_publisher>false</static_publisher>
         </plugin>
         <!-- Battery plugin -->
         <plugin filename=\"libignition-gazebo-linearbatteryplugin-system.so\"

--- a/submitted_models/robotika_x2_sensor_config_1/launch/spawner.rb
+++ b/submitted_models/robotika_x2_sensor_config_1/launch/spawner.rb
@@ -32,10 +32,21 @@ def spawner(_name, _modelURI, _worldName, _x, _y, _z, _roll, _pitch, _yaw)
         <publish_sensor_pose>true</publish_sensor_pose>
         <publish_collision_pose>false</publish_collision_pose>
         <publish_visual_pose>false</publish_visual_pose>
-        <publish_nested_model_pose>#{$enableGroundTruth}</publish_nested_model_pose>
+        <publish_nested_model_pose>false</publish_nested_model_pose>
         <use_pose_vector_msg>true</use_pose_vector_msg>
         <static_publisher>true</static_publisher>
         <static_update_frequency>1</static_update_frequency>
+      </plugin>
+      <!-- Publish ground truth information if specified by user -->
+      <plugin filename="libignition-gazebo-pose-publisher-system.so"
+        name="ignition::gazebo::systems::PosePublisher">
+        <publish_link_pose>false</publish_link_pose>
+        <publish_sensor_pose>false</publish_sensor_pose>
+        <publish_collision_pose>false</publish_collision_pose>
+        <publish_visual_pose>false</publish_visual_pose>
+        <publish_nested_model_pose>#{$enableGroundTruth}</publish_nested_model_pose>
+        <use_pose_vector_msg>true</use_pose_vector_msg>
+        <static_publisher>false</static_publisher>
       </plugin>
       <!-- Battery plugin -->
       <plugin filename="libignition-gazebo-linearbatteryplugin-system.so"

--- a/submitted_models/sophisticated_engineering_x2_sensor_config_1/launch/spawner.rb
+++ b/submitted_models/sophisticated_engineering_x2_sensor_config_1/launch/spawner.rb
@@ -34,10 +34,21 @@ def spawner(_name, _modelURI, _worldName, _x, _y, _z, _roll, _pitch, _yaw)
         <publish_sensor_pose>true</publish_sensor_pose>
         <publish_collision_pose>false</publish_collision_pose>
         <publish_visual_pose>false</publish_visual_pose>
-        <publish_nested_model_pose>#{$enableGroundTruth}</publish_nested_model_pose>
+        <publish_nested_model_pose>false</publish_nested_model_pose>
         <use_pose_vector_msg>true</use_pose_vector_msg>
         <static_publisher>true</static_publisher>
         <static_update_frequency>1</static_update_frequency>
+      </plugin>
+      <!-- Publish ground truth information if specified by user -->
+      <plugin filename="libignition-gazebo-pose-publisher-system.so"
+        name="ignition::gazebo::systems::PosePublisher">
+        <publish_link_pose>false</publish_link_pose>
+        <publish_sensor_pose>false</publish_sensor_pose>
+        <publish_collision_pose>false</publish_collision_pose>
+        <publish_visual_pose>false</publish_visual_pose>
+        <publish_nested_model_pose>#{$enableGroundTruth}</publish_nested_model_pose>
+        <use_pose_vector_msg>true</use_pose_vector_msg>
+        <static_publisher>false</static_publisher>
       </plugin>
       <!-- Battery plugin -->
       <plugin filename="libignition-gazebo-linearbatteryplugin-system.so"

--- a/submitted_models/sophisticated_engineering_x4_sensor_config_1/launch/spawner.rb
+++ b/submitted_models/sophisticated_engineering_x4_sensor_config_1/launch/spawner.rb
@@ -19,10 +19,21 @@ def spawner(_name, _modelURI, _worldName, _x, _y, _z, _roll, _pitch, _yaw)
         <publish_sensor_pose>true</publish_sensor_pose>
         <publish_collision_pose>false</publish_collision_pose>
         <publish_visual_pose>false</publish_visual_pose>
-        <publish_nested_model_pose>#{$enableGroundTruth}</publish_nested_model_pose>
+        <publish_nested_model_pose>false</publish_nested_model_pose>
         <use_pose_vector_msg>true</use_pose_vector_msg>
         <static_publisher>true</static_publisher>
         <static_update_frequency>1</static_update_frequency>
+      </plugin>
+      <!-- Publish ground truth information if specified by user -->
+      <plugin filename="libignition-gazebo-pose-publisher-system.so"
+        name="ignition::gazebo::systems::PosePublisher">
+        <publish_link_pose>false</publish_link_pose>
+        <publish_sensor_pose>false</publish_sensor_pose>
+        <publish_collision_pose>false</publish_collision_pose>
+        <publish_visual_pose>false</publish_visual_pose>
+        <publish_nested_model_pose>#{$enableGroundTruth}</publish_nested_model_pose>
+        <use_pose_vector_msg>true</use_pose_vector_msg>
+        <static_publisher>false</static_publisher>
       </plugin>
       <plugin filename="libignition-gazebo-multicopter-motor-model-system.so"
         name="ignition::gazebo::systems::MulticopterMotorModel">

--- a/submitted_models/ssci_x2_sensor_config_1/launch/spawner.rb
+++ b/submitted_models/ssci_x2_sensor_config_1/launch/spawner.rb
@@ -34,22 +34,33 @@ def spawner(_name, _modelURI, _worldName, _x, _y, _z, _roll, _pitch, _yaw)
           <wheel_separation>#{0.33559 * 1.23}</wheel_separation>
           <wheel_radius>0.098</wheel_radius>
           <topic>/model/#{_name}/cmd_vel_relay</topic>
-	  <min_velocity>-2</min_velocity>
+          <min_velocity>-2</min_velocity>
           <max_velocity>2</max_velocity>
           <min_acceleration>-6</min_acceleration>
           <max_acceleration>6</max_acceleration>
         </plugin>
         <!-- Publish robot state information -->
-        <plugin filename=\"libignition-gazebo-pose-publisher-system.so\"
-          name=\"ignition::gazebo::systems::PosePublisher\">
+        <plugin filename="libignition-gazebo-pose-publisher-system.so"
+          name="ignition::gazebo::systems::PosePublisher">
           <publish_link_pose>true</publish_link_pose>
           <publish_sensor_pose>true</publish_sensor_pose>
           <publish_collision_pose>false</publish_collision_pose>
           <publish_visual_pose>false</publish_visual_pose>
-          <publish_nested_model_pose>#{$enableGroundTruth}</publish_nested_model_pose>
+          <publish_nested_model_pose>false</publish_nested_model_pose>
           <use_pose_vector_msg>true</use_pose_vector_msg>
           <static_publisher>true</static_publisher>
           <static_update_frequency>1</static_update_frequency>
+        </plugin>
+        <!-- Publish ground truth information if specified by user -->
+        <plugin filename="libignition-gazebo-pose-publisher-system.so"
+          name="ignition::gazebo::systems::PosePublisher">
+          <publish_link_pose>false</publish_link_pose>
+          <publish_sensor_pose>false</publish_sensor_pose>
+          <publish_collision_pose>false</publish_collision_pose>
+          <publish_visual_pose>false</publish_visual_pose>
+          <publish_nested_model_pose>#{$enableGroundTruth}</publish_nested_model_pose>
+          <use_pose_vector_msg>true</use_pose_vector_msg>
+          <static_publisher>false</static_publisher>
         </plugin>
         <!-- Battery plugin -->
         <plugin filename=\"libignition-gazebo-linearbatteryplugin-system.so\"

--- a/submitted_models/ssci_x4_sensor_config_1/launch/spawner.rb
+++ b/submitted_models/ssci_x4_sensor_config_1/launch/spawner.rb
@@ -41,10 +41,21 @@ def spawner(_name, _modelURI, _worldName, _x, _y, _z, _roll, _pitch, _yaw)
           <publish_sensor_pose>true</publish_sensor_pose>
           <publish_collision_pose>false</publish_collision_pose>
           <publish_visual_pose>false</publish_visual_pose>
-          <publish_nested_model_pose>#{$enableGroundTruth}</publish_nested_model_pose>
+          <publish_nested_model_pose>false</publish_nested_model_pose>
           <use_pose_vector_msg>true</use_pose_vector_msg>
           <static_publisher>true</static_publisher>
           <static_update_frequency>1</static_update_frequency>
+        </plugin>
+        <!-- Publish ground truth information if specified by user -->
+        <plugin filename="libignition-gazebo-pose-publisher-system.so"
+          name="ignition::gazebo::systems::PosePublisher">
+          <publish_link_pose>false</publish_link_pose>
+          <publish_sensor_pose>false</publish_sensor_pose>
+          <publish_collision_pose>false</publish_collision_pose>
+          <publish_visual_pose>false</publish_visual_pose>
+          <publish_nested_model_pose>#{$enableGroundTruth}</publish_nested_model_pose>
+          <use_pose_vector_msg>true</use_pose_vector_msg>
+          <static_publisher>false</static_publisher>
         </plugin>
         <plugin filename="libignition-gazebo-multicopter-motor-model-system.so"
           name="ignition::gazebo::systems::MulticopterMotorModel">

--- a/submitted_models/ssci_x4_sensor_config_2/launch/spawner.rb
+++ b/submitted_models/ssci_x4_sensor_config_2/launch/spawner.rb
@@ -36,10 +36,21 @@ def spawner(_name, _modelURI, _worldName, _x, _y, _z, _roll, _pitch, _yaw)
           <publish_sensor_pose>true</publish_sensor_pose>
           <publish_collision_pose>false</publish_collision_pose>
           <publish_visual_pose>false</publish_visual_pose>
-          <publish_nested_model_pose>#{$enableGroundTruth}</publish_nested_model_pose>
+          <publish_nested_model_pose>false</publish_nested_model_pose>
           <use_pose_vector_msg>true</use_pose_vector_msg>
           <static_publisher>true</static_publisher>
           <static_update_frequency>1</static_update_frequency>
+        </plugin>
+        <!-- Publish ground truth information if specified by user -->
+        <plugin filename="libignition-gazebo-pose-publisher-system.so"
+          name="ignition::gazebo::systems::PosePublisher">
+          <publish_link_pose>false</publish_link_pose>
+          <publish_sensor_pose>false</publish_sensor_pose>
+          <publish_collision_pose>false</publish_collision_pose>
+          <publish_visual_pose>false</publish_visual_pose>
+          <publish_nested_model_pose>#{$enableGroundTruth}</publish_nested_model_pose>
+          <use_pose_vector_msg>true</use_pose_vector_msg>
+          <static_publisher>false</static_publisher>
         </plugin>
         <plugin filename="libignition-gazebo-multicopter-motor-model-system.so"
           name="ignition::gazebo::systems::MulticopterMotorModel">

--- a/submitted_models/x1_sensor_config_6/launch/spawner.rb
+++ b/submitted_models/x1_sensor_config_6/launch/spawner.rb
@@ -32,10 +32,21 @@ def spawner(_name, _modelURI, _worldName, _x, _y, _z, _roll, _pitch, _yaw)
         <publish_sensor_pose>true</publish_sensor_pose>
         <publish_collision_pose>false</publish_collision_pose>
         <publish_visual_pose>false</publish_visual_pose>
-        <publish_nested_model_pose>#{$enableGroundTruth}</publish_nested_model_pose>
+        <publish_nested_model_pose>false</publish_nested_model_pose>
         <use_pose_vector_msg>true</use_pose_vector_msg>
         <static_publisher>true</static_publisher>
         <static_update_frequency>1</static_update_frequency>
+      </plugin>
+      <!-- Publish ground truth information if specified by user -->
+      <plugin filename="libignition-gazebo-pose-publisher-system.so"
+        name="ignition::gazebo::systems::PosePublisher">
+        <publish_link_pose>false</publish_link_pose>
+        <publish_sensor_pose>false</publish_sensor_pose>
+        <publish_collision_pose>false</publish_collision_pose>
+        <publish_visual_pose>false</publish_visual_pose>
+        <publish_nested_model_pose>#{$enableGroundTruth}</publish_nested_model_pose>
+        <use_pose_vector_msg>true</use_pose_vector_msg>
+        <static_publisher>false</static_publisher>
       </plugin>
       <!-- Battery plugin -->
       <plugin filename="libignition-gazebo-linearbatteryplugin-system.so"

--- a/submitted_models/x2_sensor_config_7/launch/spawner.rb
+++ b/submitted_models/x2_sensor_config_7/launch/spawner.rb
@@ -32,10 +32,21 @@ def spawner(_name, _modelURI, _worldName, _x, _y, _z, _roll, _pitch, _yaw)
         <publish_sensor_pose>true</publish_sensor_pose>
         <publish_collision_pose>false</publish_collision_pose>
         <publish_visual_pose>false</publish_visual_pose>
-        <publish_nested_model_pose>#{$enableGroundTruth}</publish_nested_model_pose>
+        <publish_nested_model_pose>false</publish_nested_model_pose>
         <use_pose_vector_msg>true</use_pose_vector_msg>
         <static_publisher>true</static_publisher>
         <static_update_frequency>1</static_update_frequency>
+      </plugin>
+      <!-- Publish ground truth information if specified by user -->
+      <plugin filename="libignition-gazebo-pose-publisher-system.so"
+        name="ignition::gazebo::systems::PosePublisher">
+        <publish_link_pose>false</publish_link_pose>
+        <publish_sensor_pose>false</publish_sensor_pose>
+        <publish_collision_pose>false</publish_collision_pose>
+        <publish_visual_pose>false</publish_visual_pose>
+        <publish_nested_model_pose>#{$enableGroundTruth}</publish_nested_model_pose>
+        <use_pose_vector_msg>true</use_pose_vector_msg>
+        <static_publisher>false</static_publisher>
       </plugin>
       <!-- Battery plugin -->
       <plugin filename="libignition-gazebo-linearbatteryplugin-system.so"

--- a/submitted_models/x3_sensor_config_5/launch/spawner.rb
+++ b/submitted_models/x3_sensor_config_5/launch/spawner.rb
@@ -17,10 +17,21 @@ def spawner(_name, _modelURI, _worldName, _x, _y, _z, _roll, _pitch, _yaw)
         <publish_sensor_pose>true</publish_sensor_pose>
         <publish_collision_pose>false</publish_collision_pose>
         <publish_visual_pose>false</publish_visual_pose>
-        <publish_nested_model_pose>#{$enableGroundTruth}</publish_nested_model_pose>
+        <publish_nested_model_pose>false</publish_nested_model_pose>
         <use_pose_vector_msg>true</use_pose_vector_msg>
         <static_publisher>true</static_publisher>
         <static_update_frequency>1</static_update_frequency>
+      </plugin>
+      <!-- Publish ground truth information if specified by user -->
+      <plugin filename="libignition-gazebo-pose-publisher-system.so"
+        name="ignition::gazebo::systems::PosePublisher">
+        <publish_link_pose>false</publish_link_pose>
+        <publish_sensor_pose>false</publish_sensor_pose>
+        <publish_collision_pose>false</publish_collision_pose>
+        <publish_visual_pose>false</publish_visual_pose>
+        <publish_nested_model_pose>#{$enableGroundTruth}</publish_nested_model_pose>
+        <use_pose_vector_msg>true</use_pose_vector_msg>
+        <static_publisher>false</static_publisher>
       </plugin>
       <plugin filename="libignition-gazebo-multicopter-motor-model-system.so"
         name="ignition::gazebo::systems::MulticopterMotorModel">

--- a/submitted_models/x4_sensor_config_6/launch/spawner.rb
+++ b/submitted_models/x4_sensor_config_6/launch/spawner.rb
@@ -17,10 +17,21 @@ def spawner(_name, _modelURI, _worldName, _x, _y, _z, _roll, _pitch, _yaw)
           <publish_sensor_pose>true</publish_sensor_pose>
           <publish_collision_pose>false</publish_collision_pose>
           <publish_visual_pose>false</publish_visual_pose>
-          <publish_nested_model_pose>#{$enableGroundTruth}</publish_nested_model_pose>
+          <publish_nested_model_pose>false</publish_nested_model_pose>
           <use_pose_vector_msg>true</use_pose_vector_msg>
           <static_publisher>true</static_publisher>
           <static_update_frequency>1</static_update_frequency>
+        </plugin>
+        <!-- Publish ground truth information if specified by user -->
+        <plugin filename="libignition-gazebo-pose-publisher-system.so"
+          name="ignition::gazebo::systems::PosePublisher">
+          <publish_link_pose>false</publish_link_pose>
+          <publish_sensor_pose>false</publish_sensor_pose>
+          <publish_collision_pose>false</publish_collision_pose>
+          <publish_visual_pose>false</publish_visual_pose>
+          <publish_nested_model_pose>#{$enableGroundTruth}</publish_nested_model_pose>
+          <use_pose_vector_msg>true</use_pose_vector_msg>
+          <static_publisher>false</static_publisher>
         </plugin>
         <plugin filename="libignition-gazebo-multicopter-motor-model-system.so"
           name="ignition::gazebo::systems::MulticopterMotorModel">


### PR DESCRIPTION
 Currently, ground truth pose data is being published to a robot's `pose_static` topic, which is problematic for the following reasons:
1. This implies that the ground truth pose doesn't change (or doesn't change often, at least), which is not true for most use cases.
2. The `pose_static` topic publishes at a rate of 1Hz, making the ground truth data difficult to use for real-time debugging (the `pose` topic publishes at a rate of 250Hz).

Resolves #659 and resolves #607.

TODO:
- [ ] Make models X1 ... X4 also publish ground truth data to `/<name>/pose` (I'm waiting for #745 to be merged before doing this)

Signed-off-by: Ashton Larkin <ashton@openrobotics.org>