### PR TITLE
Implement ROS bridge for calling set_rate on cameras and lidars

### DIFF
--- a/submitted_models/ctu_cras_norlab_absolem_sensor_config_1/launch/vehicle_topics.launch
+++ b/submitted_models/ctu_cras_norlab_absolem_sensor_config_1/launch/vehicle_topics.launch
@@ -183,6 +183,11 @@
       <remap from="input/image" to="front/depth" />
       <remap from="output/image" to="front/optical/depth" />
     </node>
+    <include file="$(find subt_ros)/launch/models_common/set_rate_relay.launch">
+      <arg name="name" value="ros_ign_bridge_rgbd_set_rate" />
+      <arg name="ign_service" value="$(arg link_prefix)/base_link/sensor/camera/set_rate" />
+      <arg name="ros_service" value="front/set_rate" />
+    </include>
 
     <!-- Planar Laser -->
     <node
@@ -192,6 +197,12 @@
         args="$(arg link_prefix)/laser/sensor/laser/scan@sensor_msgs/LaserScan[ignition.msgs.LaserScan">
       <remap from="$(arg link_prefix)/laser/sensor/laser/scan" to="front_scan"/>
     </node>
+
+    <include file="$(find subt_ros)/launch/models_common/set_rate_relay.launch">
+      <arg name="name" value="ros_ign_bridge_lidar_set_rate" />
+      <arg name="ign_service" value="$(arg link_prefix)/laser/sensor/laser/scan/set_rate" />
+      <arg name="ros_service" value="front_scan/set_rate" />
+    </include>
 
     <!-- Omnicamera -->
     
@@ -219,6 +230,11 @@
       <remap from="input/camera_info" to="omni/camera_0/camera_info" />
       <remap from="output/camera_info" to="omni/camera_0/optical/camera_info" />
     </node>
+    <include file="$(find subt_ros)/launch/models_common/set_rate_relay.launch">
+      <arg name="name" value="ros_ign_bridge_omnicam0_set_rate" />
+      <arg name="ign_service" value="$(arg link_prefix)/base_link/sensor/omnicam_sensor0/image/set_rate" />
+      <arg name="ros_service" value="omni/camera_0/set_rate" />
+    </include>
     
     <node
       pkg="ros_ign_bridge"
@@ -244,6 +260,11 @@
       <remap from="input/camera_info" to="omni/camera_1/camera_info" />
       <remap from="output/camera_info" to="omni/camera_1/optical/camera_info" />
     </node>
+    <include file="$(find subt_ros)/launch/models_common/set_rate_relay.launch">
+      <arg name="name" value="ros_ign_bridge_omnicam1_set_rate" />
+      <arg name="ign_service" value="$(arg link_prefix)/base_link/sensor/omnicam_sensor1/image/set_rate" />
+      <arg name="ros_service" value="omni/camera_1/set_rate" />
+    </include>
 
     <node
       pkg="ros_ign_bridge"
@@ -269,6 +290,11 @@
       <remap from="input/camera_info" to="omni/camera_2/camera_info" />
       <remap from="output/camera_info" to="omni/camera_2/optical/camera_info" />
     </node>
+    <include file="$(find subt_ros)/launch/models_common/set_rate_relay.launch">
+      <arg name="name" value="ros_ign_bridge_omnicam2_set_rate" />
+      <arg name="ign_service" value="$(arg link_prefix)/base_link/sensor/omnicam_sensor2/image/set_rate" />
+      <arg name="ros_service" value="omni/camera_2/set_rate" />
+    </include>
 
     <node
       pkg="ros_ign_bridge"
@@ -294,6 +320,11 @@
       <remap from="input/camera_info" to="omni/camera_3/camera_info" />
       <remap from="output/camera_info" to="omni/camera_3/optical/camera_info" />
     </node>
+    <include file="$(find subt_ros)/launch/models_common/set_rate_relay.launch">
+      <arg name="name" value="ros_ign_bridge_omnicam3_set_rate" />
+      <arg name="ign_service" value="$(arg link_prefix)/base_link/sensor/omnicam_sensor3/image/set_rate" />
+      <arg name="ros_service" value="omni/camera_3/set_rate" />
+    </include>
 
     <node
       pkg="ros_ign_bridge"
@@ -319,6 +350,11 @@
       <remap from="input/camera_info" to="omni/camera_4/camera_info" />
       <remap from="output/camera_info" to="omni/camera_4/optical/camera_info" />
     </node>
+    <include file="$(find subt_ros)/launch/models_common/set_rate_relay.launch">
+      <arg name="name" value="ros_ign_bridge_omnicam4_set_rate" />
+      <arg name="ign_service" value="$(arg link_prefix)/base_link/sensor/omnicam_sensor4/image/set_rate" />
+      <arg name="ros_service" value="omni/camera_4/set_rate" />
+    </include>
 
     <node
       pkg="ros_ign_bridge"
