### PR TITLE
Modify breadcrumb deployment location

### DIFF
--- a/submitted_models/csiro_data61_dtr_sensor_config_2/launch/spawner.rb
+++ b/submitted_models/csiro_data61_dtr_sensor_config_2/launch/spawner.rb
@@ -224,7 +224,7 @@ def spawner(_name, _modelURI, _worldName, _x, _y, _z, _roll, _pitch, _yaw)
         <breadcrumb>
           <sdf version="1.6">
             <model name="#{_name}__breadcrumb__">
-              <pose>-0.6 0 0.1 0 0 0</pose>
+              <pose>-0.3 0 0.0 0 0 0</pose>
               <include>
                 <uri>https://fuel.ignitionrobotics.org/1.0/OpenRobotics/models/Breadcrumb Node</uri>
               </include>


### PR DESCRIPTION
This make the breadcrumbs appear right behind the chassis.

# To test
1. `ign launch competition.ign worldName:=simple_cave_01 circuit:=cave robotName1:=X1 robotConfig1:=CSIRO_DATA61_DTR_SENSOR_CONFIG_2`
2. ` rostopic pub /X1/breadcrumb/deploy std_msgs/Empty "{}"`
Signed-off-by: Nate Koenig <nate@openrobotics.org>