### PR TITLE
New IMU noise model

### DIFF
--- a/submitted_models/cerberus_anymal_b_sensor_config_1/model.sdf
+++ b/submitted_models/cerberus_anymal_b_sensor_config_1/model.sdf
@@ -231,71 +231,77 @@
         <always_on>1</always_on>
         <update_rate>400</update_rate>
         <imu>
-          <angular_velocity>
-            <x>
-              <noise type="gaussian">
-                <mean>0</mean>
-                <stddev>2e-4</stddev>
-                <bias_mean>0.0000075</bias_mean>
-                <bias_stddev>0.0000008</bias_stddev>
-                <dynamic_bias_stddev>0.0000004</dynamic_bias_stddev>
-                <dynamic_bias_correlation_time>1000.0</dynamic_bias_correlation_time>
-              </noise>
-            </x>
-            <y>
-              <noise type="gaussian">
-                <mean>0</mean>
-                <stddev>2e-4</stddev>
-                <bias_mean>0.0000075</bias_mean>
-                <bias_stddev>0.0000008</bias_stddev>
-                <dynamic_bias_stddev>0.0000004</dynamic_bias_stddev>
-                <dynamic_bias_correlation_time>1000.0</dynamic_bias_correlation_time>
-              </noise>
-            </y>
-            <z>
-              <noise type="gaussian">
-                <mean>0</mean>
-                <stddev>2e-4</stddev>
-                <bias_mean>0.0000075</bias_mean>
-                <bias_stddev>0.0000008</bias_stddev>
-                <dynamic_bias_stddev>0.0000004</dynamic_bias_stddev>
-                <dynamic_bias_correlation_time>1000.0</dynamic_bias_correlation_time>
-              </noise>
-            </z>
-          </angular_velocity>
-          <linear_acceleration>
-            <x>
-              <noise type="gaussian">
-                <mean>0</mean>
-                <stddev>1e-2</stddev>
-                <bias_mean>0.1</bias_mean>
-                <bias_stddev>0.001</bias_stddev>
-                <dynamic_bias_stddev>0.002</dynamic_bias_stddev>
-                <dynamic_bias_correlation_time>300.0</dynamic_bias_correlation_time>
-              </noise>
-            </x>
-            <y>
-              <noise type="gaussian">
-                <mean>0</mean>
-                <stddev>1e-2</stddev>
-                <bias_mean>0.1</bias_mean>
-                <bias_stddev>0.001</bias_stddev>
-                <dynamic_bias_stddev>0.002</dynamic_bias_stddev>
-                <dynamic_bias_correlation_time>300.0</dynamic_bias_correlation_time>
-              </noise>
-            </y>
-            <z>
-              <noise type="gaussian">
-                <mean>0</mean>
-                <stddev>1e-2</stddev>
-                <bias_mean>0.1</bias_mean>
-                <bias_stddev>0.001</bias_stddev>
-                <dynamic_bias_stddev>0.002</dynamic_bias_stddev>
-                <dynamic_bias_correlation_time>300.0</dynamic_bias_correlation_time>
-              </noise>
-            </z>
-          </linear_acceleration>
-        </imu>
+                    <angular_velocity>
+                        <x>
+                            <noise type="gaussian">
+                                <mean>0</mean>
+                                <stddev>0.009</stddev>
+                                <bias_mean>0.00075</bias_mean>
+                                <bias_stddev>0.005</bias_stddev>
+                                <dynamic_bias_stddev>0.00002</dynamic_bias_stddev>
+                                <dynamic_bias_correlation_time>400.0</dynamic_bias_correlation_time>
+                                <precision>0.00025</precision>
+                            </noise>
+                        </x>
+                        <y>
+                            <noise type="gaussian">
+                                <mean>0</mean>
+                                <stddev>0.009</stddev>
+                                <bias_mean>0.00075</bias_mean>
+                                <bias_stddev>0.005</bias_stddev>
+                                <dynamic_bias_stddev>0.00002</dynamic_bias_stddev>
+                                <dynamic_bias_correlation_time>400.0</dynamic_bias_correlation_time>
+                                <precision>0.00025</precision>
+                            </noise>
+                        </y>
+                        <z>
+                            <noise type="gaussian">
+                                <mean>0</mean>
+                                <stddev>0.009</stddev>
+                                <bias_mean>0.00075</bias_mean>
+                                <bias_stddev>0.005</bias_stddev>
+                                <dynamic_bias_stddev>0.00002</dynamic_bias_stddev>
+                                <dynamic_bias_correlation_time>400.0</dynamic_bias_correlation_time>
+                                <precision>0.00025</precision>
+                            </noise>
+                        </z>
+                    </angular_velocity>
+                    <linear_acceleration>
+                        <x>
+                            <noise type="gaussian">
+                                <mean>0</mean>
+                                <stddev>0.021</stddev>
+                                <bias_mean>0.05</bias_mean>
+                                <bias_stddev>0.0075</bias_stddev>
+                                <dynamic_bias_stddev>0.000375</dynamic_bias_stddev>
+                                <dynamic_bias_correlation_time>175.0</dynamic_bias_correlation_time>
+                                <precision>0.005</precision>
+                            </noise>
+                        </x>
+                        <y>
+                            <noise type="gaussian">
+                                <mean>0</mean>
+                                <stddev>0.021</stddev>
+                                <bias_mean>0.05</bias_mean>
+                                <bias_stddev>0.0075</bias_stddev>
+                                <dynamic_bias_stddev>0.000375</dynamic_bias_stddev>
+                                <dynamic_bias_correlation_time>175.0</dynamic_bias_correlation_time>
+                                <precision>0.005</precision>
+                            </noise>
+                        </y>
+                        <z>
+                            <noise type="gaussian">
+                                <mean>0</mean>
+                                <stddev>0.021</stddev>
+                                <bias_mean>0.05</bias_mean>
+                                <bias_stddev>0.0075</bias_stddev>
+                                <dynamic_bias_stddev>0.000375</dynamic_bias_stddev>
+                                <dynamic_bias_correlation_time>175.0</dynamic_bias_correlation_time>
+                                <precision>0.005</precision>
+                            </noise>
+                        </z>
+                    </linear_acceleration>
+                </imu>
       </sensor>
 
       <sensor name="front_laser" type="gpu_lidar">

--- a/submitted_models/cerberus_anymal_c_sensor_config_1/model.sdf
+++ b/submitted_models/cerberus_anymal_c_sensor_config_1/model.sdf
@@ -399,142 +399,154 @@
         <always_on>1</always_on>
         <update_rate>400</update_rate>
         <imu>
-          <angular_velocity>
-            <x>
-              <noise type="gaussian">
-                <mean>0</mean>
-                <stddev>2e-4</stddev>
-                <bias_mean>0.0000075</bias_mean>
-                <bias_stddev>0.0000008</bias_stddev>
-                <dynamic_bias_stddev>0.0000004</dynamic_bias_stddev>
-                <dynamic_bias_correlation_time>1000.0</dynamic_bias_correlation_time>
-              </noise>
-            </x>
-            <y>
-              <noise type="gaussian">
-                <mean>0</mean>
-                <stddev>2e-4</stddev>
-                <bias_mean>0.0000075</bias_mean>
-                <bias_stddev>0.0000008</bias_stddev>
-                <dynamic_bias_stddev>0.0000004</dynamic_bias_stddev>
-                <dynamic_bias_correlation_time>1000.0</dynamic_bias_correlation_time>
-              </noise>
-            </y>
-            <z>
-              <noise type="gaussian">
-                <mean>0</mean>
-                <stddev>2e-4</stddev>
-                <bias_mean>0.0000075</bias_mean>
-                <bias_stddev>0.0000008</bias_stddev>
-                <dynamic_bias_stddev>0.0000004</dynamic_bias_stddev>
-                <dynamic_bias_correlation_time>1000.0</dynamic_bias_correlation_time>
-              </noise>
-            </z>
-          </angular_velocity>
-          <linear_acceleration>
-            <x>
-              <noise type="gaussian">
-                <mean>0</mean>
-                <stddev>1e-2</stddev>
-                <bias_mean>0.1</bias_mean>
-                <bias_stddev>0.001</bias_stddev>
-                <dynamic_bias_stddev>0.002</dynamic_bias_stddev>
-                <dynamic_bias_correlation_time>300.0</dynamic_bias_correlation_time>
-              </noise>
-            </x>
-            <y>
-              <noise type="gaussian">
-                <mean>0</mean>
-                <stddev>1e-2</stddev>
-                <bias_mean>0.1</bias_mean>
-                <bias_stddev>0.001</bias_stddev>
-                <dynamic_bias_stddev>0.002</dynamic_bias_stddev>
-                <dynamic_bias_correlation_time>300.0</dynamic_bias_correlation_time>
-              </noise>
-            </y>
-            <z>
-              <noise type="gaussian">
-                <mean>0</mean>
-                <stddev>1e-2</stddev>
-                <bias_mean>0.1</bias_mean>
-                <bias_stddev>0.001</bias_stddev>
-                <dynamic_bias_stddev>0.002</dynamic_bias_stddev>
-                <dynamic_bias_correlation_time>300.0</dynamic_bias_correlation_time>
-              </noise>
-            </z>
-          </linear_acceleration>
-        </imu>
+                    <angular_velocity>
+                        <x>
+                            <noise type="gaussian">
+                                <mean>0</mean>
+                                <stddev>0.009</stddev>
+                                <bias_mean>0.00075</bias_mean>
+                                <bias_stddev>0.005</bias_stddev>
+                                <dynamic_bias_stddev>0.00002</dynamic_bias_stddev>
+                                <dynamic_bias_correlation_time>400.0</dynamic_bias_correlation_time>
+                                <precision>0.00025</precision>
+                            </noise>
+                        </x>
+                        <y>
+                            <noise type="gaussian">
+                                <mean>0</mean>
+                                <stddev>0.009</stddev>
+                                <bias_mean>0.00075</bias_mean>
+                                <bias_stddev>0.005</bias_stddev>
+                                <dynamic_bias_stddev>0.00002</dynamic_bias_stddev>
+                                <dynamic_bias_correlation_time>400.0</dynamic_bias_correlation_time>
+                                <precision>0.00025</precision>
+                            </noise>
+                        </y>
+                        <z>
+                            <noise type="gaussian">
+                                <mean>0</mean>
+                                <stddev>0.009</stddev>
+                                <bias_mean>0.00075</bias_mean>
+                                <bias_stddev>0.005</bias_stddev>
+                                <dynamic_bias_stddev>0.00002</dynamic_bias_stddev>
+                                <dynamic_bias_correlation_time>400.0</dynamic_bias_correlation_time>
+                                <precision>0.00025</precision>
+                            </noise>
+                        </z>
+                    </angular_velocity>
+                    <linear_acceleration>
+                        <x>
+                            <noise type="gaussian">
+                                <mean>0</mean>
+                                <stddev>0.021</stddev>
+                                <bias_mean>0.05</bias_mean>
+                                <bias_stddev>0.0075</bias_stddev>
+                                <dynamic_bias_stddev>0.000375</dynamic_bias_stddev>
+                                <dynamic_bias_correlation_time>175.0</dynamic_bias_correlation_time>
+                                <precision>0.005</precision>
+                            </noise>
+                        </x>
+                        <y>
+                            <noise type="gaussian">
+                                <mean>0</mean>
+                                <stddev>0.021</stddev>
+                                <bias_mean>0.05</bias_mean>
+                                <bias_stddev>0.0075</bias_stddev>
+                                <dynamic_bias_stddev>0.000375</dynamic_bias_stddev>
+                                <dynamic_bias_correlation_time>175.0</dynamic_bias_correlation_time>
+                                <precision>0.005</precision>
+                            </noise>
+                        </y>
+                        <z>
+                            <noise type="gaussian">
+                                <mean>0</mean>
+                                <stddev>0.021</stddev>
+                                <bias_mean>0.05</bias_mean>
+                                <bias_stddev>0.0075</bias_stddev>
+                                <dynamic_bias_stddev>0.000375</dynamic_bias_stddev>
+                                <dynamic_bias_correlation_time>175.0</dynamic_bias_correlation_time>
+                                <precision>0.005</precision>
+                            </noise>
+                        </z>
+                    </linear_acceleration>
+                </imu>
         <pose frame="">0.249 0.008 0.046 0.000 -0.000 1.571</pose>
       </sensor>
       <sensor name="perception_head_imu_sensor" type="imu">
         <always_on>1</always_on>
         <update_rate>200</update_rate>
         <imu>
-          <angular_velocity>
-            <x>
-              <noise type="gaussian">
-                <mean>0</mean>
-                <stddev>2e-4</stddev>
-                <bias_mean>0.0000075</bias_mean>
-                <bias_stddev>0.0000008</bias_stddev>
-                <dynamic_bias_stddev>0.0000004</dynamic_bias_stddev>
-                <dynamic_bias_correlation_time>1000.0</dynamic_bias_correlation_time>
-              </noise>
-            </x>
-            <y>
-              <noise type="gaussian">
-                <mean>0</mean>
-                <stddev>2e-4</stddev>
-                <bias_mean>0.0000075</bias_mean>
-                <bias_stddev>0.0000008</bias_stddev>
-                <dynamic_bias_stddev>0.0000004</dynamic_bias_stddev>
-                <dynamic_bias_correlation_time>1000.0</dynamic_bias_correlation_time>
-              </noise>
-            </y>
-            <z>
-              <noise type="gaussian">
-                <mean>0</mean>
-                <stddev>2e-4</stddev>
-                <bias_mean>0.0000075</bias_mean>
-                <bias_stddev>0.0000008</bias_stddev>
-                <dynamic_bias_stddev>0.0000004</dynamic_bias_stddev>
-                <dynamic_bias_correlation_time>1000.0</dynamic_bias_correlation_time>
-              </noise>
-            </z>
-          </angular_velocity>
-          <linear_acceleration>
-            <x>
-              <noise type="gaussian">
-                <mean>0</mean>
-                <stddev>1e-2</stddev>
-                <bias_mean>0.1</bias_mean>
-                <bias_stddev>0.001</bias_stddev>
-                <dynamic_bias_stddev>0.002</dynamic_bias_stddev>
-                <dynamic_bias_correlation_time>300.0</dynamic_bias_correlation_time>
-              </noise>
-            </x>
-            <y>
-              <noise type="gaussian">
-                <mean>0</mean>
-                <stddev>1e-2</stddev>
-                <bias_mean>0.1</bias_mean>
-                <bias_stddev>0.001</bias_stddev>
-                <dynamic_bias_stddev>0.002</dynamic_bias_stddev>
-                <dynamic_bias_correlation_time>300.0</dynamic_bias_correlation_time>
-              </noise>
-            </y>
-            <z>
-              <noise type="gaussian">
-                <mean>0</mean>
-                <stddev>1e-2</stddev>
-                <bias_mean>0.1</bias_mean>
-                <bias_stddev>0.001</bias_stddev>
-                <dynamic_bias_stddev>0.002</dynamic_bias_stddev>
-                <dynamic_bias_correlation_time>300.0</dynamic_bias_correlation_time>
-              </noise>
-            </z>
-          </linear_acceleration>
-        </imu>
+                    <angular_velocity>
+                        <x>
+                            <noise type="gaussian">
+                                <mean>0</mean>
+                                <stddev>0.009</stddev>
+                                <bias_mean>0.00075</bias_mean>
+                                <bias_stddev>0.005</bias_stddev>
+                                <dynamic_bias_stddev>0.00002</dynamic_bias_stddev>
+                                <dynamic_bias_correlation_time>400.0</dynamic_bias_correlation_time>
+                                <precision>0.00025</precision>
+                            </noise>
+                        </x>
+                        <y>
+                            <noise type="gaussian">
+                                <mean>0</mean>
+                                <stddev>0.009</stddev>
+                                <bias_mean>0.00075</bias_mean>
+                                <bias_stddev>0.005</bias_stddev>
+                                <dynamic_bias_stddev>0.00002</dynamic_bias_stddev>
+                                <dynamic_bias_correlation_time>400.0</dynamic_bias_correlation_time>
+                                <precision>0.00025</precision>
+                            </noise>
+                        </y>
+                        <z>
+                            <noise type="gaussian">
+                                <mean>0</mean>
+                                <stddev>0.009</stddev>
+                                <bias_mean>0.00075</bias_mean>
+                                <bias_stddev>0.005</bias_stddev>
+                                <dynamic_bias_stddev>0.00002</dynamic_bias_stddev>
+                                <dynamic_bias_correlation_time>400.0</dynamic_bias_correlation_time>
+                                <precision>0.00025</precision>
+                            </noise>
+                        </z>
+                    </angular_velocity>
+                    <linear_acceleration>
+                        <x>
+                            <noise type="gaussian">
+                                <mean>0</mean>
+                                <stddev>0.021</stddev>
+                                <bias_mean>0.05</bias_mean>
+                                <bias_stddev>0.0075</bias_stddev>
+                                <dynamic_bias_stddev>0.000375</dynamic_bias_stddev>
+                                <dynamic_bias_correlation_time>175.0</dynamic_bias_correlation_time>
+                                <precision>0.005</precision>
+                            </noise>
+                        </x>
+                        <y>
+                            <noise type="gaussian">
+                                <mean>0</mean>
+                                <stddev>0.021</stddev>
+                                <bias_mean>0.05</bias_mean>
+                                <bias_stddev>0.0075</bias_stddev>
+                                <dynamic_bias_stddev>0.000375</dynamic_bias_stddev>
+                                <dynamic_bias_correlation_time>175.0</dynamic_bias_correlation_time>
+                                <precision>0.005</precision>
+                            </noise>
+                        </y>
+                        <z>
+                            <noise type="gaussian">
+                                <mean>0</mean>
+                                <stddev>0.021</stddev>
+                                <bias_mean>0.05</bias_mean>
+                                <bias_stddev>0.0075</bias_stddev>
+                                <dynamic_bias_stddev>0.000375</dynamic_bias_stddev>
+                                <dynamic_bias_correlation_time>175.0</dynamic_bias_correlation_time>
+                                <precision>0.005</precision>
+                            </noise>
+                        </z>
+                    </linear_acceleration>
+                </imu>
         <pose frame="">-0.327 -0.005 0.206 0.000 0.000 -1.571</pose>
       </sensor>
       <sensor name="front_laser" type="gpu_lidar">

--- a/submitted_models/cerberus_gagarin_sensor_config_1/model.sdf
+++ b/submitted_models/cerberus_gagarin_sensor_config_1/model.sdf
@@ -97,31 +97,34 @@
                         <x>
                             <noise type="gaussian">
                                 <mean>0</mean>
-                                <stddev>2e-4</stddev>
-                                <bias_mean>0.0000075</bias_mean>
-                                <bias_stddev>0.0000008</bias_stddev>
-                                <dynamic_bias_stddev>0.0000004</dynamic_bias_stddev>
-                                <dynamic_bias_correlation_time>1000.0</dynamic_bias_correlation_time>
+                                <stddev>0.009</stddev>
+                                <bias_mean>0.00075</bias_mean>
+                                <bias_stddev>0.005</bias_stddev>
+                                <dynamic_bias_stddev>0.00002</dynamic_bias_stddev>
+                                <dynamic_bias_correlation_time>400.0</dynamic_bias_correlation_time>
+                                <precision>0.00025</precision>
                             </noise>
                         </x>
                         <y>
                             <noise type="gaussian">
                                 <mean>0</mean>
-                                <stddev>2e-4</stddev>
-                                <bias_mean>0.0000075</bias_mean>
-                                <bias_stddev>0.0000008</bias_stddev>
-                                <dynamic_bias_stddev>0.0000004</dynamic_bias_stddev>
-                                <dynamic_bias_correlation_time>1000.0</dynamic_bias_correlation_time>
+                                <stddev>0.009</stddev>
+                                <bias_mean>0.00075</bias_mean>
+                                <bias_stddev>0.005</bias_stddev>
+                                <dynamic_bias_stddev>0.00002</dynamic_bias_stddev>
+                                <dynamic_bias_correlation_time>400.0</dynamic_bias_correlation_time>
+                                <precision>0.00025</precision>
                             </noise>
                         </y>
                         <z>
                             <noise type="gaussian">
                                 <mean>0</mean>
-                                <stddev>2e-4</stddev>
-                                <bias_mean>0.0000075</bias_mean>
-                                <bias_stddev>0.0000008</bias_stddev>
-                                <dynamic_bias_stddev>0.0000004</dynamic_bias_stddev>
-                                <dynamic_bias_correlation_time>1000.0</dynamic_bias_correlation_time>
+                                <stddev>0.009</stddev>
+                                <bias_mean>0.00075</bias_mean>
+                                <bias_stddev>0.005</bias_stddev>
+                                <dynamic_bias_stddev>0.00002</dynamic_bias_stddev>
+                                <dynamic_bias_correlation_time>400.0</dynamic_bias_correlation_time>
+                                <precision>0.00025</precision>
                             </noise>
                         </z>
                     </angular_velocity>
@@ -129,31 +132,34 @@
                         <x>
                             <noise type="gaussian">
                                 <mean>0</mean>
-                                <stddev>1e-2</stddev>
-                                <bias_mean>0.1</bias_mean>
-                                <bias_stddev>0.001</bias_stddev>
-                                <dynamic_bias_stddev>0.002</dynamic_bias_stddev>
-                                <dynamic_bias_correlation_time>300.0</dynamic_bias_correlation_time>
+                                <stddev>0.021</stddev>
+                                <bias_mean>0.05</bias_mean>
+                                <bias_stddev>0.0075</bias_stddev>
+                                <dynamic_bias_stddev>0.000375</dynamic_bias_stddev>
+                                <dynamic_bias_correlation_time>175.0</dynamic_bias_correlation_time>
+                                <precision>0.005</precision>
                             </noise>
                         </x>
                         <y>
                             <noise type="gaussian">
                                 <mean>0</mean>
-                                <stddev>1e-2</stddev>
-                                <bias_mean>0.1</bias_mean>
-                                <bias_stddev>0.001</bias_stddev>
-                                <dynamic_bias_stddev>0.002</dynamic_bias_stddev>
-                                <dynamic_bias_correlation_time>300.0</dynamic_bias_correlation_time>
+                                <stddev>0.021</stddev>
+                                <bias_mean>0.05</bias_mean>
+                                <bias_stddev>0.0075</bias_stddev>
+                                <dynamic_bias_stddev>0.000375</dynamic_bias_stddev>
+                                <dynamic_bias_correlation_time>175.0</dynamic_bias_correlation_time>
+                                <precision>0.005</precision>
                             </noise>
                         </y>
                         <z>
                             <noise type="gaussian">
                                 <mean>0</mean>
-                                <stddev>1e-2</stddev>
-                                <bias_mean>0.1</bias_mean>
-                                <bias_stddev>0.001</bias_stddev>
-                                <dynamic_bias_stddev>0.002</dynamic_bias_stddev>
-                                <dynamic_bias_correlation_time>300.0</dynamic_bias_correlation_time>
+                                <stddev>0.021</stddev>
+                                <bias_mean>0.05</bias_mean>
+                                <bias_stddev>0.0075</bias_stddev>
+                                <dynamic_bias_stddev>0.000375</dynamic_bias_stddev>
+                                <dynamic_bias_correlation_time>175.0</dynamic_bias_correlation_time>
+                                <precision>0.005</precision>
                             </noise>
                         </z>
                     </linear_acceleration>