@@ -344,6 +380,11 @@
       <remap from="input/camera_info" to="omni/camera_5/camera_info" />
       <remap from="output/camera_info" to="omni/camera_5/optical/camera_info" />
     </node>
+    <include file="$(find subt_ros)/launch/models_common/set_rate_relay.launch">
+      <arg name="name" value="ros_ign_bridge_omnicam5_set_rate" />
+      <arg name="ign_service" value="$(arg link_prefix)/base_link/sensor/omnicam_sensor5/image/set_rate" />
+      <arg name="ros_service" value="omni/camera_5/set_rate" />
+    </include>
 
     <!--IMU-->
     <node

--- a/submitted_models/ctu_cras_norlab_absolem_sensor_config_1/package.xml
+++ b/submitted_models/ctu_cras_norlab_absolem_sensor_config_1/package.xml
@@ -21,6 +21,7 @@
   <exec_depend>ignition-gazebo4</exec_depend>
 
   <exec_depend>roslaunch</exec_depend>
+  <exec_depend>subt_ros</exec_depend>
   <exec_depend>xacro</exec_depend>
 
 </package>

--- a/submitted_models/explorer_ds1_sensor_config_1/launch/vehicle_topics.launch
+++ b/submitted_models/explorer_ds1_sensor_config_1/launch/vehicle_topics.launch
@@ -122,6 +122,11 @@
         <remap from="input/camera_info" to="depth/camera_info" />
         <remap from="output/camera_info" to="optical/depth/camera_info" />
       </node>
+      <include file="$(find subt_ros)/launch/models_common/set_rate_relay.launch">
+        <arg name="name" value="ros_ign_bridge_camera_set_rate" />
+        <arg name="ign_service" value="$(arg sensor_prefix)/rs_up/set_rate" />
+        <arg name="ros_service" value="set_rate" />
+      </include>
     </group>
 
     <!--DOWN RGBD camera -->
@@ -179,6 +184,11 @@
         <remap from="input/camera_info" to="depth/camera_info" />
         <remap from="output/camera_info" to="optical/depth/camera_info" />
       </node>
+      <include file="$(find subt_ros)/launch/models_common/set_rate_relay.launch">
+        <arg name="name" value="ros_ign_bridge_camera_set_rate" />
+        <arg name="ign_service" value="$(arg sensor_prefix)/rs_down/set_rate" />
+        <arg name="ros_service" value="set_rate" />
+      </include>
     </group>
 
     <!--Front RGBD camera -->
@@ -236,6 +246,11 @@
         <remap from="input/camera_info" to="depth/camera_info" />
         <remap from="output/camera_info" to="optical/depth/camera_info" />
       </node>
+      <include file="$(find subt_ros)/launch/models_common/set_rate_relay.launch">
+        <arg name="name" value="ros_ign_bridge_camera_set_rate" />
+        <arg name="ign_service" value="$(arg sensor_prefix)/rs_front/set_rate" />
+        <arg name="ros_service" value="set_rate" />
+      </include>
     </group>
 
     <!-- 3D lidar -->
@@ -247,6 +262,11 @@
         args="$(arg sensor_prefix)/front_laser/scan/points@sensor_msgs/PointCloud2[ignition.msgs.PointCloudPacked">
         <remap from="$(arg sensor_prefix)/front_laser/scan/points" to="points"/>
       </node>
+      <include file="$(find subt_ros)/launch/models_common/set_rate_relay.launch">
+        <arg name="name" value="ros_ign_bridge_lidar3d_set_rate" />
+        <arg name="ign_service" value="$(arg sensor_prefix)/front_laser/scan/set_rate" />
+        <arg name="ros_service" value="points/set_rate" />
+      </include>
     </group>
 
     <!-- UAV -->

--- a/submitted_models/explorer_ds1_sensor_config_1/package.xml
+++ b/submitted_models/explorer_ds1_sensor_config_1/package.xml
@@ -11,8 +11,10 @@
   <license>BSD</license>
 
   <buildtool_depend>catkin</buildtool_depend>
-  <buildtool_depend>roslaunch</buildtool_depend>
-  <buildtool_depend>urdf</buildtool_depend>
-  <buildtool_depend>xacro</buildtool_depend>
+
+  <exec_depend>roslaunch</exec_depend>
+  <exec_depend>subt_ros</exec_depend>
+  <exec_depend>urdf</exec_depend>
+  <exec_depend>xacro</exec_depend>
 
 </package>

--- a/submitted_models/explorer_x1_sensor_config_1/launch/vehicle_topics.launch
+++ b/submitted_models/explorer_x1_sensor_config_1/launch/vehicle_topics.launch
@@ -101,6 +101,11 @@
         <remap from="output/image" to="depth/optical/image_raw" />
       </node>
 
