### PR TITLE
Fix visual rockfall detectors

### DIFF
--- a/subt_ign/worlds/cave_circuit/06/cave_circuit_06.sdf
+++ b/subt_ign/worlds/cave_circuit/06/cave_circuit_06.sdf
@@ -89,7 +89,7 @@
       <static>true</static>
       <pose>123.259000 119.252000 18.634200 0 0 0</pose>
       <!-- Uncomment to visualize performer detector -->
-      <link name='body'>
+      <!--<link name='body'>
         <visual name="v1">
           <transparency>1.0</transparency>
           <geometry>
@@ -104,7 +104,7 @@
           <specular>0.5 0.5 0.5 1</specular>
         </material>
         <cast_shadows>false</cast_shadows>
-      </link>
+      </link>-->
       <plugin filename="libignition-gazebo-performer-detector-system.so"
         name="ignition::gazebo::systems::PerformerDetector">
         <topic>/subt_performer_detector</topic>
@@ -152,7 +152,7 @@
       <static>true</static>
       <pose>232.034000 -0.300330 9.838950 0 0 0</pose>
       <!-- Uncomment to visualize performer detector -->
-      <link name='body'>
+      <!--<link name='body'>
         <visual name="v1">
           <transparency>1.0</transparency>
           <geometry>
@@ -167,7 +167,7 @@
           <specular>0.5 0.5 0.5 1</specular>
         </material>
         <cast_shadows>false</cast_shadows>
-      </link>
+      </link>-->
       <plugin filename="libignition-gazebo-performer-detector-system.so"
         name="ignition::gazebo::systems::PerformerDetector">
         <topic>/subt_performer_detector</topic>


### PR DESCRIPTION
The uncommented links of performer_detector_rockfall models are visible to LiDAR sensors, even though they are fully transparent. As a result, robots that rely on LiDAR for navigation cannot access parts of this world that are behind these rockfall triggers. This PR comments out the visual links responsible for this issue.
![robotuav2map06run1](https://user-images.githubusercontent.com/15618729/106723870-da683a00-6607-11eb-808d-c015c0900fa6.png)