--- a/submitted_models/cerberus_m100_sensor_config_1/model.sdf
+++ b/submitted_models/cerberus_m100_sensor_config_1/model.sdf
@@ -96,31 +96,34 @@
                         <x>
                             <noise type="gaussian">
                                 <mean>0</mean>
-                                <stddev>2e-4</stddev>
-                                <bias_mean>0.0000075</bias_mean>
-                                <bias_stddev>0.0000008</bias_stddev>
-                                <dynamic_bias_stddev>0.0000004</dynamic_bias_stddev>
-                                <dynamic_bias_correlation_time>1000.0</dynamic_bias_correlation_time>
+                                <stddev>0.009</stddev>
+                                <bias_mean>0.00075</bias_mean>
+                                <bias_stddev>0.005</bias_stddev>
+                                <dynamic_bias_stddev>0.00002</dynamic_bias_stddev>
+                                <dynamic_bias_correlation_time>400.0</dynamic_bias_correlation_time>
+                                <precision>0.00025</precision>
                             </noise>
                         </x>
                         <y>
                             <noise type="gaussian">
                                 <mean>0</mean>
-                                <stddev>2e-4</stddev>
-                                <bias_mean>0.0000075</bias_mean>
-                                <bias_stddev>0.0000008</bias_stddev>
-                                <dynamic_bias_stddev>0.0000004</dynamic_bias_stddev>
-                                <dynamic_bias_correlation_time>1000.0</dynamic_bias_correlation_time>
+                                <stddev>0.009</stddev>
+                                <bias_mean>0.00075</bias_mean>
+                                <bias_stddev>0.005</bias_stddev>
+                                <dynamic_bias_stddev>0.00002</dynamic_bias_stddev>
+                                <dynamic_bias_correlation_time>400.0</dynamic_bias_correlation_time>
+                                <precision>0.00025</precision>
                             </noise>
                         </y>
                         <z>
                             <noise type="gaussian">
                                 <mean>0</mean>
-                                <stddev>2e-4</stddev>
-                                <bias_mean>0.0000075</bias_mean>
-                                <bias_stddev>0.0000008</bias_stddev>
-                                <dynamic_bias_stddev>0.0000004</dynamic_bias_stddev>
-                                <dynamic_bias_correlation_time>1000.0</dynamic_bias_correlation_time>
+                                <stddev>0.009</stddev>
+                                <bias_mean>0.00075</bias_mean>
+                                <bias_stddev>0.005</bias_stddev>
+                                <dynamic_bias_stddev>0.00002</dynamic_bias_stddev>
+                                <dynamic_bias_correlation_time>400.0</dynamic_bias_correlation_time>
+                                <precision>0.00025</precision>
                             </noise>
                         </z>
                     </angular_velocity>
@@ -128,31 +131,34 @@
                         <x>
                             <noise type="gaussian">
                                 <mean>0</mean>
-                                <stddev>1e-2</stddev>
-                                <bias_mean>0.1</bias_mean>
-                                <bias_stddev>0.001</bias_stddev>
-                                <dynamic_bias_stddev>0.002</dynamic_bias_stddev>
-                                <dynamic_bias_correlation_time>300.0</dynamic_bias_correlation_time>
+                                <stddev>0.021</stddev>
+                                <bias_mean>0.05</bias_mean>
+                                <bias_stddev>0.0075</bias_stddev>
+                                <dynamic_bias_stddev>0.000375</dynamic_bias_stddev>
+                                <dynamic_bias_correlation_time>175.0</dynamic_bias_correlation_time>
+                                <precision>0.005</precision>
                             </noise>
                         </x>
                         <y>
                             <noise type="gaussian">
                                 <mean>0</mean>
-                                <stddev>1e-2</stddev>
-                                <bias_mean>0.1</bias_mean>
-                                <bias_stddev>0.001</bias_stddev>
-                                <dynamic_bias_stddev>0.002</dynamic_bias_stddev>
-                                <dynamic_bias_correlation_time>300.0</dynamic_bias_correlation_time>
+                                <stddev>0.021</stddev>
+                                <bias_mean>0.05</bias_mean>
+                                <bias_stddev>0.0075</bias_stddev>
+                                <dynamic_bias_stddev>0.000375</dynamic_bias_stddev>
+                                <dynamic_bias_correlation_time>175.0</dynamic_bias_correlation_time>
+                                <precision>0.005</precision>
                             </noise>
                         </y>
                         <z>
                             <noise type="gaussian">
                                 <mean>0</mean>
-                                <stddev>1e-2</stddev>
-                                <bias_mean>0.1</bias_mean>
-                                <bias_stddev>0.001</bias_stddev>
-                                <dynamic_bias_stddev>0.002</dynamic_bias_stddev>
-                                <dynamic_bias_correlation_time>300.0</dynamic_bias_correlation_time>
+                                <stddev>0.021</stddev>
+                                <bias_mean>0.05</bias_mean>
+                                <bias_stddev>0.0075</bias_stddev>
+                                <dynamic_bias_stddev>0.000375</dynamic_bias_stddev>
+                                <dynamic_bias_correlation_time>175.0</dynamic_bias_correlation_time>
+                                <precision>0.005</precision>
                             </noise>
                         </z>
                     </linear_acceleration>

--- a/submitted_models/cerberus_rmf_sensor_config_1/model.sdf
+++ b/submitted_models/cerberus_rmf_sensor_config_1/model.sdf
@@ -97,31 +97,34 @@
                         <x>
                             <noise type="gaussian">
                                 <mean>0</mean>
-                                <stddev>2e-4</stddev>
-                                <bias_mean>0.0000075</bias_mean>
-                                <bias_stddev>0.0000008</bias_stddev>
-                                <dynamic_bias_stddev>0.0000004</dynamic_bias_stddev>
-                                <dynamic_bias_correlation_time>1000.0</dynamic_bias_correlation_time>
+                                <stddev>0.009</stddev>
+                                <bias_mean>0.00075</bias_mean>
+                                <bias_stddev>0.005</bias_stddev>
+                                <dynamic_bias_stddev>0.00002</dynamic_bias_stddev>
+                                <dynamic_bias_correlation_time>400.0</dynamic_bias_correlation_time>
+                                <precision>0.00025</precision>
                             </noise>
                         </x>
                         <y>
                             <noise type="gaussian">
                                 <mean>0</mean>
-                                <stddev>2e-4</stddev>
-                                <bias_mean>0.0000075</bias_mean>
-                                <bias_stddev>0.0000008</bias_stddev>
-                                <dynamic_bias_stddev>0.0000004</dynamic_bias_stddev>
-                                <dynamic_bias_correlation_time>1000.0</dynamic_bias_correlation_time>
+                                <stddev>0.009</stddev>
+                                <bias_mean>0.00075</bias_mean>
+                                <bias_stddev>0.005</bias_stddev>
+                                <dynamic_bias_stddev>0.00002</dynamic_bias_stddev>
+                                <dynamic_bias_correlation_time>400.0</dynamic_bias_correlation_time>
+                                <precision>0.00025</precision>
                             </noise>
                         </y>
                         <z>
                             <noise type="gaussian">
                                 <mean>0</mean>
-                                <stddev>2e-4</stddev>
-                                <bias_mean>0.0000075</bias_mean>
-                                <bias_stddev>0.0000008</bias_stddev>
-                                <dynamic_bias_stddev>0.0000004</dynamic_bias_stddev>
-                                <dynamic_bias_correlation_time>1000.0</dynamic_bias_correlation_time>
+                                <stddev>0.009</stddev>
+                                <bias_mean>0.00075</bias_mean>
+                                <bias_stddev>0.005</bias_stddev>
+                                <dynamic_bias_stddev>0.00002</dynamic_bias_stddev>
+                                <dynamic_bias_correlation_time>400.0</dynamic_bias_correlation_time>
+                                <precision>0.00025</precision>
                             </noise>
                         </z>
                     </angular_velocity>
@@ -129,31 +132,34 @@
                         <x>
                             <noise type="gaussian">
                                 <mean>0</mean>
-                                <stddev>1e-2</stddev>
-                                <bias_mean>0.1</bias_mean>
-                                <bias_stddev>0.001</bias_stddev>
-                                <dynamic_bias_stddev>0.002</dynamic_bias_stddev>
-                                <dynamic_bias_correlation_time>300.0</dynamic_bias_correlation_time>
+                                <stddev>0.021</stddev>
+                                <bias_mean>0.05</bias_mean>
+                                <bias_stddev>0.0075</bias_stddev>
+                                <dynamic_bias_stddev>0.000375</dynamic_bias_stddev>
+                                <dynamic_bias_correlation_time>175.0</dynamic_bias_correlation_time>
+                                <precision>0.005</precision>
                             </noise>
                         </x>
                         <y>
                             <noise type="gaussian">
                                 <mean>0</mean>
-                                <stddev>1e-2</stddev>
-                                <bias_mean>0.1</bias_mean>
-                                <bias_stddev>0.001</bias_stddev>
-                                <dynamic_bias_stddev>0.002</dynamic_bias_stddev>
-                                <dynamic_bias_correlation_time>300.0</dynamic_bias_correlation_time>
+                                <stddev>0.021</stddev>
+                                <bias_mean>0.05</bias_mean>
+                                <bias_stddev>0.0075</bias_stddev>
+                                <dynamic_bias_stddev>0.000375</dynamic_bias_stddev>
+                                <dynamic_bias_correlation_time>175.0</dynamic_bias_correlation_time>
+                                <precision>0.005</precision>
                             </noise>
                         </y>
                         <z>
                             <noise type="gaussian">
                                 <mean>0</mean>
-                                <stddev>1e-2</stddev>
-                                <bias_mean>0.1</bias_mean>
-                                <bias_stddev>0.001</bias_stddev>
-                                <dynamic_bias_stddev>0.002</dynamic_bias_stddev>
-                                <dynamic_bias_correlation_time>300.0</dynamic_bias_correlation_time>
+                                <stddev>0.021</stddev>
+                                <bias_mean>0.05</bias_mean>
+                                <bias_stddev>0.0075</bias_stddev>
+                                <dynamic_bias_stddev>0.000375</dynamic_bias_stddev>
+                                <dynamic_bias_correlation_time>175.0</dynamic_bias_correlation_time>
+                                <precision>0.005</precision>
                             </noise>
                         </z>
                     </linear_acceleration>

--- a/submitted_models/costar_husky_sensor_config_1/model.sdf
+++ b/submitted_models/costar_husky_sensor_config_1/model.sdf
@@ -349,71 +349,77 @@
         <always_on>1</always_on>
         <update_rate>50</update_rate>
         <imu>
-          <angular_velocity>
-            <x>
-              <noise type="gaussian">
-                <mean>0</mean>
-                <stddev>2e-4</stddev>
-                <bias_mean>0.0000075</bias_mean>
-                <bias_stddev>0.0000008</bias_stddev>
-                <dynamic_bias_stddev>0.0000004</dynamic_bias_stddev>
-                <dynamic_bias_correlation_time>1000.0</dynamic_bias_correlation_time>
-              </noise>
-            </x>
-            <y>
-              <noise type="gaussian">
-                <mean>0</mean>
-                <stddev>2e-4</stddev>
-                <bias_mean>0.0000075</bias_mean>
-                <bias_stddev>0.0000008</bias_stddev>
-                <dynamic_bias_stddev>0.0000004</dynamic_bias_stddev>
-                <dynamic_bias_correlation_time>1000.0</dynamic_bias_correlation_time>
-              </noise>
-            </y>
-            <z>
-              <noise type="gaussian">
-                <mean>0</mean>
-                <stddev>2e-4</stddev>
-                <bias_mean>0.0000075</bias_mean>
-                <bias_stddev>0.0000008</bias_stddev>
-                <dynamic_bias_stddev>0.0000004</dynamic_bias_stddev>
-                <dynamic_bias_correlation_time>1000.0</dynamic_bias_correlation_time>
-              </noise>
-            </z>
-          </angular_velocity>
-          <linear_acceleration>
-            <x>
-              <noise type="gaussian">
-                <mean>0</mean>
-                <stddev>1e-2</stddev>
-                <bias_mean>0.1</bias_mean>
-                <bias_stddev>0.001</bias_stddev>
-                <dynamic_bias_stddev>0.002</dynamic_bias_stddev>
-                <dynamic_bias_correlation_time>300.0</dynamic_bias_correlation_time>
-              </noise>
-            </x>
-            <y>
-              <noise type="gaussian">
-                <mean>0</mean>
-                <stddev>1e-2</stddev>
-                <bias_mean>0.1</bias_mean>
-                <bias_stddev>0.001</bias_stddev>
-                <dynamic_bias_stddev>0.002</dynamic_bias_stddev>
-                <dynamic_bias_correlation_time>300.0</dynamic_bias_correlation_time>
-              </noise>
-            </y>
-            <z>
-              <noise type="gaussian">
-                <mean>0</mean>
-                <stddev>1e-2</stddev>
-                <bias_mean>0.1</bias_mean>
-                <bias_stddev>0.001</bias_stddev>
-                <dynamic_bias_stddev>0.002</dynamic_bias_stddev>
-                <dynamic_bias_correlation_time>300.0</dynamic_bias_correlation_time>
-              </noise>
-            </z>
-          </linear_acceleration>
-        </imu>
+                    <angular_velocity>
+                        <x>
+                            <noise type="gaussian">
+                                <mean>0</mean>
+                                <stddev>0.009</stddev>
+                                <bias_mean>0.00075</bias_mean>
+                                <bias_stddev>0.005</bias_stddev>
+                                <dynamic_bias_stddev>0.00002</dynamic_bias_stddev>
+                                <dynamic_bias_correlation_time>400.0</dynamic_bias_correlation_time>
+                                <precision>0.00025</precision>
+                            </noise>
+                        </x>
+                        <y>
+                            <noise type="gaussian">
+                                <mean>0</mean>
+                                <stddev>0.009</stddev>
+                                <bias_mean>0.00075</bias_mean>
+                                <bias_stddev>0.005</bias_stddev>
+                                <dynamic_bias_stddev>0.00002</dynamic_bias_stddev>
+                                <dynamic_bias_correlation_time>400.0</dynamic_bias_correlation_time>
+                                <precision>0.00025</precision>
+                            </noise>
+                        </y>
+                        <z>
+                            <noise type="gaussian">
+                                <mean>0</mean>
+                                <stddev>0.009</stddev>
+                                <bias_mean>0.00075</bias_mean>
+                                <bias_stddev>0.005</bias_stddev>
+                                <dynamic_bias_stddev>0.00002</dynamic_bias_stddev>
+                                <dynamic_bias_correlation_time>400.0</dynamic_bias_correlation_time>
+                                <precision>0.00025</precision>
+                            </noise>
+                        </z>
+                    </angular_velocity>
+                    <linear_acceleration>
+                        <x>
+                            <noise type="gaussian">
+                                <mean>0</mean>
+                                <stddev>0.021</stddev>
+                                <bias_mean>0.05</bias_mean>
+                                <bias_stddev>0.0075</bias_stddev>
+                                <dynamic_bias_stddev>0.000375</dynamic_bias_stddev>
+                                <dynamic_bias_correlation_time>175.0</dynamic_bias_correlation_time>
+                                <precision>0.005</precision>
+                            </noise>
+                        </x>
+                        <y>
+                            <noise type="gaussian">
+                                <mean>0</mean>
+                                <stddev>0.021</stddev>
+                                <bias_mean>0.05</bias_mean>
+                                <bias_stddev>0.0075</bias_stddev>
+                                <dynamic_bias_stddev>0.000375</dynamic_bias_stddev>
+                                <dynamic_bias_correlation_time>175.0</dynamic_bias_correlation_time>
+                                <precision>0.005</precision>
+                            </noise>
+                        </y>
+                        <z>
+                            <noise type="gaussian">
+                                <mean>0</mean>
+                                <stddev>0.021</stddev>
+                                <bias_mean>0.05</bias_mean>
+                                <bias_stddev>0.0075</bias_stddev>
+                                <dynamic_bias_stddev>0.000375</dynamic_bias_stddev>
+                                <dynamic_bias_correlation_time>175.0</dynamic_bias_correlation_time>
+                                <precision>0.005</precision>
+                            </noise>
+                        </z>
+                    </linear_acceleration>
+                </imu>
       </sensor>
     </link>
     <link name="front_left_wheel_link">

--- a/submitted_models/costar_husky_sensor_config_2/model.sdf
+++ b/submitted_models/costar_husky_sensor_config_2/model.sdf
@@ -349,71 +349,77 @@
         <always_on>1</always_on>
         <update_rate>50</update_rate>
         <imu>
-          <angular_velocity>
-            <x>
-              <noise type="gaussian">
-                <mean>0</mean>
-                <stddev>2e-4</stddev>
-                <bias_mean>0.0000075</bias_mean>
-                <bias_stddev>0.0000008</bias_stddev>
-                <dynamic_bias_stddev>0.0000004</dynamic_bias_stddev>
-                <dynamic_bias_correlation_time>1000.0</dynamic_bias_correlation_time>
-              </noise>
-            </x>
-            <y>
-              <noise type="gaussian">
-                <mean>0</mean>
-                <stddev>2e-4</stddev>
-                <bias_mean>0.0000075</bias_mean>
-                <bias_stddev>0.0000008</bias_stddev>
-                <dynamic_bias_stddev>0.0000004</dynamic_bias_stddev>
-                <dynamic_bias_correlation_time>1000.0</dynamic_bias_correlation_time>
-              </noise>
-            </y>
-            <z>
-              <noise type="gaussian">
-                <mean>0</mean>
-                <stddev>2e-4</stddev>
-                <bias_mean>0.0000075</bias_mean>
-                <bias_stddev>0.0000008</bias_stddev>
-                <dynamic_bias_stddev>0.0000004</dynamic_bias_stddev>
-                <dynamic_bias_correlation_time>1000.0</dynamic_bias_correlation_time>
-              </noise>
-            </z>
-          </angular_velocity>
-          <linear_acceleration>
-            <x>
-              <noise type="gaussian">
-                <mean>0</mean>
-                <stddev>1e-2</stddev>
-                <bias_mean>0.1</bias_mean>
-                <bias_stddev>0.001</bias_stddev>
-                <dynamic_bias_stddev>0.002</dynamic_bias_stddev>
-                <dynamic_bias_correlation_time>300.0</dynamic_bias_correlation_time>
-              </noise>
-            </x>
-            <y>
-              <noise type="gaussian">
-                <mean>0</mean>
-                <stddev>1e-2</stddev>
-                <bias_mean>0.1</bias_mean>
-                <bias_stddev>0.001</bias_stddev>
-                <dynamic_bias_stddev>0.002</dynamic_bias_stddev>
-                <dynamic_bias_correlation_time>300.0</dynamic_bias_correlation_time>
-              </noise>
-            </y>
-            <z>
-              <noise type="gaussian">
-                <mean>0</mean>
-                <stddev>1e-2</stddev>
-                <bias_mean>0.1</bias_mean>
-                <bias_stddev>0.001</bias_stddev>
-                <dynamic_bias_stddev>0.002</dynamic_bias_stddev>
-                <dynamic_bias_correlation_time>300.0</dynamic_bias_correlation_time>
-              </noise>
-            </z>
-          </linear_acceleration>
-        </imu>
+                    <angular_velocity>
+                        <x>
+                            <noise type="gaussian">
+                                <mean>0</mean>
+                                <stddev>0.009</stddev>
+                                <bias_mean>0.00075</bias_mean>
+                                <bias_stddev>0.005</bias_stddev>
+                                <dynamic_bias_stddev>0.00002</dynamic_bias_stddev>
+                                <dynamic_bias_correlation_time>400.0</dynamic_bias_correlation_time>
+                                <precision>0.00025</precision>
+                            </noise>
+                        </x>
+                        <y>
+                            <noise type="gaussian">
+                                <mean>0</mean>
+                                <stddev>0.009</stddev>
+                                <bias_mean>0.00075</bias_mean>
+                                <bias_stddev>0.005</bias_stddev>
+                                <dynamic_bias_stddev>0.00002</dynamic_bias_stddev>
+                                <dynamic_bias_correlation_time>400.0</dynamic_bias_correlation_time>
+                                <precision>0.00025</precision>
+                            </noise>
+                        </y>
+                        <z>
+                            <noise type="gaussian">
+                                <mean>0</mean>
+                                <stddev>0.009</stddev>
+                                <bias_mean>0.00075</bias_mean>
+                                <bias_stddev>0.005</bias_stddev>
+                                <dynamic_bias_stddev>0.00002</dynamic_bias_stddev>
+                                <dynamic_bias_correlation_time>400.0</dynamic_bias_correlation_time>
+                                <precision>0.00025</precision>
+                            </noise>
+                        </z>
+                    </angular_velocity>
+                    <linear_acceleration>
+                        <x>
+                            <noise type="gaussian">
+                                <mean>0</mean>
+                                <stddev>0.021</stddev>
+                                <bias_mean>0.05</bias_mean>
+                                <bias_stddev>0.0075</bias_stddev>
+                                <dynamic_bias_stddev>0.000375</dynamic_bias_stddev>
+                                <dynamic_bias_correlation_time>175.0</dynamic_bias_correlation_time>
+                                <precision>0.005</precision>
+                            </noise>
+                        </x>
+                        <y>
+                            <noise type="gaussian">
+                                <mean>0</mean>
+                                <stddev>0.021</stddev>
+                                <bias_mean>0.05</bias_mean>
+                                <bias_stddev>0.0075</bias_stddev>
+                                <dynamic_bias_stddev>0.000375</dynamic_bias_stddev>
+                                <dynamic_bias_correlation_time>175.0</dynamic_bias_correlation_time>
+                                <precision>0.005</precision>
+                            </noise>
+                        </y>
+                        <z>
+                            <noise type="gaussian">
+                                <mean>0</mean>
+                                <stddev>0.021</stddev>
+                                <bias_mean>0.05</bias_mean>
+                                <bias_stddev>0.0075</bias_stddev>
+                                <dynamic_bias_stddev>0.000375</dynamic_bias_stddev>
+                                <dynamic_bias_correlation_time>175.0</dynamic_bias_correlation_time>
+                                <precision>0.005</precision>
+                            </noise>
+                        </z>
+                    </linear_acceleration>
+                </imu>
       </sensor>
     </link>
     <link name="front_left_wheel_link">

--- a/submitted_models/costar_shafter_sensor_config_1/model.sdf
+++ b/submitted_models/costar_shafter_sensor_config_1/model.sdf
@@ -67,31 +67,34 @@
                         <x>
                             <noise type="gaussian">
                                 <mean>0</mean>