+      <include file="$(find subt_ros)/launch/models_common/set_rate_relay.launch">
+        <arg name="name" value="ros_ign_bridge_camera_set_rate" />
+        <arg name="ign_service" value="$(arg sensor_prefix)/front_realsense/set_rate" />
+        <arg name="ros_service" value="set_rate" />
+      </include>
     </group>
 
     <!--Left RGBD camera -->
@@ -153,6 +158,12 @@
         <remap from="input/image" to="depth/image_raw" />
         <remap from="output/image" to="depth/optical/image_raw" />
       </node>
+
+      <include file="$(find subt_ros)/launch/models_common/set_rate_relay.launch">
+        <arg name="name" value="ros_ign_bridge_camera_set_rate" />
+        <arg name="ign_service" value="$(arg sensor_prefix)/left_realsense/set_rate" />
+        <arg name="ros_service" value="set_rate" />
+      </include>
 
     </group>
 
@@ -207,6 +218,12 @@
         <remap from="output/image" to="depth/optical/image_raw" />
       </node>
 
+      <include file="$(find subt_ros)/launch/models_common/set_rate_relay.launch">
+        <arg name="name" value="ros_ign_bridge_camera_set_rate" />
+        <arg name="ign_service" value="$(arg sensor_prefix)/rear_realsense/set_rate" />
+        <arg name="ros_service" value="set_rate" />
+      </include>
+
     </group>
 
     <!--Right RGBD camera -->
@@ -260,6 +277,12 @@
         <remap from="output/image" to="depth/optical/image_raw" />
       </node>
 
+      <include file="$(find subt_ros)/launch/models_common/set_rate_relay.launch">
+        <arg name="name" value="ros_ign_bridge_camera_set_rate" />
+        <arg name="ign_service" value="$(arg sensor_prefix)/right_realsense/set_rate" />
+        <arg name="ros_service" value="set_rate" />
+      </include>
+
     </group>
 
     <!--Front Laser-->
@@ -270,6 +293,11 @@
       args="$(arg sensor_prefix)/front_laser/scan/points@sensor_msgs/PointCloud2[ignition.msgs.PointCloudPacked">
       <remap from="$(arg sensor_prefix)/front_laser/scan/points" to="points"/>
     </node>
+    <include file="$(find subt_ros)/launch/models_common/set_rate_relay.launch">
+      <arg name="name" value="ros_ign_bridge_lidar3d_set_rate" />
+      <arg name="ign_service" value="$(arg sensor_prefix)/front_laser/scan/set_rate" />
+      <arg name="ros_service" value="points/set_rate" />
+    </include>
 
 
     <!--IMU-->

--- a/submitted_models/explorer_x1_sensor_config_1/package.xml
+++ b/submitted_models/explorer_x1_sensor_config_1/package.xml
@@ -12,6 +12,7 @@
   <buildtool_depend>catkin</buildtool_depend>
   <build_depend>roslaunch</build_depend>
   <exec_depend>lms1xx</exec_depend>
+  <exec_depend>subt_ros</exec_depend>
   <exec_depend>urdf</exec_depend>
   <exec_depend>xacro</exec_depend>
 

--- a/submitted_models/explorer_x1_sensor_config_2/launch/vehicle_topics.launch
+++ b/submitted_models/explorer_x1_sensor_config_2/launch/vehicle_topics.launch
@@ -101,6 +101,12 @@
         <remap from="output/image" to="depth/optical/image_raw" />
       </node>
 
+      <include file="$(find subt_ros)/launch/models_common/set_rate_relay.launch">
+        <arg name="name" value="ros_ign_bridge_camera_set_rate" />
+        <arg name="ign_service" value="$(arg sensor_prefix)/front_realsense/set_rate" />
+        <arg name="ros_service" value="set_rate" />
+      </include>
+
     </group>
 
     <!--Left RGBD camera -->
@@ -153,6 +159,12 @@
         <remap from="input/image" to="depth/image_raw" />
         <remap from="output/image" to="depth/optical/image_raw" />
       </node>
+
+      <include file="$(find subt_ros)/launch/models_common/set_rate_relay.launch">
+        <arg name="name" value="ros_ign_bridge_camera_set_rate" />
+        <arg name="ign_service" value="$(arg sensor_prefix)/left_realsense/set_rate" />
+        <arg name="ros_service" value="set_rate" />
+      </include>
 
     </group>
 
@@ -207,6 +219,12 @@
         <remap from="output/image" to="depth/optical/image_raw" />
       </node>
 
+      <include file="$(find subt_ros)/launch/models_common/set_rate_relay.launch">
+        <arg name="name" value="ros_ign_bridge_camera_set_rate" />
+        <arg name="ign_service" value="$(arg sensor_prefix)/rear_realsense/set_rate" />
+        <arg name="ros_service" value="set_rate" />
+      </include>
+
     </group>
 
     <!--Right RGBD camera -->