-                                <stddev>2e-4</stddev>
-                                <bias_mean>0.0000075</bias_mean>
-                                <bias_stddev>0.0000008</bias_stddev>
-                                <dynamic_bias_stddev>0.0000004</dynamic_bias_stddev>
-                                <dynamic_bias_correlation_time>1000.0</dynamic_bias_correlation_time>
+                                <stddev>0.009</stddev>
+                                <bias_mean>0.00075</bias_mean>
+                                <bias_stddev>0.005</bias_stddev>
+                                <dynamic_bias_stddev>0.00002</dynamic_bias_stddev>
+                                <dynamic_bias_correlation_time>400.0</dynamic_bias_correlation_time>
+                                <precision>0.00025</precision>
                             </noise>
                         </x>
                         <y>
                             <noise type="gaussian">
                                 <mean>0</mean>
-                                <stddev>2e-4</stddev>
-                                <bias_mean>0.0000075</bias_mean>
-                                <bias_stddev>0.0000008</bias_stddev>
-                                <dynamic_bias_stddev>0.0000004</dynamic_bias_stddev>
-                                <dynamic_bias_correlation_time>1000.0</dynamic_bias_correlation_time>
+                                <stddev>0.009</stddev>
+                                <bias_mean>0.00075</bias_mean>
+                                <bias_stddev>0.005</bias_stddev>
+                                <dynamic_bias_stddev>0.00002</dynamic_bias_stddev>
+                                <dynamic_bias_correlation_time>400.0</dynamic_bias_correlation_time>
+                                <precision>0.00025</precision>
                             </noise>
                         </y>
                         <z>
                             <noise type="gaussian">
                                 <mean>0</mean>
-                                <stddev>2e-4</stddev>
-                                <bias_mean>0.0000075</bias_mean>
-                                <bias_stddev>0.0000008</bias_stddev>
-                                <dynamic_bias_stddev>0.0000004</dynamic_bias_stddev>
-                                <dynamic_bias_correlation_time>1000.0</dynamic_bias_correlation_time>
+                                <stddev>0.009</stddev>
+                                <bias_mean>0.00075</bias_mean>
+                                <bias_stddev>0.005</bias_stddev>
+                                <dynamic_bias_stddev>0.00002</dynamic_bias_stddev>
+                                <dynamic_bias_correlation_time>400.0</dynamic_bias_correlation_time>
+                                <precision>0.00025</precision>
                             </noise>
                         </z>
                     </angular_velocity>
@@ -99,31 +102,34 @@
                         <x>
                             <noise type="gaussian">
                                 <mean>0</mean>
-                                <stddev>1e-2</stddev>
-                                <bias_mean>0.1</bias_mean>
-                                <bias_stddev>0.001</bias_stddev>
-                                <dynamic_bias_stddev>0.002</dynamic_bias_stddev>
-                                <dynamic_bias_correlation_time>300.0</dynamic_bias_correlation_time>
+                                <stddev>0.021</stddev>
+                                <bias_mean>0.05</bias_mean>
+                                <bias_stddev>0.0075</bias_stddev>
+                                <dynamic_bias_stddev>0.000375</dynamic_bias_stddev>
+                                <dynamic_bias_correlation_time>175.0</dynamic_bias_correlation_time>
+                                <precision>0.005</precision>
                             </noise>
                         </x>
                         <y>
                             <noise type="gaussian">
                                 <mean>0</mean>
-                                <stddev>1e-2</stddev>
-                                <bias_mean>0.1</bias_mean>
-                                <bias_stddev>0.001</bias_stddev>
-                                <dynamic_bias_stddev>0.002</dynamic_bias_stddev>
-                                <dynamic_bias_correlation_time>300.0</dynamic_bias_correlation_time>
+                                <stddev>0.021</stddev>
+                                <bias_mean>0.05</bias_mean>
+                                <bias_stddev>0.0075</bias_stddev>
+                                <dynamic_bias_stddev>0.000375</dynamic_bias_stddev>
+                                <dynamic_bias_correlation_time>175.0</dynamic_bias_correlation_time>
+                                <precision>0.005</precision>
                             </noise>
                         </y>
                         <z>
                             <noise type="gaussian">
                                 <mean>0</mean>
-                                <stddev>1e-2</stddev>
-                                <bias_mean>0.1</bias_mean>
-                                <bias_stddev>0.001</bias_stddev>
-                                <dynamic_bias_stddev>0.002</dynamic_bias_stddev>
-                                <dynamic_bias_correlation_time>300.0</dynamic_bias_correlation_time>
+                                <stddev>0.021</stddev>
+                                <bias_mean>0.05</bias_mean>
+                                <bias_stddev>0.0075</bias_stddev>
+                                <dynamic_bias_stddev>0.000375</dynamic_bias_stddev>
+                                <dynamic_bias_correlation_time>175.0</dynamic_bias_correlation_time>
+                                <precision>0.005</precision>
                             </noise>
                         </z>
                     </linear_acceleration>

--- a/submitted_models/csiro_data61_dtr_sensor_config_1/model.sdf
+++ b/submitted_models/csiro_data61_dtr_sensor_config_1/model.sdf
@@ -678,71 +678,77 @@
         <always_on>1</always_on>
         <update_rate>100</update_rate>
         <imu>
-          <angular_velocity>
-            <x>
-              <noise type="gaussian">
-                <mean>0</mean>
-                <stddev>2e-4</stddev>
-                <bias_mean>0.0000075</bias_mean>
-                <bias_stddev>0.0000008</bias_stddev>
-                <dynamic_bias_stddev>0.0000004</dynamic_bias_stddev>
-                <dynamic_bias_correlation_time>1000.0</dynamic_bias_correlation_time>
-              </noise>
-            </x>
-            <y>
-              <noise type="gaussian">
-                <mean>0</mean>
-                <stddev>2e-4</stddev>
-                <bias_mean>0.0000075</bias_mean>
-                <bias_stddev>0.0000008</bias_stddev>
-                <dynamic_bias_stddev>0.0000004</dynamic_bias_stddev>
-                <dynamic_bias_correlation_time>1000.0</dynamic_bias_correlation_time>
-              </noise>
-            </y>
-            <z>
-              <noise type="gaussian">
-                <mean>0</mean>
-                <stddev>2e-4</stddev>
-                <bias_mean>0.0000075</bias_mean>
-                <bias_stddev>0.0000008</bias_stddev>
-                <dynamic_bias_stddev>0.0000004</dynamic_bias_stddev>
-                <dynamic_bias_correlation_time>1000.0</dynamic_bias_correlation_time>
-              </noise>
-            </z>
-          </angular_velocity>
-          <linear_acceleration>
-            <x>
-              <noise type="gaussian">
-                <mean>0</mean>
-                <stddev>1e-2</stddev>
-                <bias_mean>0.1</bias_mean>
-                <bias_stddev>0.001</bias_stddev>
-                <dynamic_bias_stddev>0.002</dynamic_bias_stddev>
-                <dynamic_bias_correlation_time>300.0</dynamic_bias_correlation_time>
-              </noise>
-            </x>
-            <y>
-              <noise type="gaussian">
-                <mean>0</mean>
-                <stddev>1e-2</stddev>
-                <bias_mean>0.1</bias_mean>
-                <bias_stddev>0.001</bias_stddev>
-                <dynamic_bias_stddev>0.002</dynamic_bias_stddev>
-                <dynamic_bias_correlation_time>300.0</dynamic_bias_correlation_time>
-              </noise>
-            </y>
-            <z>
-              <noise type="gaussian">
-                <mean>0</mean>
-                <stddev>1e-2</stddev>
-                <bias_mean>0.1</bias_mean>
-                <bias_stddev>0.001</bias_stddev>
-                <dynamic_bias_stddev>0.002</dynamic_bias_stddev>
-                <dynamic_bias_correlation_time>300.0</dynamic_bias_correlation_time>
-              </noise>
-            </z>
-          </linear_acceleration>
-        </imu>
+                    <angular_velocity>
+                        <x>
+                            <noise type="gaussian">
+                                <mean>0</mean>
+                                <stddev>0.009</stddev>
+                                <bias_mean>0.00075</bias_mean>
+                                <bias_stddev>0.005</bias_stddev>
+                                <dynamic_bias_stddev>0.00002</dynamic_bias_stddev>
+                                <dynamic_bias_correlation_time>400.0</dynamic_bias_correlation_time>
+                                <precision>0.00025</precision>
+                            </noise>
+                        </x>
+                        <y>
+                            <noise type="gaussian">
+                                <mean>0</mean>
+                                <stddev>0.009</stddev>
+                                <bias_mean>0.00075</bias_mean>
+                                <bias_stddev>0.005</bias_stddev>
+                                <dynamic_bias_stddev>0.00002</dynamic_bias_stddev>
+                                <dynamic_bias_correlation_time>400.0</dynamic_bias_correlation_time>
+                                <precision>0.00025</precision>
+                            </noise>
+                        </y>
+                        <z>
+                            <noise type="gaussian">
+                                <mean>0</mean>
+                                <stddev>0.009</stddev>
+                                <bias_mean>0.00075</bias_mean>
+                                <bias_stddev>0.005</bias_stddev>
+                                <dynamic_bias_stddev>0.00002</dynamic_bias_stddev>
+                                <dynamic_bias_correlation_time>400.0</dynamic_bias_correlation_time>
+                                <precision>0.00025</precision>
+                            </noise>
+                        </z>
+                    </angular_velocity>
+                    <linear_acceleration>
+                        <x>
+                            <noise type="gaussian">
+                                <mean>0</mean>
+                                <stddev>0.021</stddev>
+                                <bias_mean>0.05</bias_mean>
+                                <bias_stddev>0.0075</bias_stddev>
+                                <dynamic_bias_stddev>0.000375</dynamic_bias_stddev>
+                                <dynamic_bias_correlation_time>175.0</dynamic_bias_correlation_time>
+                                <precision>0.005</precision>
+                            </noise>
+                        </x>
+                        <y>
+                            <noise type="gaussian">
+                                <mean>0</mean>
+                                <stddev>0.021</stddev>
+                                <bias_mean>0.05</bias_mean>
+                                <bias_stddev>0.0075</bias_stddev>
+                                <dynamic_bias_stddev>0.000375</dynamic_bias_stddev>
+                                <dynamic_bias_correlation_time>175.0</dynamic_bias_correlation_time>
+                                <precision>0.005</precision>
+                            </noise>
+                        </y>
+                        <z>
+                            <noise type="gaussian">
+                                <mean>0</mean>
+                                <stddev>0.021</stddev>
+                                <bias_mean>0.05</bias_mean>
+                                <bias_stddev>0.0075</bias_stddev>
+                                <dynamic_bias_stddev>0.000375</dynamic_bias_stddev>
+                                <dynamic_bias_correlation_time>175.0</dynamic_bias_correlation_time>
+                                <precision>0.005</precision>
+                            </noise>
+                        </z>
+                    </linear_acceleration>
+                </imu>
       </sensor>
     </link>
     <joint name="nav_base_link_to_imu" type="revolute">

--- a/submitted_models/csiro_data61_ozbot_atr_sensor_config_1/model.sdf
+++ b/submitted_models/csiro_data61_ozbot_atr_sensor_config_1/model.sdf
@@ -654,71 +654,77 @@
         <always_on>1</always_on>
         <update_rate>100</update_rate>
         <imu>
-          <angular_velocity>
-            <x>
-              <noise type="gaussian">
-                <mean>0</mean>
-                <stddev>2e-4</stddev>
-                <bias_mean>0.0000075</bias_mean>
-                <bias_stddev>0.0000008</bias_stddev>
-                <dynamic_bias_stddev>0.0000004</dynamic_bias_stddev>
-                <dynamic_bias_correlation_time>1000.0</dynamic_bias_correlation_time>
-              </noise>
-            </x>
-            <y>
-              <noise type="gaussian">
-                <mean>0</mean>
-                <stddev>2e-4</stddev>
-                <bias_mean>0.0000075</bias_mean>
-                <bias_stddev>0.0000008</bias_stddev>
-                <dynamic_bias_stddev>0.0000004</dynamic_bias_stddev>
-                <dynamic_bias_correlation_time>1000.0</dynamic_bias_correlation_time>
-              </noise>
-            </y>
-            <z>
-              <noise type="gaussian">
-                <mean>0</mean>
-                <stddev>2e-4</stddev>
-                <bias_mean>0.0000075</bias_mean>
-                <bias_stddev>0.0000008</bias_stddev>
-                <dynamic_bias_stddev>0.0000004</dynamic_bias_stddev>
-                <dynamic_bias_correlation_time>1000.0</dynamic_bias_correlation_time>
-              </noise>
-            </z>
-          </angular_velocity>
-          <linear_acceleration>
-            <x>
-              <noise type="gaussian">
-                <mean>0</mean>
-                <stddev>1e-2</stddev>
-                <bias_mean>0.1</bias_mean>
-                <bias_stddev>0.001</bias_stddev>
-                <dynamic_bias_stddev>0.002</dynamic_bias_stddev>
-                <dynamic_bias_correlation_time>300.0</dynamic_bias_correlation_time>
-              </noise>
-            </x>
-            <y>
-              <noise type="gaussian">
-                <mean>0</mean>
-                <stddev>1e-2</stddev>
-                <bias_mean>0.1</bias_mean>
-                <bias_stddev>0.001</bias_stddev>
-                <dynamic_bias_stddev>0.002</dynamic_bias_stddev>
-                <dynamic_bias_correlation_time>300.0</dynamic_bias_correlation_time>
-              </noise>
-            </y>
-            <z>
-              <noise type="gaussian">
-                <mean>0</mean>
-                <stddev>1e-2</stddev>
-                <bias_mean>0.1</bias_mean>
-                <bias_stddev>0.001</bias_stddev>
-                <dynamic_bias_stddev>0.002</dynamic_bias_stddev>
-                <dynamic_bias_correlation_time>300.0</dynamic_bias_correlation_time>
-              </noise>
-            </z>
-          </linear_acceleration>
-        </imu>
+                    <angular_velocity>
+                        <x>
+                            <noise type="gaussian">
+                                <mean>0</mean>
+                                <stddev>0.009</stddev>
+                                <bias_mean>0.00075</bias_mean>
+                                <bias_stddev>0.005</bias_stddev>
+                                <dynamic_bias_stddev>0.00002</dynamic_bias_stddev>
+                                <dynamic_bias_correlation_time>400.0</dynamic_bias_correlation_time>
+                                <precision>0.00025</precision>
+                            </noise>
+                        </x>
+                        <y>
+                            <noise type="gaussian">
+                                <mean>0</mean>
+                                <stddev>0.009</stddev>
+                                <bias_mean>0.00075</bias_mean>
+                                <bias_stddev>0.005</bias_stddev>
+                                <dynamic_bias_stddev>0.00002</dynamic_bias_stddev>
+                                <dynamic_bias_correlation_time>400.0</dynamic_bias_correlation_time>
+                                <precision>0.00025</precision>
+                            </noise>
+                        </y>
+                        <z>
+                            <noise type="gaussian">
+                                <mean>0</mean>
+                                <stddev>0.009</stddev>
+                                <bias_mean>0.00075</bias_mean>
+                                <bias_stddev>0.005</bias_stddev>
+                                <dynamic_bias_stddev>0.00002</dynamic_bias_stddev>
+                                <dynamic_bias_correlation_time>400.0</dynamic_bias_correlation_time>
+                                <precision>0.00025</precision>
+                            </noise>
+                        </z>
+                    </angular_velocity>
+                    <linear_acceleration>
+                        <x>
+                            <noise type="gaussian">
+                                <mean>0</mean>
+                                <stddev>0.021</stddev>
+                                <bias_mean>0.05</bias_mean>
+                                <bias_stddev>0.0075</bias_stddev>
+                                <dynamic_bias_stddev>0.000375</dynamic_bias_stddev>
+                                <dynamic_bias_correlation_time>175.0</dynamic_bias_correlation_time>
+                                <precision>0.005</precision>
+                            </noise>
+                        </x>
+                        <y>
+                            <noise type="gaussian">
+                                <mean>0</mean>
+                                <stddev>0.021</stddev>
+                                <bias_mean>0.05</bias_mean>
+                                <bias_stddev>0.0075</bias_stddev>
+                                <dynamic_bias_stddev>0.000375</dynamic_bias_stddev>
+                                <dynamic_bias_correlation_time>175.0</dynamic_bias_correlation_time>
+                                <precision>0.005</precision>
+                            </noise>
+                        </y>
+                        <z>
+                            <noise type="gaussian">
+                                <mean>0</mean>
+                                <stddev>0.021</stddev>
+                                <bias_mean>0.05</bias_mean>
+                                <bias_stddev>0.0075</bias_stddev>
+                                <dynamic_bias_stddev>0.000375</dynamic_bias_stddev>
+                                <dynamic_bias_correlation_time>175.0</dynamic_bias_correlation_time>
+                                <precision>0.005</precision>
+                            </noise>
+                        </z>
+                    </linear_acceleration>
+                </imu>
       </sensor>
     </link>
     <joint name="nav_base_link_to_imu" type="revolute">

--- a/submitted_models/ctu_cras_norlab_absolem_sensor_config_1/model.sdf
+++ b/submitted_models/ctu_cras_norlab_absolem_sensor_config_1/model.sdf
@@ -639,71 +639,77 @@
         <always_on>1</always_on>
         <update_rate>50</update_rate>
         <imu>
-          <angular_velocity>
-            <x>
-              <noise type="gaussian">
-                <mean>0</mean>
-                <stddev>0.0002</stddev>
-                <bias_mean>7.5e-06</bias_mean>
-                <bias_stddev>8e-07</bias_stddev>
-                <dynamic_bias_stddev>4e-07</dynamic_bias_stddev>
-                <dynamic_bias_correlation_time>1000</dynamic_bias_correlation_time>
-              </noise>
-            </x>
-            <y>
-              <noise type="gaussian">
-                <mean>0</mean>
-                <stddev>0.0002</stddev>
-                <bias_mean>7.5e-06</bias_mean>
-                <bias_stddev>8e-07</bias_stddev>
-                <dynamic_bias_stddev>4e-07</dynamic_bias_stddev>
-                <dynamic_bias_correlation_time>1000</dynamic_bias_correlation_time>
-              </noise>
-            </y>
-            <z>
-              <noise type="gaussian">
-                <mean>0</mean>
-                <stddev>0.0002</stddev>
-                <bias_mean>7.5e-06</bias_mean>
-                <bias_stddev>8e-07</bias_stddev>
-                <dynamic_bias_stddev>4e-07</dynamic_bias_stddev>
-                <dynamic_bias_correlation_time>1000</dynamic_bias_correlation_time>
-              </noise>
-            </z>
-          </angular_velocity>
-          <linear_acceleration>
-            <x>
-              <noise type="gaussian">
-                <mean>0</mean>
-                <stddev>0.01</stddev>
-                <bias_mean>0.1</bias_mean>
-                <bias_stddev>0.001</bias_stddev>
-                <dynamic_bias_stddev>0.002</dynamic_bias_stddev>
-                <dynamic_bias_correlation_time>300</dynamic_bias_correlation_time>
-              </noise>
-            </x>
-            <y>
-              <noise type="gaussian">
-                <mean>0</mean>
-                <stddev>0.01</stddev>
-                <bias_mean>0.1</bias_mean>
-                <bias_stddev>0.001</bias_stddev>
-                <dynamic_bias_stddev>0.002</dynamic_bias_stddev>
-                <dynamic_bias_correlation_time>300</dynamic_bias_correlation_time>
-              </noise>
-            </y>
-            <z>
-              <noise type="gaussian">
-                <mean>0</mean>
-                <stddev>0.01</stddev>
-                <bias_mean>0.1</bias_mean>
-                <bias_stddev>0.001</bias_stddev>
-                <dynamic_bias_stddev>0.002</dynamic_bias_stddev>
-                <dynamic_bias_correlation_time>300</dynamic_bias_correlation_time>
-              </noise>
-            </z>
-          </linear_acceleration>
-        </imu>
+                    <angular_velocity>
+                        <x>
+                            <noise type="gaussian">
+                                <mean>0</mean>
+                                <stddev>0.009</stddev>
+                                <bias_mean>0.00075</bias_mean>
+                                <bias_stddev>0.005</bias_stddev>
+                                <dynamic_bias_stddev>0.00002</dynamic_bias_stddev>
+                                <dynamic_bias_correlation_time>400.0</dynamic_bias_correlation_time>
+                                <precision>0.00025</precision>
+                            </noise>
+                        </x>
+                        <y>
+                            <noise type="gaussian">
+                                <mean>0</mean>
+                                <stddev>0.009</stddev>
+                                <bias_mean>0.00075</bias_mean>
+                                <bias_stddev>0.005</bias_stddev>
+                                <dynamic_bias_stddev>0.00002</dynamic_bias_stddev>
+                                <dynamic_bias_correlation_time>400.0</dynamic_bias_correlation_time>
+                                <precision>0.00025</precision>
+                            </noise>
+                        </y>
+                        <z>
+                            <noise type="gaussian">
+                                <mean>0</mean>
+                                <stddev>0.009</stddev>
+                                <bias_mean>0.00075</bias_mean>
+                                <bias_stddev>0.005</bias_stddev>
+                                <dynamic_bias_stddev>0.00002</dynamic_bias_stddev>
+                                <dynamic_bias_correlation_time>400.0</dynamic_bias_correlation_time>
+                                <precision>0.00025</precision>
+                            </noise>
+                        </z>
+                    </angular_velocity>
+                    <linear_acceleration>
+                        <x>
+                            <noise type="gaussian">
+                                <mean>0</mean>
+                                <stddev>0.021</stddev>
+                                <bias_mean>0.05</bias_mean>
+                                <bias_stddev>0.0075</bias_stddev>
+                                <dynamic_bias_stddev>0.000375</dynamic_bias_stddev>
+                                <dynamic_bias_correlation_time>175.0</dynamic_bias_correlation_time>
+                                <precision>0.005</precision>
+                            </noise>
+                        </x>
+                        <y>
+                            <noise type="gaussian">
+                                <mean>0</mean>
+                                <stddev>0.021</stddev>
+                                <bias_mean>0.05</bias_mean>
+                                <bias_stddev>0.0075</bias_stddev>
+                                <dynamic_bias_stddev>0.000375</dynamic_bias_stddev>
+                                <dynamic_bias_correlation_time>175.0</dynamic_bias_correlation_time>
+                                <precision>0.005</precision>
+                            </noise>
+                        </y>
+                        <z>
+                            <noise type="gaussian">
+                                <mean>0</mean>
+                                <stddev>0.021</stddev>
+                                <bias_mean>0.05</bias_mean>
+                                <bias_stddev>0.0075</bias_stddev>
+                                <dynamic_bias_stddev>0.000375</dynamic_bias_stddev>
+                                <dynamic_bias_correlation_time>175.0</dynamic_bias_correlation_time>
+                                <precision>0.005</precision>
+                            </noise>
+                        </z>
+                    </linear_acceleration>
+                </imu>
         <pose>0 0 0.15 -3.1415926535897931 -0 0</pose>
       </sensor>
       <sensor name="omnicam_sensor0" type="camera">

--- a/submitted_models/explorer_ds1_sensor_config_1/model.sdf
+++ b/submitted_models/explorer_ds1_sensor_config_1/model.sdf
@@ -301,31 +301,34 @@
                         <x>
                             <noise type="gaussian">
                                 <mean>0</mean>