@@ -260,6 +278,12 @@
         <remap from="output/image" to="depth/optical/image_raw" />
       </node>
 
+      <include file="$(find subt_ros)/launch/models_common/set_rate_relay.launch">
+        <arg name="name" value="ros_ign_bridge_camera_set_rate" />
+        <arg name="ign_service" value="$(arg sensor_prefix)/right_realsense/set_rate" />
+        <arg name="ros_service" value="set_rate" />
+      </include>
+
     </group>
 
     <!--Front Laser-->
@@ -270,7 +294,11 @@
       args="$(arg sensor_prefix)/front_laser/scan/points@sensor_msgs/PointCloud2[ignition.msgs.PointCloudPacked">
       <remap from="$(arg sensor_prefix)/front_laser/scan/points" to="points"/>
     </node>
-
+    <include file="$(find subt_ros)/launch/models_common/set_rate_relay.launch">
+      <arg name="name" value="ros_ign_bridge_lidar3d_set_rate" />
+      <arg name="ign_service" value="$(arg sensor_prefix)/front_laser/scan/set_rate" />
+      <arg name="ros_service" value="points/set_rate" />
+    </include>
 
     <!--IMU-->
     <node

--- a/submitted_models/explorer_x1_sensor_config_2/package.xml
+++ b/submitted_models/explorer_x1_sensor_config_2/package.xml
@@ -12,6 +12,7 @@
   <buildtool_depend>catkin</buildtool_depend>
   <build_depend>roslaunch</build_depend>
   <exec_depend>lms1xx</exec_depend>
+  <exec_depend>subt_ros</exec_depend>
   <exec_depend>urdf</exec_depend>
   <exec_depend>xacro</exec_depend>
 

--- a/submitted_models/marble_qav500_sensor_config_1/launch/vehicle_topics.launch
+++ b/submitted_models/marble_qav500_sensor_config_1/launch/vehicle_topics.launch
@@ -102,6 +102,11 @@
       <remap from="input/image" to="front/depth" />
       <remap from="output/image" to="front/optical/depth" />
     </node>
+    <include file="$(find subt_ros)/launch/models_common/set_rate_relay.launch">
+      <arg name="name" value="ros_ign_bridge_rgbd_set_rate" />
+      <arg name="ign_service" value="$(arg sensor_prefix)/camera_front/set_rate" />
+      <arg name="ros_service" value="front/set_rate" />
+    </include>
 
     <!-- Top TOF -->
     <node
@@ -134,6 +139,11 @@
       <remap from="input/camera_info" to="tof_top/camera_info" />
       <remap from="output/camera_info" to="tof_top/optical/camera_info" />
     </node>
+    <include file="$(find subt_ros)/launch/models_common/set_rate_relay.launch">
+      <arg name="name" value="ros_ign_bridge_tof_top_set_rate" />
+      <arg name="ign_service" value="$(arg sensor_prefix)/tof_top/depth_image/set_rate" />
+      <arg name="ros_service" value="tof_top/set_rate" />
+    </include>
 
     <!-- Bottom TOF -->
     <node
@@ -166,6 +176,11 @@
       <remap from="input/camera_info" to="tof_bottom/camera_info" />
       <remap from="output/camera_info" to="tof_bottom/optical/camera_info" />
     </node>
+    <include file="$(find subt_ros)/launch/models_common/set_rate_relay.launch">
+      <arg name="name" value="ros_ign_bridge_tof_bottom_set_rate" />
+      <arg name="ign_service" value="$(arg sensor_prefix)/tof_bottom/depth_image/set_rate" />
+      <arg name="ros_service" value="tof_bottom/set_rate" />
+    </include>
 
     <!-- 3D lidar -->
     <node
@@ -175,6 +190,11 @@
       args="$(arg sensor_prefix)/front_laser/scan/points@sensor_msgs/PointCloud2[ignition.msgs.PointCloudPacked">
       <remap from="$(arg sensor_prefix)/front_laser/scan/points" to="points"/>
     </node>
+    <include file="$(find subt_ros)/launch/models_common/set_rate_relay.launch">
+      <arg name="name" value="ros_ign_bridge_lidar3d_set_rate" />
+      <arg name="ign_service" value="$(arg sensor_prefix)/front_laser/scan/set_rate" />
+      <arg name="ros_service" value="points/set_rate" />
+    </include>
 
     <node
       pkg="ros_ign_bridge"

--- a/submitted_models/marble_qav500_sensor_config_1/package.xml
+++ b/submitted_models/marble_qav500_sensor_config_1/package.xml
@@ -20,8 +20,10 @@
   <license>BSD</license>
 
   <buildtool_depend>catkin</buildtool_depend>