-                                <stddev>2e-4</stddev>
-                                <bias_mean>0.0000075</bias_mean>
-                                <bias_stddev>0.0000008</bias_stddev>
-                                <dynamic_bias_stddev>0.0000004</dynamic_bias_stddev>
-                                <dynamic_bias_correlation_time>1000.0</dynamic_bias_correlation_time>
+                                <stddev>0.009</stddev>
+                                <bias_mean>0.00075</bias_mean>
+                                <bias_stddev>0.005</bias_stddev>
+                                <dynamic_bias_stddev>0.00002</dynamic_bias_stddev>
+                                <dynamic_bias_correlation_time>400.0</dynamic_bias_correlation_time>
+                                <precision>0.00025</precision>
                             </noise>
                         </x>
                         <y>
                             <noise type="gaussian">
                                 <mean>0</mean>
-                                <stddev>2e-4</stddev>
-                                <bias_mean>0.0000075</bias_mean>
-                                <bias_stddev>0.0000008</bias_stddev>
-                                <dynamic_bias_stddev>0.0000004</dynamic_bias_stddev>
-                                <dynamic_bias_correlation_time>1000.0</dynamic_bias_correlation_time>
+                                <stddev>0.009</stddev>
+                                <bias_mean>0.00075</bias_mean>
+                                <bias_stddev>0.005</bias_stddev>
+                                <dynamic_bias_stddev>0.00002</dynamic_bias_stddev>
+                                <dynamic_bias_correlation_time>400.0</dynamic_bias_correlation_time>
+                                <precision>0.00025</precision>
                             </noise>
                         </y>
                         <z>
                             <noise type="gaussian">
                                 <mean>0</mean>
-                                <stddev>2e-4</stddev>
-                                <bias_mean>0.0000075</bias_mean>
-                                <bias_stddev>0.0000008</bias_stddev>
-                                <dynamic_bias_stddev>0.0000004</dynamic_bias_stddev>
-                                <dynamic_bias_correlation_time>1000.0</dynamic_bias_correlation_time>
+                                <stddev>0.009</stddev>
+                                <bias_mean>0.00075</bias_mean>
+                                <bias_stddev>0.005</bias_stddev>
+                                <dynamic_bias_stddev>0.00002</dynamic_bias_stddev>
+                                <dynamic_bias_correlation_time>400.0</dynamic_bias_correlation_time>
+                                <precision>0.00025</precision>
                             </noise>
                         </z>
                     </angular_velocity>
@@ -333,31 +336,34 @@
                         <x>
                             <noise type="gaussian">
                                 <mean>0</mean>
-                                <stddev>1e-2</stddev>
-                                <bias_mean>0.1</bias_mean>
-                                <bias_stddev>0.001</bias_stddev>
-                                <dynamic_bias_stddev>0.002</dynamic_bias_stddev>
-                                <dynamic_bias_correlation_time>300.0</dynamic_bias_correlation_time>
+                                <stddev>0.021</stddev>
+                                <bias_mean>0.05</bias_mean>
+                                <bias_stddev>0.0075</bias_stddev>
+                                <dynamic_bias_stddev>0.000375</dynamic_bias_stddev>
+                                <dynamic_bias_correlation_time>175.0</dynamic_bias_correlation_time>
+                                <precision>0.005</precision>
                             </noise>
                         </x>
                         <y>
                             <noise type="gaussian">
                                 <mean>0</mean>
-                                <stddev>1e-2</stddev>
-                                <bias_mean>0.1</bias_mean>
-                                <bias_stddev>0.001</bias_stddev>
-                                <dynamic_bias_stddev>0.002</dynamic_bias_stddev>
-                                <dynamic_bias_correlation_time>300.0</dynamic_bias_correlation_time>
+                                <stddev>0.021</stddev>
+                                <bias_mean>0.05</bias_mean>
+                                <bias_stddev>0.0075</bias_stddev>
+                                <dynamic_bias_stddev>0.000375</dynamic_bias_stddev>
+                                <dynamic_bias_correlation_time>175.0</dynamic_bias_correlation_time>
+                                <precision>0.005</precision>
                             </noise>
                         </y>
                         <z>
                             <noise type="gaussian">
                                 <mean>0</mean>
-                                <stddev>1e-2</stddev>
-                                <bias_mean>0.1</bias_mean>
-                                <bias_stddev>0.001</bias_stddev>
-                                <dynamic_bias_stddev>0.002</dynamic_bias_stddev>
-                                <dynamic_bias_correlation_time>300.0</dynamic_bias_correlation_time>
+                                <stddev>0.021</stddev>
+                                <bias_mean>0.05</bias_mean>
+                                <bias_stddev>0.0075</bias_stddev>
+                                <dynamic_bias_stddev>0.000375</dynamic_bias_stddev>
+                                <dynamic_bias_correlation_time>175.0</dynamic_bias_correlation_time>
+                                <precision>0.005</precision>
                             </noise>
                         </z>
                     </linear_acceleration>

--- a/submitted_models/explorer_r2_sensor_config_1/model.sdf
+++ b/submitted_models/explorer_r2_sensor_config_1/model.sdf
@@ -77,31 +77,34 @@
                         <x>
                             <noise type="gaussian">
                                 <mean>0</mean>
-                                <stddev>2e-4</stddev>
-                                <bias_mean>0.0000075</bias_mean>
-                                <bias_stddev>0.0000008</bias_stddev>
-                                <dynamic_bias_stddev>0.0000004</dynamic_bias_stddev>
-                                <dynamic_bias_correlation_time>1000.0</dynamic_bias_correlation_time>
+                                <stddev>0.009</stddev>
+                                <bias_mean>0.00075</bias_mean>
+                                <bias_stddev>0.005</bias_stddev>
+                                <dynamic_bias_stddev>0.00002</dynamic_bias_stddev>
+                                <dynamic_bias_correlation_time>400.0</dynamic_bias_correlation_time>
+                                <precision>0.00025</precision>
                             </noise>
                         </x>
                         <y>
                             <noise type="gaussian">
                                 <mean>0</mean>
-                                <stddev>2e-4</stddev>
-                                <bias_mean>0.0000075</bias_mean>
-                                <bias_stddev>0.0000008</bias_stddev>
-                                <dynamic_bias_stddev>0.0000004</dynamic_bias_stddev>
-                                <dynamic_bias_correlation_time>1000.0</dynamic_bias_correlation_time>
+                                <stddev>0.009</stddev>
+                                <bias_mean>0.00075</bias_mean>
+                                <bias_stddev>0.005</bias_stddev>
+                                <dynamic_bias_stddev>0.00002</dynamic_bias_stddev>
+                                <dynamic_bias_correlation_time>400.0</dynamic_bias_correlation_time>
+                                <precision>0.00025</precision>
                             </noise>
                         </y>
                         <z>
                             <noise type="gaussian">
                                 <mean>0</mean>
-                                <stddev>2e-4</stddev>
-                                <bias_mean>0.0000075</bias_mean>
-                                <bias_stddev>0.0000008</bias_stddev>
-                                <dynamic_bias_stddev>0.0000004</dynamic_bias_stddev>
-                                <dynamic_bias_correlation_time>1000.0</dynamic_bias_correlation_time>
+                                <stddev>0.009</stddev>
+                                <bias_mean>0.00075</bias_mean>
+                                <bias_stddev>0.005</bias_stddev>
+                                <dynamic_bias_stddev>0.00002</dynamic_bias_stddev>
+                                <dynamic_bias_correlation_time>400.0</dynamic_bias_correlation_time>
+                                <precision>0.00025</precision>
                             </noise>
                         </z>
                     </angular_velocity>
@@ -109,31 +112,34 @@
                         <x>
                             <noise type="gaussian">
                                 <mean>0</mean>
-                                <stddev>1e-2</stddev>
-                                <bias_mean>0.1</bias_mean>
-                                <bias_stddev>0.001</bias_stddev>
-                                <dynamic_bias_stddev>0.002</dynamic_bias_stddev>
-                                <dynamic_bias_correlation_time>300.0</dynamic_bias_correlation_time>
+                                <stddev>0.021</stddev>
+                                <bias_mean>0.05</bias_mean>
+                                <bias_stddev>0.0075</bias_stddev>
+                                <dynamic_bias_stddev>0.000375</dynamic_bias_stddev>
+                                <dynamic_bias_correlation_time>175.0</dynamic_bias_correlation_time>
+                                <precision>0.005</precision>
                             </noise>
                         </x>
                         <y>
                             <noise type="gaussian">
                                 <mean>0</mean>
-                                <stddev>1e-2</stddev>
-                                <bias_mean>0.1</bias_mean>
-                                <bias_stddev>0.001</bias_stddev>
-                                <dynamic_bias_stddev>0.002</dynamic_bias_stddev>
-                                <dynamic_bias_correlation_time>300.0</dynamic_bias_correlation_time>
+                                <stddev>0.021</stddev>
+                                <bias_mean>0.05</bias_mean>
+                                <bias_stddev>0.0075</bias_stddev>
+                                <dynamic_bias_stddev>0.000375</dynamic_bias_stddev>
+                                <dynamic_bias_correlation_time>175.0</dynamic_bias_correlation_time>
+                                <precision>0.005</precision>
                             </noise>
                         </y>
                         <z>
                             <noise type="gaussian">
                                 <mean>0</mean>
-                                <stddev>1e-2</stddev>
-                                <bias_mean>0.1</bias_mean>
-                                <bias_stddev>0.001</bias_stddev>
-                                <dynamic_bias_stddev>0.002</dynamic_bias_stddev>
-                                <dynamic_bias_correlation_time>300.0</dynamic_bias_correlation_time>
+                                <stddev>0.021</stddev>
+                                <bias_mean>0.05</bias_mean>
+                                <bias_stddev>0.0075</bias_stddev>
+                                <dynamic_bias_stddev>0.000375</dynamic_bias_stddev>
+                                <dynamic_bias_correlation_time>175.0</dynamic_bias_correlation_time>
+                                <precision>0.005</precision>
                             </noise>
                         </z>
                     </linear_acceleration>

--- a/submitted_models/explorer_r3_sensor_config_1/model.sdf
+++ b/submitted_models/explorer_r3_sensor_config_1/model.sdf
@@ -127,71 +127,77 @@
         <always_on>1</always_on>
         <update_rate>250</update_rate>
         <imu>
-            <angular_velocity>
-                <x>
-                    <noise type="gaussian">
-                        <mean>0</mean>
-                        <stddev>2e-4</stddev>
-                        <bias_mean>0.0000075</bias_mean>
-                        <bias_stddev>0.0000008</bias_stddev>
-                        <dynamic_bias_stddev>0.0000004</dynamic_bias_stddev>
-                        <dynamic_bias_correlation_time>1000.0</dynamic_bias_correlation_time>
-                    </noise>
-                </x>
-                <y>
-                    <noise type="gaussian">
-                        <mean>0</mean>
-                        <stddev>2e-4</stddev>
-                        <bias_mean>0.0000075</bias_mean>
-                        <bias_stddev>0.0000008</bias_stddev>
-                        <dynamic_bias_stddev>0.0000004</dynamic_bias_stddev>
-                        <dynamic_bias_correlation_time>1000.0</dynamic_bias_correlation_time>
-                    </noise>
-                </y>
-                <z>
-                    <noise type="gaussian">
-                        <mean>0</mean>
-                        <stddev>2e-4</stddev>
-                        <bias_mean>0.0000075</bias_mean>
-                        <bias_stddev>0.0000008</bias_stddev>
-                        <dynamic_bias_stddev>0.0000004</dynamic_bias_stddev>
-                        <dynamic_bias_correlation_time>1000.0</dynamic_bias_correlation_time>
-                    </noise>
-                </z>
-            </angular_velocity>
-            <linear_acceleration>
-                <x>
-                    <noise type="gaussian">
-                        <mean>0</mean>
-                        <stddev>1e-2</stddev>
-                        <bias_mean>0.1</bias_mean>
-                        <bias_stddev>0.001</bias_stddev>
-                        <dynamic_bias_stddev>0.002</dynamic_bias_stddev>
-                        <dynamic_bias_correlation_time>300.0</dynamic_bias_correlation_time>
-                    </noise>
-                </x>
-                <y>
-                    <noise type="gaussian">
-                        <mean>0</mean>
-                        <stddev>1e-2</stddev>
-                        <bias_mean>0.1</bias_mean>
-                        <bias_stddev>0.001</bias_stddev>
-                        <dynamic_bias_stddev>0.002</dynamic_bias_stddev>
-                        <dynamic_bias_correlation_time>300.0</dynamic_bias_correlation_time>
-                    </noise>
-                </y>
-                <z>
-                    <noise type="gaussian">
-                        <mean>0</mean>
-                        <stddev>1e-2</stddev>
-                        <bias_mean>0.1</bias_mean>
-                        <bias_stddev>0.001</bias_stddev>
-                        <dynamic_bias_stddev>0.002</dynamic_bias_stddev>
-                        <dynamic_bias_correlation_time>300.0</dynamic_bias_correlation_time>
-                    </noise>
-                </z>
-            </linear_acceleration>
-        </imu>
+                    <angular_velocity>
+                        <x>
+                            <noise type="gaussian">
+                                <mean>0</mean>
+                                <stddev>0.009</stddev>
+                                <bias_mean>0.00075</bias_mean>
+                                <bias_stddev>0.005</bias_stddev>
+                                <dynamic_bias_stddev>0.00002</dynamic_bias_stddev>
+                                <dynamic_bias_correlation_time>400.0</dynamic_bias_correlation_time>
+                                <precision>0.00025</precision>
+                            </noise>
+                        </x>
+                        <y>
+                            <noise type="gaussian">
+                                <mean>0</mean>
+                                <stddev>0.009</stddev>
+                                <bias_mean>0.00075</bias_mean>
+                                <bias_stddev>0.005</bias_stddev>
+                                <dynamic_bias_stddev>0.00002</dynamic_bias_stddev>
+                                <dynamic_bias_correlation_time>400.0</dynamic_bias_correlation_time>
+                                <precision>0.00025</precision>
+                            </noise>
+                        </y>
+                        <z>
+                            <noise type="gaussian">
+                                <mean>0</mean>
+                                <stddev>0.009</stddev>
+                                <bias_mean>0.00075</bias_mean>
+                                <bias_stddev>0.005</bias_stddev>
+                                <dynamic_bias_stddev>0.00002</dynamic_bias_stddev>
+                                <dynamic_bias_correlation_time>400.0</dynamic_bias_correlation_time>
+                                <precision>0.00025</precision>
+                            </noise>
+                        </z>
+                    </angular_velocity>
+                    <linear_acceleration>
+                        <x>
+                            <noise type="gaussian">
+                                <mean>0</mean>
+                                <stddev>0.021</stddev>
+                                <bias_mean>0.05</bias_mean>
+                                <bias_stddev>0.0075</bias_stddev>
+                                <dynamic_bias_stddev>0.000375</dynamic_bias_stddev>
+                                <dynamic_bias_correlation_time>175.0</dynamic_bias_correlation_time>
+                                <precision>0.005</precision>
+                            </noise>
+                        </x>
+                        <y>
+                            <noise type="gaussian">
+                                <mean>0</mean>
+                                <stddev>0.021</stddev>
+                                <bias_mean>0.05</bias_mean>
+                                <bias_stddev>0.0075</bias_stddev>
+                                <dynamic_bias_stddev>0.000375</dynamic_bias_stddev>
+                                <dynamic_bias_correlation_time>175.0</dynamic_bias_correlation_time>
+                                <precision>0.005</precision>
+                            </noise>
+                        </y>
+                        <z>
+                            <noise type="gaussian">
+                                <mean>0</mean>
+                                <stddev>0.021</stddev>
+                                <bias_mean>0.05</bias_mean>
+                                <bias_stddev>0.0075</bias_stddev>
+                                <dynamic_bias_stddev>0.000375</dynamic_bias_stddev>
+                                <dynamic_bias_correlation_time>175.0</dynamic_bias_correlation_time>
+                                <precision>0.005</precision>
+                            </noise>
+                        </z>
+                    </linear_acceleration>
+                </imu>
       </sensor>
       <velocity_decay/>
       <velocity_decay/>

--- a/submitted_models/explorer_x1_sensor_config_1/model.sdf
+++ b/submitted_models/explorer_x1_sensor_config_1/model.sdf
@@ -603,71 +603,77 @@
         <always_on>1</always_on>
         <update_rate>50</update_rate>
         <imu>
-          <angular_velocity>
-            <x>
-              <noise type="gaussian">
-                <mean>0</mean>
-                <stddev>2e-4</stddev>
-                <bias_mean>0.0000075</bias_mean>
-                <bias_stddev>0.0000008</bias_stddev>
-                <dynamic_bias_stddev>0.0000004</dynamic_bias_stddev>
-                <dynamic_bias_correlation_time>1000.0</dynamic_bias_correlation_time>
-              </noise>
-            </x>
-            <y>
-              <noise type="gaussian">
-                <mean>0</mean>
-                <stddev>2e-4</stddev>
-                <bias_mean>0.0000075</bias_mean>
-                <bias_stddev>0.0000008</bias_stddev>
-                <dynamic_bias_stddev>0.0000004</dynamic_bias_stddev>
-                <dynamic_bias_correlation_time>1000.0</dynamic_bias_correlation_time>
-              </noise>
-            </y>
-            <z>
-              <noise type="gaussian">
-                <mean>0</mean>
-                <stddev>2e-4</stddev>
-                <bias_mean>0.0000075</bias_mean>
-                <bias_stddev>0.0000008</bias_stddev>
-                <dynamic_bias_stddev>0.0000004</dynamic_bias_stddev>
-                <dynamic_bias_correlation_time>1000.0</dynamic_bias_correlation_time>
-              </noise>
-            </z>
-          </angular_velocity>
-          <linear_acceleration>
-            <x>
-              <noise type="gaussian">
-                <mean>0</mean>
-                <stddev>1e-2</stddev>
-                <bias_mean>0.1</bias_mean>
-                <bias_stddev>0.001</bias_stddev>
-                <dynamic_bias_stddev>0.002</dynamic_bias_stddev>
-                <dynamic_bias_correlation_time>300.0</dynamic_bias_correlation_time>
-              </noise>
-            </x>
-            <y>
-              <noise type="gaussian">
-                <mean>0</mean>
-                <stddev>1e-2</stddev>
-                <bias_mean>0.1</bias_mean>
-                <bias_stddev>0.001</bias_stddev>
-                <dynamic_bias_stddev>0.002</dynamic_bias_stddev>
-                <dynamic_bias_correlation_time>300.0</dynamic_bias_correlation_time>
-              </noise>
-            </y>
-            <z>
-              <noise type="gaussian">
-                <mean>0</mean>
-                <stddev>1e-2</stddev>
-                <bias_mean>0.1</bias_mean>
-                <bias_stddev>0.001</bias_stddev>
-                <dynamic_bias_stddev>0.002</dynamic_bias_stddev>
-                <dynamic_bias_correlation_time>300.0</dynamic_bias_correlation_time>
-              </noise>
-            </z>
-          </linear_acceleration>
-        </imu>
+                    <angular_velocity>
+                        <x>
+                            <noise type="gaussian">
+                                <mean>0</mean>
+                                <stddev>0.009</stddev>
+                                <bias_mean>0.00075</bias_mean>
+                                <bias_stddev>0.005</bias_stddev>
+                                <dynamic_bias_stddev>0.00002</dynamic_bias_stddev>
+                                <dynamic_bias_correlation_time>400.0</dynamic_bias_correlation_time>
+                                <precision>0.00025</precision>
+                            </noise>
+                        </x>
+                        <y>
+                            <noise type="gaussian">
+                                <mean>0</mean>
+                                <stddev>0.009</stddev>
+                                <bias_mean>0.00075</bias_mean>
+                                <bias_stddev>0.005</bias_stddev>
+                                <dynamic_bias_stddev>0.00002</dynamic_bias_stddev>
+                                <dynamic_bias_correlation_time>400.0</dynamic_bias_correlation_time>
+                                <precision>0.00025</precision>
+                            </noise>
+                        </y>
+                        <z>
+                            <noise type="gaussian">
+                                <mean>0</mean>
+                                <stddev>0.009</stddev>
+                                <bias_mean>0.00075</bias_mean>
+                                <bias_stddev>0.005</bias_stddev>
+                                <dynamic_bias_stddev>0.00002</dynamic_bias_stddev>
+                                <dynamic_bias_correlation_time>400.0</dynamic_bias_correlation_time>
+                                <precision>0.00025</precision>
+                            </noise>
+                        </z>
+                    </angular_velocity>
+                    <linear_acceleration>
+                        <x>
+                            <noise type="gaussian">
+                                <mean>0</mean>
+                                <stddev>0.021</stddev>
+                                <bias_mean>0.05</bias_mean>
+                                <bias_stddev>0.0075</bias_stddev>
+                                <dynamic_bias_stddev>0.000375</dynamic_bias_stddev>
+                                <dynamic_bias_correlation_time>175.0</dynamic_bias_correlation_time>
+                                <precision>0.005</precision>
+                            </noise>
+                        </x>
+                        <y>
+                            <noise type="gaussian">
+                                <mean>0</mean>
+                                <stddev>0.021</stddev>
+                                <bias_mean>0.05</bias_mean>
+                                <bias_stddev>0.0075</bias_stddev>
+                                <dynamic_bias_stddev>0.000375</dynamic_bias_stddev>
+                                <dynamic_bias_correlation_time>175.0</dynamic_bias_correlation_time>
+                                <precision>0.005</precision>
+                            </noise>
+                        </y>
+                        <z>
+                            <noise type="gaussian">
+                                <mean>0</mean>
+                                <stddev>0.021</stddev>
+                                <bias_mean>0.05</bias_mean>
+                                <bias_stddev>0.0075</bias_stddev>
+                                <dynamic_bias_stddev>0.000375</dynamic_bias_stddev>
+                                <dynamic_bias_correlation_time>175.0</dynamic_bias_correlation_time>
+                                <precision>0.005</precision>
+                            </noise>
+                        </z>
+                    </linear_acceleration>
+                </imu>
       </sensor>
       <light name="left_headlight_body_light_source_light" type="spot">
         <pose frame="">0.514147 0.216803 0.180 3.14159 1.56859 0</pose>

--- a/submitted_models/explorer_x1_sensor_config_2/model.sdf
+++ b/submitted_models/explorer_x1_sensor_config_2/model.sdf
@@ -603,71 +603,77 @@
         <always_on>1</always_on>
         <update_rate>50</update_rate>
         <imu>