-  <buildtool_depend>roslaunch</buildtool_depend>
-  <buildtool_depend>urdf</buildtool_depend>
-  <buildtool_depend>xacro</buildtool_depend>
+
+  <exec_depend>roslaunch</exec_depend>
+  <exec_depend>subt_ros</exec_depend>
+  <exec_depend>urdf</exec_depend>
+  <exec_depend>xacro</exec_depend>
 
 </package>

--- a/submitted_models/ssci_x4_sensor_config_1/launch/vehicle_topics.launch
+++ b/submitted_models/ssci_x4_sensor_config_1/launch/vehicle_topics.launch
@@ -97,6 +97,11 @@
         args="$(arg sensor_prefix)/front_laser/scan/points@sensor_msgs/PointCloud2[ignition.msgs.PointCloudPacked">
         <remap from="$(arg sensor_prefix)/front_laser/scan/points" to="points"/>
       </node>
+      <include file="$(find subt_ros)/launch/models_common/set_rate_relay.launch">
+        <arg name="name" value="ros_ign_bridge_lidar3d_set_rate" />
+        <arg name="ign_service" value="$(arg sensor_prefix)/front_laser/scan/set_rate" />
+        <arg name="ros_service" value="points/set_rate" />
+      </include>
     </group>
 
     <!-- stereo -->
@@ -168,6 +173,11 @@
         <remap from="input/camera_info" to="front/camera_info" />
         <remap from="output/camera_info" to="front/optical/camera_info" />
       </node>
+      <include file="$(find subt_ros)/launch/models_common/set_rate_relay.launch">
+        <arg name="name" value="ros_ign_bridge_camera_set_rate" />
+        <arg name="ign_service" value="$(arg sensor_prefix)/camera_front/image/set_rate" />
+        <arg name="ros_service" value="front/set_rate" />
+      </include>
 
     </group>
 
@@ -180,6 +190,11 @@
         args="$(arg sensor_prefix)/front_laser/scan@sensor_msgs/LaserScan[ignition.msgs.LaserScan">
         <remap from="$(arg sensor_prefix)/front_laser/scan" to="front_scan"/>
       </node>
+      <include file="$(find subt_ros)/launch/models_common/set_rate_relay.launch">
+        <arg name="name" value="ros_ign_bridge_front_laser_set_rate" />
+        <arg name="ign_service" value="$(arg sensor_prefix)/front_laser/scan/set_rate" />
+        <arg name="ros_service" value="front_scan/set_rate" />
+      </include>
     </group>
 
     <!-- top scan -->
@@ -191,6 +206,11 @@
         args="$(arg sensor_prefix)/top_laser/scan@sensor_msgs/LaserScan[ignition.msgs.LaserScan">
         <remap from="$(arg sensor_prefix)/top_laser/scan" to="top_scan"/>
       </node>
+      <include file="$(find subt_ros)/launch/models_common/set_rate_relay.launch">
+        <arg name="name" value="ros_ign_bridge_top_laser_set_rate" />
+        <arg name="ign_service" value="$(arg sensor_prefix)/top_laser/scan/set_rate" />
+        <arg name="ros_service" value="top_scan/set_rate" />
+      </include>
     </group>
 
     <!-- bottom scan -->
@@ -202,6 +222,11 @@
         args="$(arg sensor_prefix)/bottom_laser/scan@sensor_msgs/LaserScan[ignition.msgs.LaserScan">
         <remap from="$(arg sensor_prefix)/bottom_laser/scan" to="bottom_scan"/>
       </node>
+      <include file="$(find subt_ros)/launch/models_common/set_rate_relay.launch">
+        <arg name="name" value="ros_ign_bridge_bottom_laser_set_rate" />
+        <arg name="ign_service" value="$(arg sensor_prefix)/bottom_laser/scan/set_rate" />
+        <arg name="ros_service" value="bottom_scan/set_rate" />
+      </include>
     </group>
 
     <!-- UAV -->

--- a/submitted_models/ssci_x4_sensor_config_1/package.xml
+++ b/submitted_models/ssci_x4_sensor_config_1/package.xml
@@ -13,8 +13,10 @@
   <license>BSD</license>
 
   <buildtool_depend>catkin</buildtool_depend>
-  <buildtool_depend>roslaunch</buildtool_depend>
-  <buildtool_depend>urdf</buildtool_depend>
-  <buildtool_depend>xacro</buildtool_depend>
+
+  <exec_depend>roslaunch</exec_depend>
+  <exec_depend>subt_ros</exec_depend>
+  <exec_depend>urdf</exec_depend>
+  <exec_depend>xacro</exec_depend>
 
 </package>