-          <angular_velocity>
-            <x>
-              <noise type="gaussian">
-                <mean>0</mean>
-                <stddev>2e-4</stddev>
-                <bias_mean>0.0000075</bias_mean>
-                <bias_stddev>0.0000008</bias_stddev>
-                <dynamic_bias_stddev>0.0000004</dynamic_bias_stddev>
-                <dynamic_bias_correlation_time>1000.0</dynamic_bias_correlation_time>
-              </noise>
-            </x>
-            <y>
-              <noise type="gaussian">
-                <mean>0</mean>
-                <stddev>2e-4</stddev>
-                <bias_mean>0.0000075</bias_mean>
-                <bias_stddev>0.0000008</bias_stddev>
-                <dynamic_bias_stddev>0.0000004</dynamic_bias_stddev>
-                <dynamic_bias_correlation_time>1000.0</dynamic_bias_correlation_time>
-              </noise>
-            </y>
-            <z>
-              <noise type="gaussian">
-                <mean>0</mean>
-                <stddev>2e-4</stddev>
-                <bias_mean>0.0000075</bias_mean>
-                <bias_stddev>0.0000008</bias_stddev>
-                <dynamic_bias_stddev>0.0000004</dynamic_bias_stddev>
-                <dynamic_bias_correlation_time>1000.0</dynamic_bias_correlation_time>
-              </noise>
-            </z>
-          </angular_velocity>
-          <linear_acceleration>
-            <x>
-              <noise type="gaussian">
-                <mean>0</mean>
-                <stddev>1e-2</stddev>
-                <bias_mean>0.1</bias_mean>
-                <bias_stddev>0.001</bias_stddev>
-                <dynamic_bias_stddev>0.002</dynamic_bias_stddev>
-                <dynamic_bias_correlation_time>300.0</dynamic_bias_correlation_time>
-              </noise>
-            </x>
-            <y>
-              <noise type="gaussian">
-                <mean>0</mean>
-                <stddev>1e-2</stddev>
-                <bias_mean>0.1</bias_mean>
-                <bias_stddev>0.001</bias_stddev>
-                <dynamic_bias_stddev>0.002</dynamic_bias_stddev>
-                <dynamic_bias_correlation_time>300.0</dynamic_bias_correlation_time>
-              </noise>
-            </y>
-            <z>
-              <noise type="gaussian">
-                <mean>0</mean>
-                <stddev>1e-2</stddev>
-                <bias_mean>0.1</bias_mean>
-                <bias_stddev>0.001</bias_stddev>
-                <dynamic_bias_stddev>0.002</dynamic_bias_stddev>
-                <dynamic_bias_correlation_time>300.0</dynamic_bias_correlation_time>
-              </noise>
-            </z>
-          </linear_acceleration>
-        </imu>
+                    <angular_velocity>
+                        <x>
+                            <noise type="gaussian">
+                                <mean>0</mean>
+                                <stddev>0.009</stddev>
+                                <bias_mean>0.00075</bias_mean>
+                                <bias_stddev>0.005</bias_stddev>
+                                <dynamic_bias_stddev>0.00002</dynamic_bias_stddev>
+                                <dynamic_bias_correlation_time>400.0</dynamic_bias_correlation_time>
+                                <precision>0.00025</precision>
+                            </noise>
+                        </x>
+                        <y>
+                            <noise type="gaussian">
+                                <mean>0</mean>
+                                <stddev>0.009</stddev>
+                                <bias_mean>0.00075</bias_mean>
+                                <bias_stddev>0.005</bias_stddev>
+                                <dynamic_bias_stddev>0.00002</dynamic_bias_stddev>
+                                <dynamic_bias_correlation_time>400.0</dynamic_bias_correlation_time>
+                                <precision>0.00025</precision>
+                            </noise>
+                        </y>
+                        <z>
+                            <noise type="gaussian">
+                                <mean>0</mean>
+                                <stddev>0.009</stddev>
+                                <bias_mean>0.00075</bias_mean>
+                                <bias_stddev>0.005</bias_stddev>
+                                <dynamic_bias_stddev>0.00002</dynamic_bias_stddev>
+                                <dynamic_bias_correlation_time>400.0</dynamic_bias_correlation_time>
+                                <precision>0.00025</precision>
+                            </noise>
+                        </z>
+                    </angular_velocity>
+                    <linear_acceleration>
+                        <x>
+                            <noise type="gaussian">
+                                <mean>0</mean>
+                                <stddev>0.021</stddev>
+                                <bias_mean>0.05</bias_mean>
+                                <bias_stddev>0.0075</bias_stddev>
+                                <dynamic_bias_stddev>0.000375</dynamic_bias_stddev>
+                                <dynamic_bias_correlation_time>175.0</dynamic_bias_correlation_time>
+                                <precision>0.005</precision>
+                            </noise>
+                        </x>
+                        <y>
+                            <noise type="gaussian">
+                                <mean>0</mean>
+                                <stddev>0.021</stddev>
+                                <bias_mean>0.05</bias_mean>
+                                <bias_stddev>0.0075</bias_stddev>
+                                <dynamic_bias_stddev>0.000375</dynamic_bias_stddev>
+                                <dynamic_bias_correlation_time>175.0</dynamic_bias_correlation_time>
+                                <precision>0.005</precision>
+                            </noise>
+                        </y>
+                        <z>
+                            <noise type="gaussian">
+                                <mean>0</mean>
+                                <stddev>0.021</stddev>
+                                <bias_mean>0.05</bias_mean>
+                                <bias_stddev>0.0075</bias_stddev>
+                                <dynamic_bias_stddev>0.000375</dynamic_bias_stddev>
+                                <dynamic_bias_correlation_time>175.0</dynamic_bias_correlation_time>
+                                <precision>0.005</precision>
+                            </noise>
+                        </z>
+                    </linear_acceleration>
+                </imu>
       </sensor>
       <light name="left_headlight_body_light_source_light" type="spot">
         <pose frame="">0.514147 0.216803 0.180 3.14159 1.56859 0</pose>

--- a/submitted_models/marble_hd2_sensor_config_1/model.sdf
+++ b/submitted_models/marble_hd2_sensor_config_1/model.sdf
@@ -333,71 +333,77 @@
                       <always_on>1</always_on>
                       <update_rate>50</update_rate>
                       <imu>
-                        <angular_velocity>
-                          <x>
+                    <angular_velocity>
+                        <x>
                             <noise type="gaussian">
-                              <mean>0</mean>
-                              <stddev>2e-4</stddev>
-                              <bias_mean>0.0000075</bias_mean>
-                              <bias_stddev>0.0000008</bias_stddev>
-                              <dynamic_bias_stddev>0.0000004</dynamic_bias_stddev>
-                              <dynamic_bias_correlation_time>1000.0</dynamic_bias_correlation_time>
+                                <mean>0</mean>
+                                <stddev>0.009</stddev>
+                                <bias_mean>0.00075</bias_mean>
+                                <bias_stddev>0.005</bias_stddev>
+                                <dynamic_bias_stddev>0.00002</dynamic_bias_stddev>
+                                <dynamic_bias_correlation_time>400.0</dynamic_bias_correlation_time>
+                                <precision>0.00025</precision>
                             </noise>
-                          </x>
-                          <y>
+                        </x>
+                        <y>
                             <noise type="gaussian">
-                              <mean>0</mean>
-                              <stddev>2e-4</stddev>
-                              <bias_mean>0.0000075</bias_mean>
-                              <bias_stddev>0.0000008</bias_stddev>
-                              <dynamic_bias_stddev>0.0000004</dynamic_bias_stddev>
-                              <dynamic_bias_correlation_time>1000.0</dynamic_bias_correlation_time>
+                                <mean>0</mean>
+                                <stddev>0.009</stddev>
+                                <bias_mean>0.00075</bias_mean>
+                                <bias_stddev>0.005</bias_stddev>
+                                <dynamic_bias_stddev>0.00002</dynamic_bias_stddev>
+                                <dynamic_bias_correlation_time>400.0</dynamic_bias_correlation_time>
+                                <precision>0.00025</precision>
                             </noise>
-                          </y>
-                          <z>
+                        </y>
+                        <z>
                             <noise type="gaussian">
-                              <mean>0</mean>
-                              <stddev>2e-4</stddev>
-                              <bias_mean>0.0000075</bias_mean>
-                              <bias_stddev>0.0000008</bias_stddev>
-                              <dynamic_bias_stddev>0.0000004</dynamic_bias_stddev>
-                              <dynamic_bias_correlation_time>1000.0</dynamic_bias_correlation_time>
+                                <mean>0</mean>
+                                <stddev>0.009</stddev>
+                                <bias_mean>0.00075</bias_mean>
+                                <bias_stddev>0.005</bias_stddev>
+                                <dynamic_bias_stddev>0.00002</dynamic_bias_stddev>
+                                <dynamic_bias_correlation_time>400.0</dynamic_bias_correlation_time>
+                                <precision>0.00025</precision>
                             </noise>
-                          </z>
-                        </angular_velocity>
-                        <linear_acceleration>
-                          <x>
+                        </z>
+                    </angular_velocity>
+                    <linear_acceleration>
+                        <x>
                             <noise type="gaussian">
-                              <mean>0</mean>
-                              <stddev>1e-2</stddev>
-                              <bias_mean>0.1</bias_mean>
-                              <bias_stddev>0.001</bias_stddev>
-                              <dynamic_bias_stddev>0.002</dynamic_bias_stddev>
-                              <dynamic_bias_correlation_time>300.0</dynamic_bias_correlation_time>
+                                <mean>0</mean>
+                                <stddev>0.021</stddev>
+                                <bias_mean>0.05</bias_mean>
+                                <bias_stddev>0.0075</bias_stddev>
+                                <dynamic_bias_stddev>0.000375</dynamic_bias_stddev>
+                                <dynamic_bias_correlation_time>175.0</dynamic_bias_correlation_time>
+                                <precision>0.005</precision>
                             </noise>
-                          </x>
-                          <y>
+                        </x>
+                        <y>
                             <noise type="gaussian">
-                              <mean>0</mean>
-                              <stddev>1e-2</stddev>
-                              <bias_mean>0.1</bias_mean>
-                              <bias_stddev>0.001</bias_stddev>
-                              <dynamic_bias_stddev>0.002</dynamic_bias_stddev>
-                              <dynamic_bias_correlation_time>300.0</dynamic_bias_correlation_time>
+                                <mean>0</mean>
+                                <stddev>0.021</stddev>
+                                <bias_mean>0.05</bias_mean>
+                                <bias_stddev>0.0075</bias_stddev>
+                                <dynamic_bias_stddev>0.000375</dynamic_bias_stddev>
+                                <dynamic_bias_correlation_time>175.0</dynamic_bias_correlation_time>
+                                <precision>0.005</precision>
                             </noise>
-                          </y>
-                          <z>
+                        </y>
+                        <z>
                             <noise type="gaussian">
-                              <mean>0</mean>
-                              <stddev>1e-2</stddev>
-                              <bias_mean>0.1</bias_mean>
-                              <bias_stddev>0.001</bias_stddev>
-                              <dynamic_bias_stddev>0.002</dynamic_bias_stddev>
-                              <dynamic_bias_correlation_time>300.0</dynamic_bias_correlation_time>
+                                <mean>0</mean>
+                                <stddev>0.021</stddev>
+                                <bias_mean>0.05</bias_mean>
+                                <bias_stddev>0.0075</bias_stddev>
+                                <dynamic_bias_stddev>0.000375</dynamic_bias_stddev>
+                                <dynamic_bias_correlation_time>175.0</dynamic_bias_correlation_time>
+                                <precision>0.005</precision>
                             </noise>
-                          </z>
-                        </linear_acceleration>
-                      </imu>
+                        </z>
+                    </linear_acceleration>
+                </imu>
                     </sensor>
                   </link>
                   <!-- Left Side Wheels  -->

--- a/submitted_models/marble_husky_sensor_config_1/model.sdf
+++ b/submitted_models/marble_husky_sensor_config_1/model.sdf
@@ -440,71 +440,77 @@
         <always_on>1</always_on>
         <update_rate>50</update_rate>
         <imu>
-          <angular_velocity>
-            <x>
-              <noise type="gaussian">
-                <mean>0</mean>
-                <stddev>2e-4</stddev>
-                <bias_mean>0.0000075</bias_mean>
-                <bias_stddev>0.0000008</bias_stddev>
-                <dynamic_bias_stddev>0.0000004</dynamic_bias_stddev>
-                <dynamic_bias_correlation_time>1000.0</dynamic_bias_correlation_time>
-              </noise>
-            </x>
-            <y>
-              <noise type="gaussian">
-                <mean>0</mean>
-                <stddev>2e-4</stddev>
-                <bias_mean>0.0000075</bias_mean>
-                <bias_stddev>0.0000008</bias_stddev>
-                <dynamic_bias_stddev>0.0000004</dynamic_bias_stddev>
-                <dynamic_bias_correlation_time>1000.0</dynamic_bias_correlation_time>
-              </noise>
-            </y>
-            <z>
-              <noise type="gaussian">
-                <mean>0</mean>
-                <stddev>2e-4</stddev>
-                <bias_mean>0.0000075</bias_mean>
-                <bias_stddev>0.0000008</bias_stddev>
-                <dynamic_bias_stddev>0.0000004</dynamic_bias_stddev>
-                <dynamic_bias_correlation_time>1000.0</dynamic_bias_correlation_time>
-              </noise>
-            </z>
-          </angular_velocity>
-          <linear_acceleration>
-            <x>
-              <noise type="gaussian">
-                <mean>0</mean>
-                <stddev>1e-2</stddev>
-                <bias_mean>0.1</bias_mean>
-                <bias_stddev>0.001</bias_stddev>
-                <dynamic_bias_stddev>0.002</dynamic_bias_stddev>
-                <dynamic_bias_correlation_time>300.0</dynamic_bias_correlation_time>
-              </noise>
-            </x>
-            <y>
-              <noise type="gaussian">
-                <mean>0</mean>
-                <stddev>1e-2</stddev>
-                <bias_mean>0.1</bias_mean>
-                <bias_stddev>0.001</bias_stddev>
-                <dynamic_bias_stddev>0.002</dynamic_bias_stddev>
-                <dynamic_bias_correlation_time>300.0</dynamic_bias_correlation_time>
-              </noise>
-            </y>
-            <z>
-              <noise type="gaussian">
-                <mean>0</mean>
-                <stddev>1e-2</stddev>
-                <bias_mean>0.1</bias_mean>
-                <bias_stddev>0.001</bias_stddev>
-                <dynamic_bias_stddev>0.002</dynamic_bias_stddev>
-                <dynamic_bias_correlation_time>300.0</dynamic_bias_correlation_time>
-              </noise>
-            </z>
-          </linear_acceleration>
-        </imu>
+                    <angular_velocity>
+                        <x>
+                            <noise type="gaussian">
+                                <mean>0</mean>
+                                <stddev>0.009</stddev>
+                                <bias_mean>0.00075</bias_mean>
+                                <bias_stddev>0.005</bias_stddev>
+                                <dynamic_bias_stddev>0.00002</dynamic_bias_stddev>
+                                <dynamic_bias_correlation_time>400.0</dynamic_bias_correlation_time>
+                                <precision>0.00025</precision>
+                            </noise>
+                        </x>
+                        <y>
+                            <noise type="gaussian">
+                                <mean>0</mean>
+                                <stddev>0.009</stddev>
+                                <bias_mean>0.00075</bias_mean>
+                                <bias_stddev>0.005</bias_stddev>
+                                <dynamic_bias_stddev>0.00002</dynamic_bias_stddev>
+                                <dynamic_bias_correlation_time>400.0</dynamic_bias_correlation_time>
+                                <precision>0.00025</precision>
+                            </noise>
+                        </y>
+                        <z>
+                            <noise type="gaussian">
+                                <mean>0</mean>
+                                <stddev>0.009</stddev>
+                                <bias_mean>0.00075</bias_mean>
+                                <bias_stddev>0.005</bias_stddev>
+                                <dynamic_bias_stddev>0.00002</dynamic_bias_stddev>
+                                <dynamic_bias_correlation_time>400.0</dynamic_bias_correlation_time>
+                                <precision>0.00025</precision>
+                            </noise>
+                        </z>
+                    </angular_velocity>
+                    <linear_acceleration>
+                        <x>
+                            <noise type="gaussian">
+                                <mean>0</mean>
+                                <stddev>0.021</stddev>
+                                <bias_mean>0.05</bias_mean>
+                                <bias_stddev>0.0075</bias_stddev>
+                                <dynamic_bias_stddev>0.000375</dynamic_bias_stddev>
+                                <dynamic_bias_correlation_time>175.0</dynamic_bias_correlation_time>
+                                <precision>0.005</precision>
+                            </noise>
+                        </x>
+                        <y>
+                            <noise type="gaussian">
+                                <mean>0</mean>
+                                <stddev>0.021</stddev>
+                                <bias_mean>0.05</bias_mean>
+                                <bias_stddev>0.0075</bias_stddev>
+                                <dynamic_bias_stddev>0.000375</dynamic_bias_stddev>
+                                <dynamic_bias_correlation_time>175.0</dynamic_bias_correlation_time>
+                                <precision>0.005</precision>
+                            </noise>
+                        </y>
+                        <z>
+                            <noise type="gaussian">
+                                <mean>0</mean>
+                                <stddev>0.021</stddev>
+                                <bias_mean>0.05</bias_mean>
+                                <bias_stddev>0.0075</bias_stddev>
+                                <dynamic_bias_stddev>0.000375</dynamic_bias_stddev>
+                                <dynamic_bias_correlation_time>175.0</dynamic_bias_correlation_time>
+                                <precision>0.005</precision>
+                            </noise>
+                        </z>
+                    </linear_acceleration>
+                </imu>
       </sensor>
     </link>
     <link name="front_left_wheel_link">

--- a/submitted_models/marble_qav500_sensor_config_1/model.sdf
+++ b/submitted_models/marble_qav500_sensor_config_1/model.sdf
@@ -187,31 +187,34 @@
                         <x>
                             <noise type="gaussian">
                                 <mean>0</mean>
-                                <stddev>2e-4</stddev>
-                                <bias_mean>0.0000075</bias_mean>
-                                <bias_stddev>0.0000008</bias_stddev>
-                                <dynamic_bias_stddev>0.0000004</dynamic_bias_stddev>
-                                <dynamic_bias_correlation_time>1000.0</dynamic_bias_correlation_time>
+                                <stddev>0.009</stddev>
+                                <bias_mean>0.00075</bias_mean>
+                                <bias_stddev>0.005</bias_stddev>
+                                <dynamic_bias_stddev>0.00002</dynamic_bias_stddev>
+                                <dynamic_bias_correlation_time>400.0</dynamic_bias_correlation_time>
+                                <precision>0.00025</precision>
                             </noise>
                         </x>
                         <y>
                             <noise type="gaussian">
                                 <mean>0</mean>
-                                <stddev>2e-4</stddev>
-                                <bias_mean>0.0000075</bias_mean>
-                                <bias_stddev>0.0000008</bias_stddev>
-                                <dynamic_bias_stddev>0.0000004</dynamic_bias_stddev>
-                                <dynamic_bias_correlation_time>1000.0</dynamic_bias_correlation_time>
+                                <stddev>0.009</stddev>
+                                <bias_mean>0.00075</bias_mean>
+                                <bias_stddev>0.005</bias_stddev>
+                                <dynamic_bias_stddev>0.00002</dynamic_bias_stddev>
+                                <dynamic_bias_correlation_time>400.0</dynamic_bias_correlation_time>
+                                <precision>0.00025</precision>
                             </noise>
                         </y>
                         <z>
                             <noise type="gaussian">
                                 <mean>0</mean>
-                                <stddev>2e-4</stddev>
-                                <bias_mean>0.0000075</bias_mean>
-                                <bias_stddev>0.0000008</bias_stddev>
-                                <dynamic_bias_stddev>0.0000004</dynamic_bias_stddev>
-                                <dynamic_bias_correlation_time>1000.0</dynamic_bias_correlation_time>
+                                <stddev>0.009</stddev>
+                                <bias_mean>0.00075</bias_mean>
+                                <bias_stddev>0.005</bias_stddev>
+                                <dynamic_bias_stddev>0.00002</dynamic_bias_stddev>
+                                <dynamic_bias_correlation_time>400.0</dynamic_bias_correlation_time>
+                                <precision>0.00025</precision>
                             </noise>
                         </z>
                     </angular_velocity>
@@ -219,31 +222,34 @@
                         <x>
                             <noise type="gaussian">
                                 <mean>0</mean>
-                                <stddev>1e-2</stddev>
-                                <bias_mean>0.1</bias_mean>
-                                <bias_stddev>0.001</bias_stddev>
-                                <dynamic_bias_stddev>0.002</dynamic_bias_stddev>
-                                <dynamic_bias_correlation_time>300.0</dynamic_bias_correlation_time>
+                                <stddev>0.021</stddev>
+                                <bias_mean>0.05</bias_mean>
+                                <bias_stddev>0.0075</bias_stddev>
+                                <dynamic_bias_stddev>0.000375</dynamic_bias_stddev>
+                                <dynamic_bias_correlation_time>175.0</dynamic_bias_correlation_time>
+                                <precision>0.005</precision>
                             </noise>
                         </x>
                         <y>
                             <noise type="gaussian">
                                 <mean>0</mean>
-                                <stddev>1e-2</stddev>
-                                <bias_mean>0.1</bias_mean>
-                                <bias_stddev>0.001</bias_stddev>
-                                <dynamic_bias_stddev>0.002</dynamic_bias_stddev>
-                                <dynamic_bias_correlation_time>300.0</dynamic_bias_correlation_time>
+                                <stddev>0.021</stddev>
+                                <bias_mean>0.05</bias_mean>
+                                <bias_stddev>0.0075</bias_stddev>
+                                <dynamic_bias_stddev>0.000375</dynamic_bias_stddev>
+                                <dynamic_bias_correlation_time>175.0</dynamic_bias_correlation_time>
+                                <precision>0.005</precision>
                             </noise>
                         </y>
                         <z>
                             <noise type="gaussian">
                                 <mean>0</mean>
-                                <stddev>1e-2</stddev>
-                                <bias_mean>0.1</bias_mean>
-                                <bias_stddev>0.001</bias_stddev>
-                                <dynamic_bias_stddev>0.002</dynamic_bias_stddev>
-                                <dynamic_bias_correlation_time>300.0</dynamic_bias_correlation_time>
+                                <stddev>0.021</stddev>
+                                <bias_mean>0.05</bias_mean>
+                                <bias_stddev>0.0075</bias_stddev>
+                                <dynamic_bias_stddev>0.000375</dynamic_bias_stddev>
+                                <dynamic_bias_correlation_time>175.0</dynamic_bias_correlation_time>
+                                <precision>0.005</precision>
                             </noise>
                         </z>
                     </linear_acceleration>

--- a/submitted_models/robotika_freyja_sensor_config_1/model.sdf
+++ b/submitted_models/robotika_freyja_sensor_config_1/model.sdf
@@ -449,71 +449,77 @@
         <always_on>1</always_on>
         <update_rate>50</update_rate>
         <imu>
-          <angular_velocity>
-            <x>
-              <noise type="gaussian">
-                <mean>0</mean>
-                <stddev>2e-4</stddev>
-                <bias_mean>0.0000075</bias_mean>
-                <bias_stddev>0.0000008</bias_stddev>
-                <dynamic_bias_stddev>0.0000004</dynamic_bias_stddev>
-                <dynamic_bias_correlation_time>1000.0</dynamic_bias_correlation_time>
-              </noise>
-            </x>
-            <y>
-              <noise type="gaussian">
-                <mean>0</mean>
-                <stddev>2e-4</stddev>
-                <bias_mean>0.0000075</bias_mean>
-                <bias_stddev>0.0000008</bias_stddev>
-                <dynamic_bias_stddev>0.0000004</dynamic_bias_stddev>
-                <dynamic_bias_correlation_time>1000.0</dynamic_bias_correlation_time>
-              </noise>
-            </y>
-            <z>
-              <noise type="gaussian">
-                <mean>0</mean>
-                <stddev>2e-4</stddev>
-                <bias_mean>0.0000075</bias_mean>
-                <bias_stddev>0.0000008</bias_stddev>
-                <dynamic_bias_stddev>0.0000004</dynamic_bias_stddev>
-                <dynamic_bias_correlation_time>1000.0</dynamic_bias_correlation_time>
-              </noise>
-            </z>
-          </angular_velocity>
-          <linear_acceleration>
-            <x>
-              <noise type="gaussian">
-                <mean>0</mean>
-                <stddev>1e-2</stddev>
-                <bias_mean>0.1</bias_mean>
-                <bias_stddev>0.001</bias_stddev>
-                <dynamic_bias_stddev>0.002</dynamic_bias_stddev>
-                <dynamic_bias_correlation_time>300.0</dynamic_bias_correlation_time>
-              </noise>
-            </x>
-            <y>
-              <noise type="gaussian">
-                <mean>0</mean>
-                <stddev>1e-2</stddev>
-                <bias_mean>0.1</bias_mean>
-                <bias_stddev>0.001</bias_stddev>
-                <dynamic_bias_stddev>0.002</dynamic_bias_stddev>
-                <dynamic_bias_correlation_time>300.0</dynamic_bias_correlation_time>
-              </noise>
-            </y>
-            <z>
-              <noise type="gaussian">
-                <mean>0</mean>
-                <stddev>1e-2</stddev>
-                <bias_mean>0.1</bias_mean>
-                <bias_stddev>0.001</bias_stddev>
-                <dynamic_bias_stddev>0.002</dynamic_bias_stddev>
-                <dynamic_bias_correlation_time>300.0</dynamic_bias_correlation_time>
-              </noise>
-            </z>
-          </linear_acceleration>
-        </imu>
+                    <angular_velocity>
+                        <x>
+                            <noise type="gaussian">
+                                <mean>0</mean>
+                                <stddev>0.009</stddev>
+                                <bias_mean>0.00075</bias_mean>
+                                <bias_stddev>0.005</bias_stddev>
+                                <dynamic_bias_stddev>0.00002</dynamic_bias_stddev>
+                                <dynamic_bias_correlation_time>400.0</dynamic_bias_correlation_time>
+                                <precision>0.00025</precision>
+                            </noise>
+                        </x>
+                        <y>
+                            <noise type="gaussian">
+                                <mean>0</mean>
+                                <stddev>0.009</stddev>
+                                <bias_mean>0.00075</bias_mean>
+                                <bias_stddev>0.005</bias_stddev>
+                                <dynamic_bias_stddev>0.00002</dynamic_bias_stddev>
+                                <dynamic_bias_correlation_time>400.0</dynamic_bias_correlation_time>
+                                <precision>0.00025</precision>
+                            </noise>
+                        </y>
+                        <z>
+                            <noise type="gaussian">
+                                <mean>0</mean>
+                                <stddev>0.009</stddev>
+                                <bias_mean>0.00075</bias_mean>
+                                <bias_stddev>0.005</bias_stddev>
+                                <dynamic_bias_stddev>0.00002</dynamic_bias_stddev>
+                                <dynamic_bias_correlation_time>400.0</dynamic_bias_correlation_time>
+                                <precision>0.00025</precision>
+                            </noise>
+                        </z>
+                    </angular_velocity>
+                    <linear_acceleration>
+                        <x>
+                            <noise type="gaussian">
+                                <mean>0</mean>
+                                <stddev>0.021</stddev>
+                                <bias_mean>0.05</bias_mean>
+                                <bias_stddev>0.0075</bias_stddev>
+                                <dynamic_bias_stddev>0.000375</dynamic_bias_stddev>
+                                <dynamic_bias_correlation_time>175.0</dynamic_bias_correlation_time>
+                                <precision>0.005</precision>
+                            </noise>
+                        </x>
+                        <y>
+                            <noise type="gaussian">
+                                <mean>0</mean>
+                                <stddev>0.021</stddev>
+                                <bias_mean>0.05</bias_mean>
+                                <bias_stddev>0.0075</bias_stddev>
+                                <dynamic_bias_stddev>0.000375</dynamic_bias_stddev>
+                                <dynamic_bias_correlation_time>175.0</dynamic_bias_correlation_time>
+                                <precision>0.005</precision>
+                            </noise>
+                        </y>
+                        <z>
+                            <noise type="gaussian">
+                                <mean>0</mean>
+                                <stddev>0.021</stddev>
+                                <bias_mean>0.05</bias_mean>
+                                <bias_stddev>0.0075</bias_stddev>
+                                <dynamic_bias_stddev>0.000375</dynamic_bias_stddev>
+                                <dynamic_bias_correlation_time>175.0</dynamic_bias_correlation_time>
+                                <precision>0.005</precision>
+                            </noise>
+                        </z>
+                    </linear_acceleration>
+                </imu>
       </sensor>
       <sensor name="magnetometer" type="magnetometer">
         <always_on>1</always_on>

--- a/submitted_models/robotika_kloubak_sensor_config_1/model.sdf
+++ b/submitted_models/robotika_kloubak_sensor_config_1/model.sdf
@@ -107,71 +107,77 @@
             <always_on>1</always_on>
             <update_rate>50</update_rate>
             <imu>
-                <angular_velocity>
-                    <x>
-                        <noise type="gaussian">
-                            <mean>0</mean>
-                            <stddev>2e-4</stddev>
-                            <bias_mean>0.0000075</bias_mean>
-                            <bias_stddev>0.0000008</bias_stddev>
-                            <dynamic_bias_stddev>0.0000004</dynamic_bias_stddev>
-                            <dynamic_bias_correlation_time>1000.0</dynamic_bias_correlation_time>
-                        </noise>
-                    </x>
-                    <y>
-                        <noise type="gaussian">
-                            <mean>0</mean>
-                            <stddev>2e-4</stddev>
-                            <bias_mean>0.0000075</bias_mean>
-                            <bias_stddev>0.0000008</bias_stddev>
-                            <dynamic_bias_stddev>0.0000004</dynamic_bias_stddev>
-                            <dynamic_bias_correlation_time>1000.0</dynamic_bias_correlation_time>
-                        </noise>
-                    </y>
-                    <z>
-                        <noise type="gaussian">
-                            <mean>0</mean>
-                            <stddev>2e-4</stddev>
-                            <bias_mean>0.0000075</bias_mean>
-                            <bias_stddev>0.0000008</bias_stddev>
-                            <dynamic_bias_stddev>0.0000004</dynamic_bias_stddev>
-                            <dynamic_bias_correlation_time>1000.0</dynamic_bias_correlation_time>
-                        </noise>
-                    </z>
-                </angular_velocity>
-                <linear_acceleration>
-                    <x>
-                        <noise type="gaussian">
-                            <mean>0</mean>
-                            <stddev>1e-2</stddev>
-                            <bias_mean>0.1</bias_mean>
-                            <bias_stddev>0.001</bias_stddev>
-                            <dynamic_bias_stddev>0.002</dynamic_bias_stddev>
-                            <dynamic_bias_correlation_time>300.0</dynamic_bias_correlation_time>
-                        </noise>
-                    </x>
-                    <y>
-                        <noise type="gaussian">
-                            <mean>0</mean>
-                            <stddev>1e-2</stddev>
-                            <bias_mean>0.1</bias_mean>
-                            <bias_stddev>0.001</bias_stddev>
-                            <dynamic_bias_stddev>0.002</dynamic_bias_stddev>
-                            <dynamic_bias_correlation_time>300.0</dynamic_bias_correlation_time>
-                        </noise>
-                    </y>
-                    <z>
-                        <noise type="gaussian">
-                            <mean>0</mean>
-                            <stddev>1e-2</stddev>
-                            <bias_mean>0.1</bias_mean>
-                            <bias_stddev>0.001</bias_stddev>
-                            <dynamic_bias_stddev>0.002</dynamic_bias_stddev>
-                            <dynamic_bias_correlation_time>300.0</dynamic_bias_correlation_time>
-                        </noise>
-                    </z>
-                </linear_acceleration>
-            </imu>
+                    <angular_velocity>
+                        <x>
+                            <noise type="gaussian">
+                                <mean>0</mean>
+                                <stddev>0.009</stddev>
+                                <bias_mean>0.00075</bias_mean>
+                                <bias_stddev>0.005</bias_stddev>
+                                <dynamic_bias_stddev>0.00002</dynamic_bias_stddev>
+                                <dynamic_bias_correlation_time>400.0</dynamic_bias_correlation_time>
+                                <precision>0.00025</precision>
+                            </noise>
+                        </x>
+                        <y>
+                            <noise type="gaussian">
+                                <mean>0</mean>
+                                <stddev>0.009</stddev>
+                                <bias_mean>0.00075</bias_mean>
+                                <bias_stddev>0.005</bias_stddev>
+                                <dynamic_bias_stddev>0.00002</dynamic_bias_stddev>
+                                <dynamic_bias_correlation_time>400.0</dynamic_bias_correlation_time>
+                                <precision>0.00025</precision>
+                            </noise>
+                        </y>
+                        <z>
+                            <noise type="gaussian">
+                                <mean>0</mean>
+                                <stddev>0.009</stddev>
+                                <bias_mean>0.00075</bias_mean>
+                                <bias_stddev>0.005</bias_stddev>
+                                <dynamic_bias_stddev>0.00002</dynamic_bias_stddev>
+                                <dynamic_bias_correlation_time>400.0</dynamic_bias_correlation_time>
+                                <precision>0.00025</precision>
+                            </noise>
+                        </z>
+                    </angular_velocity>
+                    <linear_acceleration>
+                        <x>
+                            <noise type="gaussian">
+                                <mean>0</mean>
+                                <stddev>0.021</stddev>
+                                <bias_mean>0.05</bias_mean>
+                                <bias_stddev>0.0075</bias_stddev>
+                                <dynamic_bias_stddev>0.000375</dynamic_bias_stddev>
+                                <dynamic_bias_correlation_time>175.0</dynamic_bias_correlation_time>
+                                <precision>0.005</precision>
+                            </noise>
+                        </x>
+                        <y>
+                            <noise type="gaussian">
+                                <mean>0</mean>
+                                <stddev>0.021</stddev>
+                                <bias_mean>0.05</bias_mean>
+                                <bias_stddev>0.0075</bias_stddev>
+                                <dynamic_bias_stddev>0.000375</dynamic_bias_stddev>
+                                <dynamic_bias_correlation_time>175.0</dynamic_bias_correlation_time>
+                                <precision>0.005</precision>
+                            </noise>
+                        </y>
+                        <z>
+                            <noise type="gaussian">
+                                <mean>0</mean>
+                                <stddev>0.021</stddev>
+                                <bias_mean>0.05</bias_mean>
+                                <bias_stddev>0.0075</bias_stddev>
+                                <dynamic_bias_stddev>0.000375</dynamic_bias_stddev>
+                                <dynamic_bias_correlation_time>175.0</dynamic_bias_correlation_time>
+                                <precision>0.005</precision>
+                            </noise>
+                        </z>
+                    </linear_acceleration>
+                </imu>
         </sensor>
         <sensor name="magnetometer_front" type="magnetometer">
             <always_on>1</always_on>
@@ -446,71 +452,77 @@
             <always_on>1</always_on>
             <update_rate>50</update_rate>
             <imu>
-                <angular_velocity>
-                    <x>
-                        <noise type="gaussian">
-                            <mean>0</mean>
-                            <stddev>2e-4</stddev>
-                            <bias_mean>0.0000075</bias_mean>
-                            <bias_stddev>0.0000008</bias_stddev>
-                            <dynamic_bias_stddev>0.0000004</dynamic_bias_stddev>
-                            <dynamic_bias_correlation_time>1000.0</dynamic_bias_correlation_time>
-                        </noise>
-                    </x>
-                    <y>
-                        <noise type="gaussian">
-                            <mean>0</mean>
-                            <stddev>2e-4</stddev>
-                            <bias_mean>0.0000075</bias_mean>
-                            <bias_stddev>0.0000008</bias_stddev>
-                            <dynamic_bias_stddev>0.0000004</dynamic_bias_stddev>
-                            <dynamic_bias_correlation_time>1000.0</dynamic_bias_correlation_time>
-                        </noise>
-                    </y>
-                    <z>
-                        <noise type="gaussian">
-                            <mean>0</mean>
-                            <stddev>2e-4</stddev>
-                            <bias_mean>0.0000075</bias_mean>
-                            <bias_stddev>0.0000008</bias_stddev>
-                            <dynamic_bias_stddev>0.0000004</dynamic_bias_stddev>
-                            <dynamic_bias_correlation_time>1000.0</dynamic_bias_correlation_time>
-                        </noise>
-                    </z>
-                </angular_velocity>
-                <linear_acceleration>
-                    <x>
-                        <noise type="gaussian">
-                            <mean>0</mean>
-                            <stddev>1e-2</stddev>
-                            <bias_mean>0.1</bias_mean>
-                            <bias_stddev>0.001</bias_stddev>
-                            <dynamic_bias_stddev>0.002</dynamic_bias_stddev>
-                            <dynamic_bias_correlation_time>300.0</dynamic_bias_correlation_time>
-                        </noise>
-                    </x>
-                    <y>
-                        <noise type="gaussian">
-                            <mean>0</mean>
-                            <stddev>1e-2</stddev>
-                            <bias_mean>0.1</bias_mean>
-                            <bias_stddev>0.001</bias_stddev>
-                            <dynamic_bias_stddev>0.002</dynamic_bias_stddev>
-                            <dynamic_bias_correlation_time>300.0</dynamic_bias_correlation_time>
-                        </noise>
-                    </y>
-                    <z>
-                        <noise type="gaussian">
-                            <mean>0</mean>
-                            <stddev>1e-2</stddev>
-                            <bias_mean>0.1</bias_mean>
-                            <bias_stddev>0.001</bias_stddev>
-                            <dynamic_bias_stddev>0.002</dynamic_bias_stddev>
-                            <dynamic_bias_correlation_time>300.0</dynamic_bias_correlation_time>
-                        </noise>
-                    </z>
-                </linear_acceleration>
-            </imu>
+                    <angular_velocity>
+                        <x>
+                            <noise type="gaussian">
+                                <mean>0</mean>
+                                <stddev>0.009</stddev>
+                                <bias_mean>0.00075</bias_mean>
+                                <bias_stddev>0.005</bias_stddev>
+                                <dynamic_bias_stddev>0.00002</dynamic_bias_stddev>
+                                <dynamic_bias_correlation_time>400.0</dynamic_bias_correlation_time>
+                                <precision>0.00025</precision>
+                            </noise>
+                        </x>
+                        <y>
+                            <noise type="gaussian">
+                                <mean>0</mean>
+                                <stddev>0.009</stddev>
+                                <bias_mean>0.00075</bias_mean>
+                                <bias_stddev>0.005</bias_stddev>
+                                <dynamic_bias_stddev>0.00002</dynamic_bias_stddev>
+                                <dynamic_bias_correlation_time>400.0</dynamic_bias_correlation_time>
+                                <precision>0.00025</precision>
+                            </noise>
+                        </y>
+                        <z>
+                            <noise type="gaussian">
+                                <mean>0</mean>
+                                <stddev>0.009</stddev>
+                                <bias_mean>0.00075</bias_mean>
+                                <bias_stddev>0.005</bias_stddev>
+                                <dynamic_bias_stddev>0.00002</dynamic_bias_stddev>
+                                <dynamic_bias_correlation_time>400.0</dynamic_bias_correlation_time>
+                                <precision>0.00025</precision>
+                            </noise>
+                        </z>
+                    </angular_velocity>
+                    <linear_acceleration>
+                        <x>
+                            <noise type="gaussian">
+                                <mean>0</mean>
+                                <stddev>0.021</stddev>
+                                <bias_mean>0.05</bias_mean>
+                                <bias_stddev>0.0075</bias_stddev>
+                                <dynamic_bias_stddev>0.000375</dynamic_bias_stddev>
+                                <dynamic_bias_correlation_time>175.0</dynamic_bias_correlation_time>
+                                <precision>0.005</precision>
+                            </noise>
+                        </x>
+                        <y>
+                            <noise type="gaussian">
+                                <mean>0</mean>
+                                <stddev>0.021</stddev>
+                                <bias_mean>0.05</bias_mean>
+                                <bias_stddev>0.0075</bias_stddev>
+                                <dynamic_bias_stddev>0.000375</dynamic_bias_stddev>
+                                <dynamic_bias_correlation_time>175.0</dynamic_bias_correlation_time>
+                                <precision>0.005</precision>
+                            </noise>
+                        </y>
+                        <z>
+                            <noise type="gaussian">
+                                <mean>0</mean>
+                                <stddev>0.021</stddev>
+                                <bias_mean>0.05</bias_mean>
+                                <bias_stddev>0.0075</bias_stddev>
+                                <dynamic_bias_stddev>0.000375</dynamic_bias_stddev>
+                                <dynamic_bias_correlation_time>175.0</dynamic_bias_correlation_time>
+                                <precision>0.005</precision>
+                            </noise>
+                        </z>
+                    </linear_acceleration>
+                </imu>
         </sensor>
         <sensor name="magnetometer_back" type="magnetometer">
             <always_on>1</always_on>

--- a/submitted_models/robotika_x2_sensor_config_1/model.sdf
+++ b/submitted_models/robotika_x2_sensor_config_1/model.sdf
@@ -157,31 +157,34 @@
                         <x>
                             <noise type="gaussian">
                                 <mean>0</mean>
-                                <stddev>2e-4</stddev>
-                                <bias_mean>0.0000075</bias_mean>
-                                <bias_stddev>0.0000008</bias_stddev>
-                                <dynamic_bias_stddev>0.0000004</dynamic_bias_stddev>
-                                <dynamic_bias_correlation_time>1000.0</dynamic_bias_correlation_time>
+                                <stddev>0.009</stddev>
+                                <bias_mean>0.00075</bias_mean>
+                                <bias_stddev>0.005</bias_stddev>
+                                <dynamic_bias_stddev>0.00002</dynamic_bias_stddev>
+                                <dynamic_bias_correlation_time>400.0</dynamic_bias_correlation_time>
+                                <precision>0.00025</precision>
                             </noise>
                         </x>
                         <y>
                             <noise type="gaussian">
                                 <mean>0</mean>
-                                <stddev>2e-4</stddev>
-                                <bias_mean>0.0000075</bias_mean>
-                                <bias_stddev>0.0000008</bias_stddev>
-                                <dynamic_bias_stddev>0.0000004</dynamic_bias_stddev>
-                                <dynamic_bias_correlation_time>1000.0</dynamic_bias_correlation_time>
+                                <stddev>0.009</stddev>
+                                <bias_mean>0.00075</bias_mean>
+                                <bias_stddev>0.005</bias_stddev>
+                                <dynamic_bias_stddev>0.00002</dynamic_bias_stddev>
+                                <dynamic_bias_correlation_time>400.0</dynamic_bias_correlation_time>
+                                <precision>0.00025</precision>
                             </noise>
                         </y>
                         <z>
                             <noise type="gaussian">
                                 <mean>0</mean>
-                                <stddev>2e-4</stddev>
-                                <bias_mean>0.0000075</bias_mean>
-                                <bias_stddev>0.0000008</bias_stddev>
-                                <dynamic_bias_stddev>0.0000004</dynamic_bias_stddev>
-                                <dynamic_bias_correlation_time>1000.0</dynamic_bias_correlation_time>
+                                <stddev>0.009</stddev>
+                                <bias_mean>0.00075</bias_mean>
+                                <bias_stddev>0.005</bias_stddev>
+                                <dynamic_bias_stddev>0.00002</dynamic_bias_stddev>
+                                <dynamic_bias_correlation_time>400.0</dynamic_bias_correlation_time>
+                                <precision>0.00025</precision>
                             </noise>
                         </z>
                     </angular_velocity>
@@ -189,31 +192,34 @@
                         <x>
                             <noise type="gaussian">
                                 <mean>0</mean>
-                                <stddev>1e-2</stddev>
-                                <bias_mean>0.1</bias_mean>
-                                <bias_stddev>0.001</bias_stddev>
-                                <dynamic_bias_stddev>0.002</dynamic_bias_stddev>
-                                <dynamic_bias_correlation_time>300.0</dynamic_bias_correlation_time>
+                                <stddev>0.021</stddev>
+                                <bias_mean>0.05</bias_mean>
+                                <bias_stddev>0.0075</bias_stddev>
+                                <dynamic_bias_stddev>0.000375</dynamic_bias_stddev>
+                                <dynamic_bias_correlation_time>175.0</dynamic_bias_correlation_time>
+                                <precision>0.005</precision>
                             </noise>
                         </x>
                         <y>
                             <noise type="gaussian">
                                 <mean>0</mean>
-                                <stddev>1e-2</stddev>
-                                <bias_mean>0.1</bias_mean>
-                                <bias_stddev>0.001</bias_stddev>
-                                <dynamic_bias_stddev>0.002</dynamic_bias_stddev>
-                                <dynamic_bias_correlation_time>300.0</dynamic_bias_correlation_time>
+                                <stddev>0.021</stddev>
+                                <bias_mean>0.05</bias_mean>
+                                <bias_stddev>0.0075</bias_stddev>
+                                <dynamic_bias_stddev>0.000375</dynamic_bias_stddev>
+                                <dynamic_bias_correlation_time>175.0</dynamic_bias_correlation_time>
+                                <precision>0.005</precision>
                             </noise>
                         </y>
                         <z>
                             <noise type="gaussian">
                                 <mean>0</mean>
-                                <stddev>1e-2</stddev>
-                                <bias_mean>0.1</bias_mean>
-                                <bias_stddev>0.001</bias_stddev>
-                                <dynamic_bias_stddev>0.002</dynamic_bias_stddev>
-                                <dynamic_bias_correlation_time>300.0</dynamic_bias_correlation_time>
+                                <stddev>0.021</stddev>
+                                <bias_mean>0.05</bias_mean>
+                                <bias_stddev>0.0075</bias_stddev>
+                                <dynamic_bias_stddev>0.000375</dynamic_bias_stddev>
+                                <dynamic_bias_correlation_time>175.0</dynamic_bias_correlation_time>
+                                <precision>0.005</precision>
                             </noise>
                         </z>
                     </linear_acceleration>

--- a/submitted_models/sophisticated_engineering_x2_sensor_config_1/model.sdf
+++ b/submitted_models/sophisticated_engineering_x2_sensor_config_1/model.sdf
@@ -157,31 +157,34 @@
                         <x>
                             <noise type="gaussian">
                                 <mean>0</mean>