--- a/subt_msgs/CMakeLists.txt
+++ b/subt_msgs/CMakeLists.txt
@@ -12,6 +12,7 @@ add_service_files(
     DatagramRos.srv
     Bind.srv
     SetPose.srv
+    SetRate.srv
     PoseFromArtifact.srv
     Register.srv
     Unregister.srv

--- a/subt_msgs/srv/SetRate.srv
+++ b/subt_msgs/srv/SetRate.srv
@@ -1,0 +1,2 @@
+float64 rate
+---

--- a/subt_ros/CMakeLists.txt
+++ b/subt_ros/CMakeLists.txt
@@ -102,8 +102,20 @@ target_link_libraries(set_pose_relay
 )
 add_dependencies(set_pose_relay ${catkin_EXPORTED_TARGETS})
 
+add_executable(set_rate_relay src/SetRateRelay.cc)
+target_include_directories(set_rate_relay
+  PRIVATE ${CATKIN_DEVEL_PREFIX}/include)
+target_link_libraries(set_rate_relay
+  PUBLIC
+    ignition-common3::ignition-common3
+    ignition-msgs6::ignition-msgs6
+    ignition-transport9::ignition-transport9
+    ${catkin_LIBRARIES}
+)
+add_dependencies(set_rate_relay ${catkin_EXPORTED_TARGETS})
+
 install(TARGETS pose_tf_broadcaster subt_ros_relay set_pose_relay bridge_logger
-  optical_frame_publisher
+  optical_frame_publisher set_rate_relay
   DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}
 )
 install(DIRECTORY launch

--- a/subt_ros/launch/models_common/set_rate_relay.launch
+++ b/subt_ros/launch/models_common/set_rate_relay.launch
@@ -1,0 +1,10 @@
+<launch>
+    <arg name="name" />
+    <arg name="ign_service" />
+    <arg name="ros_service" />
+
+    <node name="$(arg name)" pkg="subt_ros" type="set_rate_relay">
+        <param name="service" value="$(arg ign_service)" />
+        <remap from="$(arg ign_service)" to="$(arg ros_service)" />
+    </node>
+</launch>

--- a/subt_ros/launch/vehicle_topics.launch
+++ b/subt_ros/launch/vehicle_topics.launch
@@ -79,6 +79,11 @@
         <remap from="input/image" to="front/depth" />
         <remap from="output/image" to="front/optical/depth" />
       </node>
+      <include file="$(find subt_ros)/launch/models_common/set_rate_relay.launch">
+        <arg name="name" value="ros_ign_bridge_rgbd_set_rate" />
+        <arg name="ign_service" value="$(arg sensor_prefix)/camera_front/set_rate" />
+        <arg name="ros_service" value="front/set_rate" />
+      </include>
 
     </group>
 
@@ -91,6 +96,11 @@
         args="$(arg sensor_prefix)/front_laser/scan/points@sensor_msgs/PointCloud2[ignition.msgs.PointCloudPacked">
         <remap from="$(arg sensor_prefix)/front_laser/scan/points" to="points"/>
       </node>
+      <include file="$(find subt_ros)/launch/models_common/set_rate_relay.launch">
+        <arg name="name" value="ros_ign_bridge_lidar3d_set_rate" />
+        <arg name="ign_service" value="$(arg sensor_prefix)/front_laser/scan/set_rate" />
+        <arg name="ros_service" value="points/set_rate" />
+      </include>
     </group>
 
     <!-- stereo -->
@@ -133,6 +143,16 @@
         <remap from="input/camera_info" to="front/left/camera_info" />
         <remap from="output/camera_info" to="front/left/optical/camera_info" />
       </node>
+      <include file="$(find subt_ros)/launch/models_common/set_rate_relay.launch">
+        <arg name="name" value="ros_ign_bridge_stereo_left_set_rate" />
+        <arg name="ign_service" value="$(arg sensor_prefix)/camera_front_left/image/set_rate" />
+        <arg name="ros_service" value="front/left/set_rate" />
+      </include>
+      <include file="$(find subt_ros)/launch/models_common/set_rate_relay.launch">
+        <arg name="name" value="ros_ign_bridge_stereo_right_set_rate" />
+        <arg name="ign_service" value="$(arg sensor_prefix)/camera_front_right/image/set_rate" />
+        <arg name="ros_service" value="front/right/set_rate" />
+      </include>
 
     </group>
 
@@ -162,6 +182,11 @@
         <remap from="input/camera_info" to="front/camera_info" />
         <remap from="output/camera_info" to="front/optical/camera_info" />
       </node>
+      <include file="$(find subt_ros)/launch/models_common/set_rate_relay.launch" unless="$(arg rgbd_cam)">
+        <arg name="name" value="ros_ign_bridge_camera_set_rate" />
+        <arg name="ign_service" value="$(arg sensor_prefix)/camera_front/image/set_rate" />
+        <arg name="ros_service" value="front/set_rate" />
+      </include>
 
     </group>
 
@@ -174,6 +199,11 @@
         args="$(arg sensor_prefix)/front_laser/scan@sensor_msgs/LaserScan[ignition.msgs.LaserScan">
         <remap from="$(arg sensor_prefix)/front_laser/scan" to="front_scan"/>
       </node>
+      <include file="$(find subt_ros)/launch/models_common/set_rate_relay.launch">
+        <arg name="name" value="ros_ign_bridge_front_laser_set_rate" />
+        <arg name="ign_service" value="$(arg sensor_prefix)/front_laser/scan/set_rate" />
+        <arg name="ros_service" value="front_scan/set_rate" />
+      </include>
     </group>
 
     <!-- UAV -->

--- a/subt_ros/src/SetRateRelay.cc
+++ b/subt_ros/src/SetRateRelay.cc
@@ -1,0 +1,140 @@
+/*
+ * Copyright (C) 2019 Open Source Robotics Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+*/
+#include <ros/ros.h>
+
+#include <ignition/msgs/double.pb.h>
+
+#include <subt_msgs/SetRate.h>
+
+#include <ignition/common/Util.hh>
+#include <ignition/transport/Node.hh>
+
+/// \brief This is a Ign-ROS relay for set_rate service for cameras
+/// (added in https://github.com/ignitionrobotics/ign-sensors/pull/95).
+///
+/// ROS parameters:
+/// - ~service string Full name of the Ignition set_rate service.
+/// - ~timeout uint Timeout for calling the service (in ms). Default is 1000.
+///
+/// Advertised ROS services:
+/// - ~${service} (subt_msgs/SetRate) Set rate of the connected camera to the given
+///                                   value. The ROS service is named the same as
+///                                   the Ignition service it is relayed to.
+class SetRateRelay
+{
+  /// \brief Constructor
+  public: SetRateRelay();
+
+  /// \brief Destructor
+  public: ~SetRateRelay() = default;
+
+  /// \brief ROS service callback triggered when the service is called.
+  /// \param[in]  _req The message containing the desired publishing rate for
+  /// a camera.
+  /// \param[out] _res The response message.
+  public: bool OnSetRateCall(subt_msgs::SetRate::Request &_req,
+                             subt_msgs::SetRate::Response &_res);
+
+  /// \brief Ignition Transport node.
+  public: ignition::transport::Node node;
+
+  /// \brief The ROS node handler used for private communications.
+  public: ros::NodeHandle pnh;
+
+  /// \brief ROS service to receive a call to set camera rate.
+  public: ros::ServiceServer setRateService;
+
+  /// \brief Name of the set_rate service in both Ignition Transport and ROS.
+  public: std::string serviceName;
+};
+
+//////////////////////////////////////////////////
+SetRateRelay::SetRateRelay() : pnh("~")
+{
+  if (!this->pnh.getParam("service", this->serviceName)) {
+    ROS_ERROR("Cannot operate without parameter '~service' set to the path to the Ignition "
+              "Transport service set_rate for the camera.");
+    ros::shutdown();
+    return;
+  }
+  std::string topicStats;
+  ignition::common::env("IGN_TRANSPORT_TOPIC_STATISTICS", topicStats, true);
+
+  std::vector<std::string> services;
+  bool firstLoop {true};
+  bool waitedAtLeastOnce = false;
+  while (ros::ok() && std::find(services.begin(), services.end(), this->serviceName) == services.end())
+  {
+    if (firstLoop)
+    {
+      firstLoop = false;
+    }
+    else
+    {
+      std::string topicStatsWarning;
+      if (topicStats == "1" && waitedAtLeastOnce)
+      {
+        topicStatsWarning = " IGN_TRANSPORT_TOPIC_STATISTICS is set to 1. Make sure all parts of the simulator "
+                            "run with this setting, otherwise the parts with different values of this variable "
+                            "would not be able to communicate with each other.";
+      }
+
+      ROS_WARN_STREAM_DELAYED_THROTTLE(60.0,
+        "Waiting for ignition service " << this->serviceName << " to appear." << topicStatsWarning);
+
+      ros::WallDuration(1, 0).sleep();
+      waitedAtLeastOnce = true;
+    }
+    this->node.ServiceList(services);
+  }
+
+  if (!ros::ok())
+    return;
+
+  if (waitedAtLeastOnce)
+    ROS_INFO_STREAM("Ignition Service " << this->serviceName << " found.");
+
+  this->setRateService = this->pnh.advertiseService(
+    this->serviceName, &SetRateRelay::OnSetRateCall, this);
+
+  ROS_INFO_STREAM("Started set_rate relay from Ign service " << this->serviceName
+                  << " to ROS service " << this->setRateService.getService());
+}
+
+/////////////////////////////////////////////////
+bool SetRateRelay::OnSetRateCall(subt_msgs::SetRate::Request &_req,
+  subt_msgs::SetRate::Response &_res)
+{
+  ignition::msgs::Double req;
+  req.set_data(_req.rate);
+
+  ROS_DEBUG_STREAM("Relaying " << this->setRateService.getService() << ": " << _req);
+
+  // Pass the request onto ignition transport
+  return this->node.Request(this->serviceName, req);
+}
+
+//////////////////////////////////////////////////
+int main(int argc, char * argv[])
+{
+  ros::init(argc, argv, "subt_set_rate_relay");
+
+  SetRateRelay relay;
+
+  ros::spin();
+  return 0;
+}


### PR DESCRIPTION
Depends on release of https://github.com/ignitionrobotics/ign-sensors/pull/95 in ign-sensors4.

This PR adds ROS services `.../set_rate` to cameras and lidars which can be used to call their Ignition counterparts. This is to allow users to deliberately lower the FPS of the rendering sensors, speeding up the simulation. It doesn't change the default behavior of the sensors in any way (i.e. until the ROS service is called, the sensors publish at the rate specified in SDF). 

https://github.com/ignitionrobotics/ign-sensors/pull/95 makes sure it is not possible to set the rate higher than what it specified in SDF (special case 0 is only allowed to be set if SDF contains 0). Negative set_rate requests are ignored.

Each time the set_rate request is processed by the simulator, it emits a debug message like

    [Dbg] [Sensor.cc:266] Setting update rate of sensor X1::base_link::camera_front to 10 Hz

It also checks whether the Ignition service is available. If it's not, it emits this kind of warning once per minute:

    [ WARN] [1613162940.414493909, 60.944000000] [ros.subt_ros]: Waiting for ignition service /world/simple_cave_01/model/X1/link/base_link/sensor/camera_front/image/set_rate to appear.

Moreover, if `IGN_TRANSPORT_TOPIC_STATISTICS=1`, the warning will also include this text:

    IGN_TRANSPORT_TOPIC_STATISTICS is set to 1. Make sure all parts of the simulator run with this setting, otherwise the parts with different values of this variable would not be able to communicate with each other.

The ROS service is only advertised after existence of the Ignition service is confirmed.

So far I added the services mostly to robots we regularly use. There's no reason not to add it to other robots, too, but it needs to be tested a bit (whether you connected the ROS service to the correct Ignition service) and that would take time, so I first want to get a thumbs up on how this is implemented, and when the implementation is agreed upon, I can try to fix the other robots.

---

There is an alternative implementation, which would not need changing all robot launchers. It would be a node that would periodically list all ignition services and create the set_rate ROS counterparts on-the-fly as the Ignition services appear. But I didn't like this solution that much because it's not really transparent (automagic) and it would create weird service names (we would need to name them after the Ignition services because there is no other hint for a name). It would also create the services for sensors where it doesn't make sense to lower the rate because generating their data is not expensive (IMUs, pressure sensors, magnetometers).

---

I also probably found a bug in https://github.com/osrf/subt/blob/6bd98e3142f3ecfe1f9de05b787f8c391211ba40/subt_ros/launch/vehicle_topics.launch#L140-L166 .

It begins with a block `unless="$(arg stereo_cam)"` and adds a RGB camera. But the models which use RGBD camera do not include this additional RGB camera (i.e. X4_SENSOR_CONFIG_2). However, bridges for the RGB cam are created. I only protected the set_rate bridge with the additional `unless="$(arg rgbd_cam)"`, but I think the whole RGB camera block should be excluded when the RGBD is present. But I felt that doing such change could break something I did not foresee, so I did not do it.

---

I also fixed some package.xml's which apparently mistakenly used `<buildtool_depend>` instead of `<exec_depend>` (because I needed to add `<exec_depend>subt_ros</exec_depend>` and it seemed to me this is a good opprotunity to fix the package.xml).

---

Finally, I noticed there's a large room for code reuse in the model launch files.

  - roslaunch/XML includes (e.g. the breadcrumb robot config could include the non-breadcrumb robot launch and just add the breadcrumb bridge)
  - common roslaunch/XML "library" of bridge pieces (i.e. `rgb_cam_bridge.launch` which could be included, given a few args, and would bring in all the required nodes like cam info bridge, image bridge, optical frame publisher, set_rate bridge etc.)
  - spawner.rb could also utilize some robot building library that would contain plugin definitions which could be composed as Ruby strings (that would be an extension of #786)

All of this would ease the development of new robot models and maintenance of the existing ones and decrease the reviewer's load. But I don't think I have the time for such large refactoring. I'm also not sure if it'd be allowed/ethical to do such large changes to other teams' robot packages. And it would need extensive testing (which could be automated a bit e.g. comparing the "resolved" roslaunch XML files and the resulting Ruby strings in spawners).