-                                <stddev>2e-4</stddev>
-                                <bias_mean>0.0000075</bias_mean>
-                                <bias_stddev>0.0000008</bias_stddev>
-                                <dynamic_bias_stddev>0.0000004</dynamic_bias_stddev>
-                                <dynamic_bias_correlation_time>1000.0</dynamic_bias_correlation_time>
+                                <stddev>0.009</stddev>
+                                <bias_mean>0.00075</bias_mean>
+                                <bias_stddev>0.005</bias_stddev>
+                                <dynamic_bias_stddev>0.00002</dynamic_bias_stddev>
+                                <dynamic_bias_correlation_time>400.0</dynamic_bias_correlation_time>
+                                <precision>0.00025</precision>
                             </noise>
                         </x>
                         <y>
                             <noise type="gaussian">
                                 <mean>0</mean>
-                                <stddev>2e-4</stddev>
-                                <bias_mean>0.0000075</bias_mean>
-                                <bias_stddev>0.0000008</bias_stddev>
-                                <dynamic_bias_stddev>0.0000004</dynamic_bias_stddev>
-                                <dynamic_bias_correlation_time>1000.0</dynamic_bias_correlation_time>
+                                <stddev>0.009</stddev>
+                                <bias_mean>0.00075</bias_mean>
+                                <bias_stddev>0.005</bias_stddev>
+                                <dynamic_bias_stddev>0.00002</dynamic_bias_stddev>
+                                <dynamic_bias_correlation_time>400.0</dynamic_bias_correlation_time>
+                                <precision>0.00025</precision>
                             </noise>
                         </y>
                         <z>
                             <noise type="gaussian">
                                 <mean>0</mean>
-                                <stddev>2e-4</stddev>
-                                <bias_mean>0.0000075</bias_mean>
-                                <bias_stddev>0.0000008</bias_stddev>
-                                <dynamic_bias_stddev>0.0000004</dynamic_bias_stddev>
-                                <dynamic_bias_correlation_time>1000.0</dynamic_bias_correlation_time>
+                                <stddev>0.009</stddev>
+                                <bias_mean>0.00075</bias_mean>
+                                <bias_stddev>0.005</bias_stddev>
+                                <dynamic_bias_stddev>0.00002</dynamic_bias_stddev>
+                                <dynamic_bias_correlation_time>400.0</dynamic_bias_correlation_time>
+                                <precision>0.00025</precision>
                             </noise>
                         </z>
                     </angular_velocity>
@@ -189,31 +192,34 @@
                         <x>
                             <noise type="gaussian">
                                 <mean>0</mean>
-                                <stddev>1e-2</stddev>
-                                <bias_mean>0.1</bias_mean>
-                                <bias_stddev>0.001</bias_stddev>
-                                <dynamic_bias_stddev>0.002</dynamic_bias_stddev>
-                                <dynamic_bias_correlation_time>300.0</dynamic_bias_correlation_time>
+                                <stddev>0.021</stddev>
+                                <bias_mean>0.05</bias_mean>
+                                <bias_stddev>0.0075</bias_stddev>
+                                <dynamic_bias_stddev>0.000375</dynamic_bias_stddev>
+                                <dynamic_bias_correlation_time>175.0</dynamic_bias_correlation_time>
+                                <precision>0.005</precision>
                             </noise>
                         </x>
                         <y>
                             <noise type="gaussian">
                                 <mean>0</mean>
-                                <stddev>1e-2</stddev>
-                                <bias_mean>0.1</bias_mean>
-                                <bias_stddev>0.001</bias_stddev>
-                                <dynamic_bias_stddev>0.002</dynamic_bias_stddev>
-                                <dynamic_bias_correlation_time>300.0</dynamic_bias_correlation_time>
+                                <stddev>0.021</stddev>
+                                <bias_mean>0.05</bias_mean>
+                                <bias_stddev>0.0075</bias_stddev>
+                                <dynamic_bias_stddev>0.000375</dynamic_bias_stddev>
+                                <dynamic_bias_correlation_time>175.0</dynamic_bias_correlation_time>
+                                <precision>0.005</precision>
                             </noise>
                         </y>
                         <z>
                             <noise type="gaussian">
                                 <mean>0</mean>
-                                <stddev>1e-2</stddev>
-                                <bias_mean>0.1</bias_mean>
-                                <bias_stddev>0.001</bias_stddev>
-                                <dynamic_bias_stddev>0.002</dynamic_bias_stddev>
-                                <dynamic_bias_correlation_time>300.0</dynamic_bias_correlation_time>
+                                <stddev>0.021</stddev>
+                                <bias_mean>0.05</bias_mean>
+                                <bias_stddev>0.0075</bias_stddev>
+                                <dynamic_bias_stddev>0.000375</dynamic_bias_stddev>
+                                <dynamic_bias_correlation_time>175.0</dynamic_bias_correlation_time>
+                                <precision>0.005</precision>
                             </noise>
                         </z>
                     </linear_acceleration>

--- a/submitted_models/sophisticated_engineering_x4_sensor_config_1/model.sdf
+++ b/submitted_models/sophisticated_engineering_x4_sensor_config_1/model.sdf
@@ -151,31 +151,34 @@
                         <x>
                             <noise type="gaussian">
                                 <mean>0</mean>
-                                <stddev>2e-4</stddev>
-                                <bias_mean>0.0000075</bias_mean>
-                                <bias_stddev>0.0000008</bias_stddev>
-                                <dynamic_bias_stddev>0.0000004</dynamic_bias_stddev>
-                                <dynamic_bias_correlation_time>1000.0</dynamic_bias_correlation_time>
+                                <stddev>0.009</stddev>
+                                <bias_mean>0.00075</bias_mean>
+                                <bias_stddev>0.005</bias_stddev>
+                                <dynamic_bias_stddev>0.00002</dynamic_bias_stddev>
+                                <dynamic_bias_correlation_time>400.0</dynamic_bias_correlation_time>
+                                <precision>0.00025</precision>
                             </noise>
                         </x>
                         <y>
                             <noise type="gaussian">
                                 <mean>0</mean>
-                                <stddev>2e-4</stddev>
-                                <bias_mean>0.0000075</bias_mean>
-                                <bias_stddev>0.0000008</bias_stddev>
-                                <dynamic_bias_stddev>0.0000004</dynamic_bias_stddev>
-                                <dynamic_bias_correlation_time>1000.0</dynamic_bias_correlation_time>
+                                <stddev>0.009</stddev>
+                                <bias_mean>0.00075</bias_mean>
+                                <bias_stddev>0.005</bias_stddev>
+                                <dynamic_bias_stddev>0.00002</dynamic_bias_stddev>
+                                <dynamic_bias_correlation_time>400.0</dynamic_bias_correlation_time>
+                                <precision>0.00025</precision>
                             </noise>
                         </y>
                         <z>
                             <noise type="gaussian">
                                 <mean>0</mean>
-                                <stddev>2e-4</stddev>
-                                <bias_mean>0.0000075</bias_mean>
-                                <bias_stddev>0.0000008</bias_stddev>
-                                <dynamic_bias_stddev>0.0000004</dynamic_bias_stddev>
-                                <dynamic_bias_correlation_time>1000.0</dynamic_bias_correlation_time>
+                                <stddev>0.009</stddev>
+                                <bias_mean>0.00075</bias_mean>
+                                <bias_stddev>0.005</bias_stddev>
+                                <dynamic_bias_stddev>0.00002</dynamic_bias_stddev>
+                                <dynamic_bias_correlation_time>400.0</dynamic_bias_correlation_time>
+                                <precision>0.00025</precision>
                             </noise>
                         </z>
                     </angular_velocity>
@@ -183,31 +186,34 @@
                         <x>
                             <noise type="gaussian">
                                 <mean>0</mean>
-                                <stddev>1e-2</stddev>
-                                <bias_mean>0.1</bias_mean>
-                                <bias_stddev>0.001</bias_stddev>
-                                <dynamic_bias_stddev>0.002</dynamic_bias_stddev>
-                                <dynamic_bias_correlation_time>300.0</dynamic_bias_correlation_time>
+                                <stddev>0.021</stddev>
+                                <bias_mean>0.05</bias_mean>
+                                <bias_stddev>0.0075</bias_stddev>
+                                <dynamic_bias_stddev>0.000375</dynamic_bias_stddev>
+                                <dynamic_bias_correlation_time>175.0</dynamic_bias_correlation_time>
+                                <precision>0.005</precision>
                             </noise>
                         </x>
                         <y>
                             <noise type="gaussian">
                                 <mean>0</mean>
-                                <stddev>1e-2</stddev>
-                                <bias_mean>0.1</bias_mean>
-                                <bias_stddev>0.001</bias_stddev>
-                                <dynamic_bias_stddev>0.002</dynamic_bias_stddev>
-                                <dynamic_bias_correlation_time>300.0</dynamic_bias_correlation_time>
+                                <stddev>0.021</stddev>
+                                <bias_mean>0.05</bias_mean>
+                                <bias_stddev>0.0075</bias_stddev>
+                                <dynamic_bias_stddev>0.000375</dynamic_bias_stddev>
+                                <dynamic_bias_correlation_time>175.0</dynamic_bias_correlation_time>
+                                <precision>0.005</precision>
                             </noise>
                         </y>
                         <z>
                             <noise type="gaussian">
                                 <mean>0</mean>
-                                <stddev>1e-2</stddev>
-                                <bias_mean>0.1</bias_mean>
-                                <bias_stddev>0.001</bias_stddev>
-                                <dynamic_bias_stddev>0.002</dynamic_bias_stddev>
-                                <dynamic_bias_correlation_time>300.0</dynamic_bias_correlation_time>
+                                <stddev>0.021</stddev>
+                                <bias_mean>0.05</bias_mean>
+                                <bias_stddev>0.0075</bias_stddev>
+                                <dynamic_bias_stddev>0.000375</dynamic_bias_stddev>
+                                <dynamic_bias_correlation_time>175.0</dynamic_bias_correlation_time>
+                                <precision>0.005</precision>
                             </noise>
                         </z>
                     </linear_acceleration>

--- a/submitted_models/ssci_x2_sensor_config_1/model.sdf
+++ b/submitted_models/ssci_x2_sensor_config_1/model.sdf
@@ -157,31 +157,34 @@
                         <x>
                             <noise type="gaussian">
                                 <mean>0</mean>
-                                <stddev>2e-4</stddev>
-                                <bias_mean>0.0000075</bias_mean>
-                                <bias_stddev>0.0000008</bias_stddev>
-                                <dynamic_bias_stddev>0.0000004</dynamic_bias_stddev>
-                                <dynamic_bias_correlation_time>1000.0</dynamic_bias_correlation_time>
+                                <stddev>0.009</stddev>
+                                <bias_mean>0.00075</bias_mean>
+                                <bias_stddev>0.005</bias_stddev>
+                                <dynamic_bias_stddev>0.00002</dynamic_bias_stddev>
+                                <dynamic_bias_correlation_time>400.0</dynamic_bias_correlation_time>
+                                <precision>0.00025</precision>
                             </noise>
                         </x>
                         <y>
                             <noise type="gaussian">
                                 <mean>0</mean>
-                                <stddev>2e-4</stddev>
-                                <bias_mean>0.0000075</bias_mean>
-                                <bias_stddev>0.0000008</bias_stddev>
-                                <dynamic_bias_stddev>0.0000004</dynamic_bias_stddev>
-                                <dynamic_bias_correlation_time>1000.0</dynamic_bias_correlation_time>
+                                <stddev>0.009</stddev>
+                                <bias_mean>0.00075</bias_mean>
+                                <bias_stddev>0.005</bias_stddev>
+                                <dynamic_bias_stddev>0.00002</dynamic_bias_stddev>
+                                <dynamic_bias_correlation_time>400.0</dynamic_bias_correlation_time>
+                                <precision>0.00025</precision>
                             </noise>
                         </y>
                         <z>
                             <noise type="gaussian">
                                 <mean>0</mean>
-                                <stddev>2e-4</stddev>
-                                <bias_mean>0.0000075</bias_mean>
-                                <bias_stddev>0.0000008</bias_stddev>
-                                <dynamic_bias_stddev>0.0000004</dynamic_bias_stddev>
-                                <dynamic_bias_correlation_time>1000.0</dynamic_bias_correlation_time>
+                                <stddev>0.009</stddev>
+                                <bias_mean>0.00075</bias_mean>
+                                <bias_stddev>0.005</bias_stddev>
+                                <dynamic_bias_stddev>0.00002</dynamic_bias_stddev>
+                                <dynamic_bias_correlation_time>400.0</dynamic_bias_correlation_time>
+                                <precision>0.00025</precision>
                             </noise>
                         </z>
                     </angular_velocity>
@@ -189,31 +192,34 @@
                         <x>
                             <noise type="gaussian">
                                 <mean>0</mean>
-                                <stddev>1e-2</stddev>
-                                <bias_mean>0.1</bias_mean>
-                                <bias_stddev>0.001</bias_stddev>
-                                <dynamic_bias_stddev>0.002</dynamic_bias_stddev>
-                                <dynamic_bias_correlation_time>300.0</dynamic_bias_correlation_time>
+                                <stddev>0.021</stddev>
+                                <bias_mean>0.05</bias_mean>
+                                <bias_stddev>0.0075</bias_stddev>
+                                <dynamic_bias_stddev>0.000375</dynamic_bias_stddev>
+                                <dynamic_bias_correlation_time>175.0</dynamic_bias_correlation_time>
+                                <precision>0.005</precision>
                             </noise>
                         </x>
                         <y>
                             <noise type="gaussian">
                                 <mean>0</mean>
-                                <stddev>1e-2</stddev>
-                                <bias_mean>0.1</bias_mean>
-                                <bias_stddev>0.001</bias_stddev>
-                                <dynamic_bias_stddev>0.002</dynamic_bias_stddev>
-                                <dynamic_bias_correlation_time>300.0</dynamic_bias_correlation_time>
+                                <stddev>0.021</stddev>
+                                <bias_mean>0.05</bias_mean>
+                                <bias_stddev>0.0075</bias_stddev>
+                                <dynamic_bias_stddev>0.000375</dynamic_bias_stddev>
+                                <dynamic_bias_correlation_time>175.0</dynamic_bias_correlation_time>
+                                <precision>0.005</precision>
                             </noise>
                         </y>
                         <z>
                             <noise type="gaussian">
                                 <mean>0</mean>
-                                <stddev>1e-2</stddev>
-                                <bias_mean>0.1</bias_mean>
-                                <bias_stddev>0.001</bias_stddev>
-                                <dynamic_bias_stddev>0.002</dynamic_bias_stddev>
-                                <dynamic_bias_correlation_time>300.0</dynamic_bias_correlation_time>
+                                <stddev>0.021</stddev>
+                                <bias_mean>0.05</bias_mean>
+                                <bias_stddev>0.0075</bias_stddev>
+                                <dynamic_bias_stddev>0.000375</dynamic_bias_stddev>
+                                <dynamic_bias_correlation_time>175.0</dynamic_bias_correlation_time>
+                                <precision>0.005</precision>
                             </noise>
                         </z>
                     </linear_acceleration>

--- a/submitted_models/ssci_x4_sensor_config_1/model.sdf
+++ b/submitted_models/ssci_x4_sensor_config_1/model.sdf
@@ -149,31 +149,34 @@
                         <x>
                             <noise type="gaussian">
                                 <mean>0</mean>
-                                <stddev>2e-4</stddev>
-                                <bias_mean>0.0000075</bias_mean>
-                                <bias_stddev>0.0000008</bias_stddev>
-                                <dynamic_bias_stddev>0.0000004</dynamic_bias_stddev>
-                                <dynamic_bias_correlation_time>1000.0</dynamic_bias_correlation_time>
+                                <stddev>0.009</stddev>
+                                <bias_mean>0.00075</bias_mean>
+                                <bias_stddev>0.005</bias_stddev>
+                                <dynamic_bias_stddev>0.00002</dynamic_bias_stddev>
+                                <dynamic_bias_correlation_time>400.0</dynamic_bias_correlation_time>
+                                <precision>0.00025</precision>
                             </noise>
                         </x>
                         <y>
                             <noise type="gaussian">
                                 <mean>0</mean>
-                                <stddev>2e-4</stddev>
-                                <bias_mean>0.0000075</bias_mean>
-                                <bias_stddev>0.0000008</bias_stddev>
-                                <dynamic_bias_stddev>0.0000004</dynamic_bias_stddev>
-                                <dynamic_bias_correlation_time>1000.0</dynamic_bias_correlation_time>
+                                <stddev>0.009</stddev>
+                                <bias_mean>0.00075</bias_mean>
+                                <bias_stddev>0.005</bias_stddev>
+                                <dynamic_bias_stddev>0.00002</dynamic_bias_stddev>
+                                <dynamic_bias_correlation_time>400.0</dynamic_bias_correlation_time>
+                                <precision>0.00025</precision>
                             </noise>
                         </y>
                         <z>
                             <noise type="gaussian">
                                 <mean>0</mean>
-                                <stddev>2e-4</stddev>
-                                <bias_mean>0.0000075</bias_mean>
-                                <bias_stddev>0.0000008</bias_stddev>
-                                <dynamic_bias_stddev>0.0000004</dynamic_bias_stddev>
-                                <dynamic_bias_correlation_time>1000.0</dynamic_bias_correlation_time>
+                                <stddev>0.009</stddev>
+                                <bias_mean>0.00075</bias_mean>
+                                <bias_stddev>0.005</bias_stddev>
+                                <dynamic_bias_stddev>0.00002</dynamic_bias_stddev>
+                                <dynamic_bias_correlation_time>400.0</dynamic_bias_correlation_time>
+                                <precision>0.00025</precision>
                             </noise>
                         </z>
                     </angular_velocity>
@@ -181,31 +184,34 @@
                         <x>
                             <noise type="gaussian">
                                 <mean>0</mean>
-                                <stddev>1e-2</stddev>
-                                <bias_mean>0.1</bias_mean>
-                                <bias_stddev>0.001</bias_stddev>
-                                <dynamic_bias_stddev>0.002</dynamic_bias_stddev>
-                                <dynamic_bias_correlation_time>300.0</dynamic_bias_correlation_time>
+                                <stddev>0.021</stddev>
+                                <bias_mean>0.05</bias_mean>
+                                <bias_stddev>0.0075</bias_stddev>
+                                <dynamic_bias_stddev>0.000375</dynamic_bias_stddev>
+                                <dynamic_bias_correlation_time>175.0</dynamic_bias_correlation_time>
+                                <precision>0.005</precision>
                             </noise>
                         </x>
                         <y>
                             <noise type="gaussian">
                                 <mean>0</mean>
-                                <stddev>1e-2</stddev>
-                                <bias_mean>0.1</bias_mean>
-                                <bias_stddev>0.001</bias_stddev>
-                                <dynamic_bias_stddev>0.002</dynamic_bias_stddev>
-                                <dynamic_bias_correlation_time>300.0</dynamic_bias_correlation_time>
+                                <stddev>0.021</stddev>
+                                <bias_mean>0.05</bias_mean>
+                                <bias_stddev>0.0075</bias_stddev>
+                                <dynamic_bias_stddev>0.000375</dynamic_bias_stddev>
+                                <dynamic_bias_correlation_time>175.0</dynamic_bias_correlation_time>
+                                <precision>0.005</precision>
                             </noise>
                         </y>
                         <z>
                             <noise type="gaussian">
                                 <mean>0</mean>
-                                <stddev>1e-2</stddev>
-                                <bias_mean>0.1</bias_mean>
-                                <bias_stddev>0.001</bias_stddev>
-                                <dynamic_bias_stddev>0.002</dynamic_bias_stddev>
-                                <dynamic_bias_correlation_time>300.0</dynamic_bias_correlation_time>
+                                <stddev>0.021</stddev>
+                                <bias_mean>0.05</bias_mean>
+                                <bias_stddev>0.0075</bias_stddev>
+                                <dynamic_bias_stddev>0.000375</dynamic_bias_stddev>
+                                <dynamic_bias_correlation_time>175.0</dynamic_bias_correlation_time>
+                                <precision>0.005</precision>
                             </noise>
                         </z>
                     </linear_acceleration>

--- a/submitted_models/ssci_x4_sensor_config_2/model.sdf
+++ b/submitted_models/ssci_x4_sensor_config_2/model.sdf
@@ -149,31 +149,34 @@
                         <x>
                             <noise type="gaussian">
                                 <mean>0</mean>
-                                <stddev>2e-4</stddev>
-                                <bias_mean>0.0000075</bias_mean>
-                                <bias_stddev>0.0000008</bias_stddev>
-                                <dynamic_bias_stddev>0.0000004</dynamic_bias_stddev>
-                                <dynamic_bias_correlation_time>1000.0</dynamic_bias_correlation_time>
+                                <stddev>0.009</stddev>
+                                <bias_mean>0.00075</bias_mean>
+                                <bias_stddev>0.005</bias_stddev>
+                                <dynamic_bias_stddev>0.00002</dynamic_bias_stddev>
+                                <dynamic_bias_correlation_time>400.0</dynamic_bias_correlation_time>
+                                <precision>0.00025</precision>
                             </noise>
                         </x>
                         <y>
                             <noise type="gaussian">
                                 <mean>0</mean>
-                                <stddev>2e-4</stddev>
-                                <bias_mean>0.0000075</bias_mean>
-                                <bias_stddev>0.0000008</bias_stddev>
-                                <dynamic_bias_stddev>0.0000004</dynamic_bias_stddev>
-                                <dynamic_bias_correlation_time>1000.0</dynamic_bias_correlation_time>
+                                <stddev>0.009</stddev>
+                                <bias_mean>0.00075</bias_mean>
+                                <bias_stddev>0.005</bias_stddev>
+                                <dynamic_bias_stddev>0.00002</dynamic_bias_stddev>
+                                <dynamic_bias_correlation_time>400.0</dynamic_bias_correlation_time>
+                                <precision>0.00025</precision>
                             </noise>
                         </y>
                         <z>
                             <noise type="gaussian">
                                 <mean>0</mean>
-                                <stddev>2e-4</stddev>
-                                <bias_mean>0.0000075</bias_mean>
-                                <bias_stddev>0.0000008</bias_stddev>
-                                <dynamic_bias_stddev>0.0000004</dynamic_bias_stddev>
-                                <dynamic_bias_correlation_time>1000.0</dynamic_bias_correlation_time>
+                                <stddev>0.009</stddev>
+                                <bias_mean>0.00075</bias_mean>
+                                <bias_stddev>0.005</bias_stddev>
+                                <dynamic_bias_stddev>0.00002</dynamic_bias_stddev>
+                                <dynamic_bias_correlation_time>400.0</dynamic_bias_correlation_time>
+                                <precision>0.00025</precision>
                             </noise>
                         </z>
                     </angular_velocity>
@@ -181,31 +184,34 @@
                         <x>
                             <noise type="gaussian">
                                 <mean>0</mean>
-                                <stddev>1e-2</stddev>
-                                <bias_mean>0.1</bias_mean>
-                                <bias_stddev>0.001</bias_stddev>
-                                <dynamic_bias_stddev>0.002</dynamic_bias_stddev>
-                                <dynamic_bias_correlation_time>300.0</dynamic_bias_correlation_time>
+                                <stddev>0.021</stddev>
+                                <bias_mean>0.05</bias_mean>
+                                <bias_stddev>0.0075</bias_stddev>
+                                <dynamic_bias_stddev>0.000375</dynamic_bias_stddev>
+                                <dynamic_bias_correlation_time>175.0</dynamic_bias_correlation_time>
+                                <precision>0.005</precision>
                             </noise>
                         </x>
                         <y>
                             <noise type="gaussian">
                                 <mean>0</mean>
-                                <stddev>1e-2</stddev>
-                                <bias_mean>0.1</bias_mean>
-                                <bias_stddev>0.001</bias_stddev>
-                                <dynamic_bias_stddev>0.002</dynamic_bias_stddev>
-                                <dynamic_bias_correlation_time>300.0</dynamic_bias_correlation_time>
+                                <stddev>0.021</stddev>
+                                <bias_mean>0.05</bias_mean>
+                                <bias_stddev>0.0075</bias_stddev>
+                                <dynamic_bias_stddev>0.000375</dynamic_bias_stddev>
+                                <dynamic_bias_correlation_time>175.0</dynamic_bias_correlation_time>
+                                <precision>0.005</precision>
                             </noise>
                         </y>
                         <z>
                             <noise type="gaussian">
                                 <mean>0</mean>
-                                <stddev>1e-2</stddev>
-                                <bias_mean>0.1</bias_mean>
-                                <bias_stddev>0.001</bias_stddev>
-                                <dynamic_bias_stddev>0.002</dynamic_bias_stddev>
-                                <dynamic_bias_correlation_time>300.0</dynamic_bias_correlation_time>
+                                <stddev>0.021</stddev>
+                                <bias_mean>0.05</bias_mean>
+                                <bias_stddev>0.0075</bias_stddev>
+                                <dynamic_bias_stddev>0.000375</dynamic_bias_stddev>
+                                <dynamic_bias_correlation_time>175.0</dynamic_bias_correlation_time>
+                                <precision>0.005</precision>
                             </noise>
                         </z>
                     </linear_acceleration>

--- a/submitted_models/x1_sensor_config_6/model.sdf
+++ b/submitted_models/x1_sensor_config_6/model.sdf
@@ -240,31 +240,34 @@
                         <x>
                             <noise type="gaussian">
                                 <mean>0</mean>
-                                <stddev>2e-4</stddev>
-                                <bias_mean>0.0000075</bias_mean>
-                                <bias_stddev>0.0000008</bias_stddev>
-                                <dynamic_bias_stddev>0.0000004</dynamic_bias_stddev>
-                                <dynamic_bias_correlation_time>1000.0</dynamic_bias_correlation_time>
+                                <stddev>0.009</stddev>
+                                <bias_mean>0.00075</bias_mean>
+                                <bias_stddev>0.005</bias_stddev>
+                                <dynamic_bias_stddev>0.00002</dynamic_bias_stddev>
+				<dynamic_bias_correlation_time>400.0</dynamic_bias_correlation_time>
+				<precision>0.00025</precision>
                             </noise>
                         </x>
                         <y>
                             <noise type="gaussian">
                                 <mean>0</mean>
-                                <stddev>2e-4</stddev>
-                                <bias_mean>0.0000075</bias_mean>
-                                <bias_stddev>0.0000008</bias_stddev>
-                                <dynamic_bias_stddev>0.0000004</dynamic_bias_stddev>
-                                <dynamic_bias_correlation_time>1000.0</dynamic_bias_correlation_time>
+                                <stddev>0.009</stddev>
+                                <bias_mean>0.00075</bias_mean>
+                                <bias_stddev>0.005</bias_stddev>
+                                <dynamic_bias_stddev>0.00002</dynamic_bias_stddev>
+				<dynamic_bias_correlation_time>400.0</dynamic_bias_correlation_time>
+				<precision>0.00025</precision>
                             </noise>
                         </y>
                         <z>
                             <noise type="gaussian">
                                 <mean>0</mean>
-                                <stddev>2e-4</stddev>
-                                <bias_mean>0.0000075</bias_mean>
-                                <bias_stddev>0.0000008</bias_stddev>
-                                <dynamic_bias_stddev>0.0000004</dynamic_bias_stddev>
-                                <dynamic_bias_correlation_time>1000.0</dynamic_bias_correlation_time>
+                                <stddev>0.009</stddev>
+                                <bias_mean>0.00075</bias_mean>
+                                <bias_stddev>0.005</bias_stddev>
+                                <dynamic_bias_stddev>0.00002</dynamic_bias_stddev>
+				<dynamic_bias_correlation_time>400.0</dynamic_bias_correlation_time>
+				<precision>0.00025</precision>
                             </noise>
                         </z>
                     </angular_velocity>
@@ -272,31 +275,34 @@
                         <x>
                             <noise type="gaussian">
                                 <mean>0</mean>
-                                <stddev>1e-2</stddev>
-                                <bias_mean>0.1</bias_mean>
-                                <bias_stddev>0.001</bias_stddev>
-                                <dynamic_bias_stddev>0.002</dynamic_bias_stddev>
-                                <dynamic_bias_correlation_time>300.0</dynamic_bias_correlation_time>
+                                <stddev>0.021</stddev>
+                                <bias_mean>0.05</bias_mean>
+                                <bias_stddev>0.0075</bias_stddev>
+                                <dynamic_bias_stddev>0.000375</dynamic_bias_stddev>
+				<dynamic_bias_correlation_time>175.0</dynamic_bias_correlation_time>
+				<precision>0.005</precision>
                             </noise>
                         </x>
                         <y>
                             <noise type="gaussian">
                                 <mean>0</mean>
-                                <stddev>1e-2</stddev>
-                                <bias_mean>0.1</bias_mean>
-                                <bias_stddev>0.001</bias_stddev>
-                                <dynamic_bias_stddev>0.002</dynamic_bias_stddev>
-                                <dynamic_bias_correlation_time>300.0</dynamic_bias_correlation_time>
+                                <stddev>0.021</stddev>
+                                <bias_mean>0.05</bias_mean>
+                                <bias_stddev>0.0075</bias_stddev>
+                                <dynamic_bias_stddev>0.000375</dynamic_bias_stddev>
+				<dynamic_bias_correlation_time>175.0</dynamic_bias_correlation_time>
+				<precision>0.005</precision>
                             </noise>
                         </y>
                         <z>
                             <noise type="gaussian">
                                 <mean>0</mean>
-                                <stddev>1e-2</stddev>
-                                <bias_mean>0.1</bias_mean>
-                                <bias_stddev>0.001</bias_stddev>
-                                <dynamic_bias_stddev>0.002</dynamic_bias_stddev>
-                                <dynamic_bias_correlation_time>300.0</dynamic_bias_correlation_time>
+                                <stddev>0.021</stddev>
+                                <bias_mean>0.05</bias_mean>
+                                <bias_stddev>0.0075</bias_stddev>
+                                <dynamic_bias_stddev>0.000375</dynamic_bias_stddev>
+				<dynamic_bias_correlation_time>175.0</dynamic_bias_correlation_time>
+				<precision>0.005</precision>
                             </noise>
                         </z>
                     </linear_acceleration>

--- a/submitted_models/x2_sensor_config_7/model.sdf
+++ b/submitted_models/x2_sensor_config_7/model.sdf
@@ -148,36 +148,39 @@
             <sensor name="imu_sensor" type="imu">
                 <always_on>1</always_on>
                 <update_rate>50</update_rate>
-                <imu>
-                    <angular_velocity>
+		<imu>
+		<angular_velocity>
                         <x>
                             <noise type="gaussian">
                                 <mean>0</mean>
-                                <stddev>2e-4</stddev>
-                                <bias_mean>0.0000075</bias_mean>
-                                <bias_stddev>0.0000008</bias_stddev>
-                                <dynamic_bias_stddev>0.0000004</dynamic_bias_stddev>
-                                <dynamic_bias_correlation_time>1000.0</dynamic_bias_correlation_time>
+                                <stddev>0.009</stddev>
+                                <bias_mean>0.00075</bias_mean>
+                                <bias_stddev>0.005</bias_stddev>
+                                <dynamic_bias_stddev>0.00002</dynamic_bias_stddev>
+                                <dynamic_bias_correlation_time>400.0</dynamic_bias_correlation_time>
+                                <precision>0.00025</precision>
                             </noise>
                         </x>
                         <y>
                             <noise type="gaussian">
                                 <mean>0</mean>
-                                <stddev>2e-4</stddev>
-                                <bias_mean>0.0000075</bias_mean>
-                                <bias_stddev>0.0000008</bias_stddev>
-                                <dynamic_bias_stddev>0.0000004</dynamic_bias_stddev>
-                                <dynamic_bias_correlation_time>1000.0</dynamic_bias_correlation_time>
+                                <stddev>0.009</stddev>
+                                <bias_mean>0.00075</bias_mean>
+                                <bias_stddev>0.005</bias_stddev>
+                                <dynamic_bias_stddev>0.00002</dynamic_bias_stddev>
+                                <dynamic_bias_correlation_time>400.0</dynamic_bias_correlation_time>
+                                <precision>0.00025</precision>
                             </noise>
                         </y>
                         <z>
                             <noise type="gaussian">
                                 <mean>0</mean>
-                                <stddev>2e-4</stddev>
-                                <bias_mean>0.0000075</bias_mean>
-                                <bias_stddev>0.0000008</bias_stddev>
-                                <dynamic_bias_stddev>0.0000004</dynamic_bias_stddev>
-                                <dynamic_bias_correlation_time>1000.0</dynamic_bias_correlation_time>
+                                <stddev>0.009</stddev>
+                                <bias_mean>0.00075</bias_mean>
+                                <bias_stddev>0.005</bias_stddev>
+                                <dynamic_bias_stddev>0.00002</dynamic_bias_stddev>
+                                <dynamic_bias_correlation_time>400.0</dynamic_bias_correlation_time>
+                                <precision>0.00025</precision>
                             </noise>
                         </z>
                     </angular_velocity>
@@ -185,31 +188,34 @@
                         <x>
                             <noise type="gaussian">
                                 <mean>0</mean>
-                                <stddev>1e-2</stddev>
-                                <bias_mean>0.1</bias_mean>
-                                <bias_stddev>0.001</bias_stddev>
-                                <dynamic_bias_stddev>0.002</dynamic_bias_stddev>
-                                <dynamic_bias_correlation_time>300.0</dynamic_bias_correlation_time>
+                                <stddev>0.021</stddev>
+                                <bias_mean>0.05</bias_mean>
+                                <bias_stddev>0.0075</bias_stddev>
+                                <dynamic_bias_stddev>0.000375</dynamic_bias_stddev>
+                                <dynamic_bias_correlation_time>175.0</dynamic_bias_correlation_time>
+                                <precision>0.005</precision>
                             </noise>
                         </x>
                         <y>
                             <noise type="gaussian">
                                 <mean>0</mean>
-                                <stddev>1e-2</stddev>
-                                <bias_mean>0.1</bias_mean>
-                                <bias_stddev>0.001</bias_stddev>
-                                <dynamic_bias_stddev>0.002</dynamic_bias_stddev>
-                                <dynamic_bias_correlation_time>300.0</dynamic_bias_correlation_time>
+                                <stddev>0.021</stddev>
+                                <bias_mean>0.05</bias_mean>
+                                <bias_stddev>0.0075</bias_stddev>
+                                <dynamic_bias_stddev>0.000375</dynamic_bias_stddev>
+                                <dynamic_bias_correlation_time>175.0</dynamic_bias_correlation_time>
+                                <precision>0.005</precision>
                             </noise>
                         </y>
                         <z>
                             <noise type="gaussian">
                                 <mean>0</mean>
-                                <stddev>1e-2</stddev>
-                                <bias_mean>0.1</bias_mean>
-                                <bias_stddev>0.001</bias_stddev>
-                                <dynamic_bias_stddev>0.002</dynamic_bias_stddev>
-                                <dynamic_bias_correlation_time>300.0</dynamic_bias_correlation_time>
+                                <stddev>0.021</stddev>
+                                <bias_mean>0.05</bias_mean>
+                                <bias_stddev>0.0075</bias_stddev>
+                                <dynamic_bias_stddev>0.000375</dynamic_bias_stddev>
+                                <dynamic_bias_correlation_time>175.0</dynamic_bias_correlation_time>
+                                <precision>0.005</precision>
                             </noise>
                         </z>
                     </linear_acceleration>

--- a/submitted_models/x3_sensor_config_5/model.sdf
+++ b/submitted_models/x3_sensor_config_5/model.sdf
@@ -146,31 +146,34 @@
                         <x>
                             <noise type="gaussian">
                                 <mean>0</mean>
-                                <stddev>2e-4</stddev>
-                                <bias_mean>0.0000075</bias_mean>
-                                <bias_stddev>0.0000008</bias_stddev>
-                                <dynamic_bias_stddev>0.0000004</dynamic_bias_stddev>
-                                <dynamic_bias_correlation_time>1000.0</dynamic_bias_correlation_time>
+                                <stddev>0.009</stddev>
+                                <bias_mean>0.00075</bias_mean>
+                                <bias_stddev>0.005</bias_stddev>
+                                <dynamic_bias_stddev>0.00002</dynamic_bias_stddev>
+                                <dynamic_bias_correlation_time>400.0</dynamic_bias_correlation_time>
+                                <precision>0.00025</precision>
                             </noise>
                         </x>
                         <y>
                             <noise type="gaussian">
                                 <mean>0</mean>
-                                <stddev>2e-4</stddev>
-                                <bias_mean>0.0000075</bias_mean>
-                                <bias_stddev>0.0000008</bias_stddev>
-                                <dynamic_bias_stddev>0.0000004</dynamic_bias_stddev>
-                                <dynamic_bias_correlation_time>1000.0</dynamic_bias_correlation_time>
+                                <stddev>0.009</stddev>
+                                <bias_mean>0.00075</bias_mean>
+                                <bias_stddev>0.005</bias_stddev>
+                                <dynamic_bias_stddev>0.00002</dynamic_bias_stddev>
+                                <dynamic_bias_correlation_time>400.0</dynamic_bias_correlation_time>
+                                <precision>0.00025</precision>
                             </noise>
                         </y>
                         <z>
                             <noise type="gaussian">
                                 <mean>0</mean>
-                                <stddev>2e-4</stddev>
-                                <bias_mean>0.0000075</bias_mean>
-                                <bias_stddev>0.0000008</bias_stddev>
-                                <dynamic_bias_stddev>0.0000004</dynamic_bias_stddev>
-                                <dynamic_bias_correlation_time>1000.0</dynamic_bias_correlation_time>
+                                <stddev>0.009</stddev>
+                                <bias_mean>0.00075</bias_mean>
+                                <bias_stddev>0.005</bias_stddev>
+                                <dynamic_bias_stddev>0.00002</dynamic_bias_stddev>
+                                <dynamic_bias_correlation_time>400.0</dynamic_bias_correlation_time>
+                                <precision>0.00025</precision>
                             </noise>
                         </z>
                     </angular_velocity>
@@ -178,31 +181,34 @@
                         <x>
                             <noise type="gaussian">
                                 <mean>0</mean>
-                                <stddev>1e-2</stddev>
-                                <bias_mean>0.1</bias_mean>
-                                <bias_stddev>0.001</bias_stddev>
-                                <dynamic_bias_stddev>0.002</dynamic_bias_stddev>
-                                <dynamic_bias_correlation_time>300.0</dynamic_bias_correlation_time>
+                                <stddev>0.021</stddev>
+                                <bias_mean>0.05</bias_mean>
+                                <bias_stddev>0.0075</bias_stddev>
+                                <dynamic_bias_stddev>0.000375</dynamic_bias_stddev>
+                                <dynamic_bias_correlation_time>175.0</dynamic_bias_correlation_time>
+                                <precision>0.005</precision>
                             </noise>
                         </x>
                         <y>
                             <noise type="gaussian">
                                 <mean>0</mean>
-                                <stddev>1e-2</stddev>
-                                <bias_mean>0.1</bias_mean>
-                                <bias_stddev>0.001</bias_stddev>
-                                <dynamic_bias_stddev>0.002</dynamic_bias_stddev>
-                                <dynamic_bias_correlation_time>300.0</dynamic_bias_correlation_time>
+                                <stddev>0.021</stddev>
+                                <bias_mean>0.05</bias_mean>
+                                <bias_stddev>0.0075</bias_stddev>
+                                <dynamic_bias_stddev>0.000375</dynamic_bias_stddev>
+                                <dynamic_bias_correlation_time>175.0</dynamic_bias_correlation_time>
+                                <precision>0.005</precision>
                             </noise>
                         </y>
                         <z>
                             <noise type="gaussian">
                                 <mean>0</mean>
-                                <stddev>1e-2</stddev>
-                                <bias_mean>0.1</bias_mean>
-                                <bias_stddev>0.001</bias_stddev>
-                                <dynamic_bias_stddev>0.002</dynamic_bias_stddev>
-                                <dynamic_bias_correlation_time>300.0</dynamic_bias_correlation_time>
+                                <stddev>0.021</stddev>
+                                <bias_mean>0.05</bias_mean>
+                                <bias_stddev>0.0075</bias_stddev>
+                                <dynamic_bias_stddev>0.000375</dynamic_bias_stddev>
+                                <dynamic_bias_correlation_time>175.0</dynamic_bias_correlation_time>
+                                <precision>0.005</precision>
                             </noise>
                         </z>
                     </linear_acceleration>

--- a/submitted_models/x4_sensor_config_6/model.sdf
+++ b/submitted_models/x4_sensor_config_6/model.sdf
@@ -149,31 +149,34 @@
                         <x>
                             <noise type="gaussian">
                                 <mean>0</mean>
-                                <stddev>2e-4</stddev>
-                                <bias_mean>0.0000075</bias_mean>
-                                <bias_stddev>0.0000008</bias_stddev>
-                                <dynamic_bias_stddev>0.0000004</dynamic_bias_stddev>
-                                <dynamic_bias_correlation_time>1000.0</dynamic_bias_correlation_time>
+                                <stddev>0.009</stddev>
+                                <bias_mean>0.00075</bias_mean>
+                                <bias_stddev>0.005</bias_stddev>
+                                <dynamic_bias_stddev>0.00002</dynamic_bias_stddev>
+                                <dynamic_bias_correlation_time>400.0</dynamic_bias_correlation_time>
+                                <precision>0.00025</precision>
                             </noise>
                         </x>
                         <y>
                             <noise type="gaussian">
                                 <mean>0</mean>
-                                <stddev>2e-4</stddev>
-                                <bias_mean>0.0000075</bias_mean>
-                                <bias_stddev>0.0000008</bias_stddev>
-                                <dynamic_bias_stddev>0.0000004</dynamic_bias_stddev>
-                                <dynamic_bias_correlation_time>1000.0</dynamic_bias_correlation_time>
+                                <stddev>0.009</stddev>
+                                <bias_mean>0.00075</bias_mean>
+                                <bias_stddev>0.005</bias_stddev>
+                                <dynamic_bias_stddev>0.00002</dynamic_bias_stddev>
+                                <dynamic_bias_correlation_time>400.0</dynamic_bias_correlation_time>
+                                <precision>0.00025</precision>
                             </noise>
                         </y>
                         <z>
                             <noise type="gaussian">
                                 <mean>0</mean>
-                                <stddev>2e-4</stddev>
-                                <bias_mean>0.0000075</bias_mean>
-                                <bias_stddev>0.0000008</bias_stddev>
-                                <dynamic_bias_stddev>0.0000004</dynamic_bias_stddev>
-                                <dynamic_bias_correlation_time>1000.0</dynamic_bias_correlation_time>
+                                <stddev>0.009</stddev>
+                                <bias_mean>0.00075</bias_mean>
+                                <bias_stddev>0.005</bias_stddev>
+                                <dynamic_bias_stddev>0.00002</dynamic_bias_stddev>
+                                <dynamic_bias_correlation_time>400.0</dynamic_bias_correlation_time>
+                                <precision>0.00025</precision>
                             </noise>
                         </z>
                     </angular_velocity>
@@ -181,31 +184,34 @@
                         <x>
                             <noise type="gaussian">
                                 <mean>0</mean>
-                                <stddev>1e-2</stddev>
-                                <bias_mean>0.1</bias_mean>
-                                <bias_stddev>0.001</bias_stddev>
-                                <dynamic_bias_stddev>0.002</dynamic_bias_stddev>
-                                <dynamic_bias_correlation_time>300.0</dynamic_bias_correlation_time>
+                                <stddev>0.021</stddev>
+                                <bias_mean>0.05</bias_mean>
+                                <bias_stddev>0.0075</bias_stddev>
+                                <dynamic_bias_stddev>0.000375</dynamic_bias_stddev>
+                                <dynamic_bias_correlation_time>175.0</dynamic_bias_correlation_time>
+                                <precision>0.005</precision>
                             </noise>
                         </x>
                         <y>
                             <noise type="gaussian">
                                 <mean>0</mean>
-                                <stddev>1e-2</stddev>
-                                <bias_mean>0.1</bias_mean>
-                                <bias_stddev>0.001</bias_stddev>
-                                <dynamic_bias_stddev>0.002</dynamic_bias_stddev>
-                                <dynamic_bias_correlation_time>300.0</dynamic_bias_correlation_time>
+                                <stddev>0.021</stddev>
+                                <bias_mean>0.05</bias_mean>
+                                <bias_stddev>0.0075</bias_stddev>
+                                <dynamic_bias_stddev>0.000375</dynamic_bias_stddev>
+                                <dynamic_bias_correlation_time>175.0</dynamic_bias_correlation_time>
+                                <precision>0.005</precision>
                             </noise>
                         </y>
                         <z>
                             <noise type="gaussian">
                                 <mean>0</mean>
-                                <stddev>1e-2</stddev>
-                                <bias_mean>0.1</bias_mean>
-                                <bias_stddev>0.001</bias_stddev>
-                                <dynamic_bias_stddev>0.002</dynamic_bias_stddev>
-                                <dynamic_bias_correlation_time>300.0</dynamic_bias_correlation_time>
+                                <stddev>0.021</stddev>
+                                <bias_mean>0.05</bias_mean>
+                                <bias_stddev>0.0075</bias_stddev>
+                                <dynamic_bias_stddev>0.000375</dynamic_bias_stddev>
+                                <dynamic_bias_correlation_time>175.0</dynamic_bias_correlation_time>
+                                <precision>0.005</precision>
                             </noise>
                         </z>
                     </linear_acceleration>


### PR DESCRIPTION
This pull request updates the IMU noise model for all robots in the SubT Tech Repo. In the interest of advancing the real-world relevance of software developments in the Virtual Competition, the new IMU noise model parameters have been derived from a representative range of IMUs used in field robotics. 

A combination of datasheets and research literature informed the selected parameters including the empirically determined parameters derived in the following paper for low- and high-cost IMUs:
Gonzalez, R.; Dabove, P. Performance Assessment of an Ultra Low-Cost Inertial Measurement Unit for Ground Vehicle Navigation. Sensors 2019, 19, 3865. https://doi.org/10.3390/s19183865