### PR TITLE
Add breadcrumb remaining ROS topic

### DIFF
--- a/submitted_models/cerberus_anymal_b_sensor_config_1/launch/vehicle_topics.launch
+++ b/submitted_models/cerberus_anymal_b_sensor_config_1/launch/vehicle_topics.launch
@@ -195,6 +195,13 @@
         args="/model/$(arg name)/breadcrumb/deploy@std_msgs/Empty]ignition.msgs.Empty">
         <remap from="/model/$(arg name)/breadcrumb/deploy" to="breadcrumb/deploy"/>
       </node>
+      <node
+        pkg="ros_ign_bridge"
+        type="parameter_bridge"
+        name="ros_ign_bridge_breadcrumbs_remaining"
+        args="/model/$(arg name)/breadcrumb/deploy/remaining@std_msgs/Int32[ignition.msgs.Int32">
+        <remap from="/model/$(arg name)/breadcrumb/deploy/remaining" to="breadcrumb/remaining"/>
+      </node>
     </group>
 
   </group>

--- a/submitted_models/cerberus_anymal_c_sensor_config_1/launch/vehicle_topics.launch
+++ b/submitted_models/cerberus_anymal_c_sensor_config_1/launch/vehicle_topics.launch
@@ -301,6 +301,13 @@
         args="/model/$(arg name)/breadcrumb/deploy@std_msgs/Empty]ignition.msgs.Empty">
         <remap from="/model/$(arg name)/breadcrumb/deploy" to="breadcrumb/deploy"/>
       </node>
+      <node
+        pkg="ros_ign_bridge"
+        type="parameter_bridge"
+        name="ros_ign_bridge_breadcrumbs_remaining"
+        args="/model/$(arg name)/breadcrumb/deploy/remaining@std_msgs/Int32[ignition.msgs.Int32">
+        <remap from="/model/$(arg name)/breadcrumb/deploy/remaining" to="breadcrumb/remaining"/>
+      </node>
     </group>
 
   </group>

--- a/submitted_models/costar_husky_sensor_config_2/launch/vehicle_topics.launch
+++ b/submitted_models/costar_husky_sensor_config_2/launch/vehicle_topics.launch
@@ -143,6 +143,13 @@
       args="/model/$(arg name)/breadcrumb/deploy@std_msgs/Empty]ignition.msgs.Empty">
       <remap from="/model/$(arg name)/breadcrumb/deploy" to="breadcrumb/deploy"/>
     </node>
+    <node
+      pkg="ros_ign_bridge"
+      type="parameter_bridge"
+      name="ros_ign_bridge_breadcrumbs_remaining"
+      args="/model/$(arg name)/breadcrumb/deploy/remaining@std_msgs/Int32[ignition.msgs.Int32">
+      <remap from="/model/$(arg name)/breadcrumb/deploy/remaining" to="breadcrumb/remaining"/>
+    </node>
 
   </group>
 </launch>

--- a/submitted_models/csiro_data61_dtr_sensor_config_1/launch/vehicle_topics.launch
+++ b/submitted_models/csiro_data61_dtr_sensor_config_1/launch/vehicle_topics.launch
@@ -196,6 +196,13 @@
         args="/model/$(arg name)/breadcrumb/deploy@std_msgs/Empty]ignition.msgs.Empty">
         <remap from="/model/$(arg name)/breadcrumb/deploy" to="breadcrumb/deploy"/>
       </node>
+      <node
+        pkg="ros_ign_bridge"
+        type="parameter_bridge"
+        name="ros_ign_bridge_breadcrumbs_remaining"
+        args="/model/$(arg name)/breadcrumb/deploy/remaining@std_msgs/Int32[ignition.msgs.Int32">
+        <remap from="/model/$(arg name)/breadcrumb/deploy/remaining" to="breadcrumb/remaining"/>
+      </node>
     </group>
 
     <!-- Gas sensor -->

--- a/submitted_models/csiro_data61_ozbot_atr_sensor_config_1/launch/vehicle_topics.launch
+++ b/submitted_models/csiro_data61_ozbot_atr_sensor_config_1/launch/vehicle_topics.launch
@@ -197,6 +197,13 @@
         args="/model/$(arg name)/breadcrumb/deploy@std_msgs/Empty]ignition.msgs.Empty">
         <remap from="/model/$(arg name)/breadcrumb/deploy" to="breadcrumb/deploy"/>
       </node>
+      <node
+        pkg="ros_ign_bridge"
+        type="parameter_bridge"
+        name="ros_ign_bridge_breadcrumbs_remaining"
+        args="/model/$(arg name)/breadcrumb/deploy/remaining@std_msgs/Int32[ignition.msgs.Int32">
+        <remap from="/model/$(arg name)/breadcrumb/deploy/remaining" to="breadcrumb/remaining"/>
+      </node>
     </group>
 
     <!-- Gas sensor -->

--- a/submitted_models/ctu_cras_norlab_absolem_sensor_config_1/launch/vehicle_topics.launch
+++ b/submitted_models/ctu_cras_norlab_absolem_sensor_config_1/launch/vehicle_topics.launch
@@ -412,7 +412,14 @@
         args="/model/$(arg name)/breadcrumb/deploy@std_msgs/Empty]ignition.msgs.Empty">
         <remap from="/model/$(arg name)/breadcrumb/deploy" to="breadcrumb/deploy"/>
       </node>
+      <node
+        pkg="ros_ign_bridge"
+        type="parameter_bridge"
+        name="ros_ign_bridge_breadcrumbs_remaining"
+        args="/model/$(arg name)/breadcrumb/deploy/remaining@std_msgs/Int32[ignition.msgs.Int32">
+        <remap from="/model/$(arg name)/breadcrumb/deploy/remaining" to="breadcrumb/remaining"/>
+      </node>
     </group>
   </group>
-  
+
 </launch>

--- a/submitted_models/explorer_r2_sensor_config_1/launch/vehicle_topics.launch
+++ b/submitted_models/explorer_r2_sensor_config_1/launch/vehicle_topics.launch
@@ -316,6 +316,13 @@
         args="/model/$(arg name)/breadcrumb/deploy@std_msgs/Empty]ignition.msgs.Empty">
         <remap from="/model/$(arg name)/breadcrumb/deploy" to="breadcrumb/deploy"/>
       </node>
+      <node
+        pkg="ros_ign_bridge"
+        type="parameter_bridge"
+        name="ros_ign_bridge_breadcrumbs_remaining"
+        args="/model/$(arg name)/breadcrumb/deploy/remaining@std_msgs/Int32[ignition.msgs.Int32">
+        <remap from="/model/$(arg name)/breadcrumb/deploy/remaining" to="breadcrumb/remaining"/>
+      </node>
     </group>
   </group>
 </launch>

--- a/submitted_models/explorer_r3_sensor_config_1/launch/vehicle_topics.launch
+++ b/submitted_models/explorer_r3_sensor_config_1/launch/vehicle_topics.launch
@@ -315,6 +315,13 @@
         args="/model/$(arg name)/breadcrumb/deploy@std_msgs/Empty]ignition.msgs.Empty">
         <remap from="/model/$(arg name)/breadcrumb/deploy" to="breadcrumb/deploy"/>
       </node>
+      <node
+        pkg="ros_ign_bridge"
+        type="parameter_bridge"
+        name="ros_ign_bridge_breadcrumbs_remaining"
+        args="/model/$(arg name)/breadcrumb/deploy/remaining@std_msgs/Int32[ignition.msgs.Int32">
+        <remap from="/model/$(arg name)/breadcrumb/deploy/remaining" to="breadcrumb/remaining"/>
+      </node>
     </group>
   </group>
 </launch>

--- a/submitted_models/explorer_x1_sensor_config_2/launch/vehicle_topics.launch
+++ b/submitted_models/explorer_x1_sensor_config_2/launch/vehicle_topics.launch
@@ -325,6 +325,13 @@
       args="/model/$(arg name)/breadcrumb/deploy@std_msgs/Empty]ignition.msgs.Empty">
       <remap from="/model/$(arg name)/breadcrumb/deploy" to="breadcrumb/deploy"/>
     </node>
+    <node
+      pkg="ros_ign_bridge"
+      type="parameter_bridge"
+      name="ros_ign_bridge_breadcrumbs_remaining"
+      args="/model/$(arg name)/breadcrumb/deploy/remaining@std_msgs/Int32[ignition.msgs.Int32">
+      <remap from="/model/$(arg name)/breadcrumb/deploy/remaining" to="breadcrumb/remaining"/>
+    </node>
 
   </group>
 </launch>

--- a/submitted_models/marble_hd2_sensor_config_1/launch/vehicle_topics.launch
+++ b/submitted_models/marble_hd2_sensor_config_1/launch/vehicle_topics.launch
@@ -293,6 +293,13 @@
         args="/model/$(arg name)/breadcrumb/deploy@std_msgs/Empty]ignition.msgs.Empty">
         <remap from="/model/$(arg name)/breadcrumb/deploy" to="breadcrumb/deploy"/>
       </node>
+      <node
+        pkg="ros_ign_bridge"
+        type="parameter_bridge"
+        name="ros_ign_bridge_breadcrumbs_remaining"
+        args="/model/$(arg name)/breadcrumb/deploy/remaining@std_msgs/Int32[ignition.msgs.Int32">
+        <remap from="/model/$(arg name)/breadcrumb/deploy/remaining" to="breadcrumb/remaining"/>
+      </node>
     </group>
   </group>
 </launch>

--- a/submitted_models/marble_husky_sensor_config_1/launch/vehicle_topics.launch
+++ b/submitted_models/marble_husky_sensor_config_1/launch/vehicle_topics.launch
@@ -296,6 +296,13 @@
         args="/model/$(arg name)/breadcrumb/deploy@std_msgs/Empty]ignition.msgs.Empty">
         <remap from="/model/$(arg name)/breadcrumb/deploy" to="breadcrumb/deploy"/>
       </node>
+      <node
+        pkg="ros_ign_bridge"
+        type="parameter_bridge"
+        name="ros_ign_bridge_breadcrumbs_remaining"
+        args="/model/$(arg name)/breadcrumb/deploy/remaining@std_msgs/Int32[ignition.msgs.Int32">
+        <remap from="/model/$(arg name)/breadcrumb/deploy/remaining" to="breadcrumb/remaining"/>
+      </node>
     </group>
   </group>
 </launch>

--- a/submitted_models/robotika_freyja_sensor_config_1/launch/vehicle_topics.launch
+++ b/submitted_models/robotika_freyja_sensor_config_1/launch/vehicle_topics.launch
@@ -272,6 +272,13 @@
         args="/model/$(arg name)/breadcrumb/deploy@std_msgs/Empty]ignition.msgs.Empty">
         <remap from="/model/$(arg name)/breadcrumb/deploy" to="breadcrumb/deploy"/>
       </node>
+      <node
+        pkg="ros_ign_bridge"
+        type="parameter_bridge"
+        name="ros_ign_bridge_breadcrumbs_remaining"
+        args="/model/$(arg name)/breadcrumb/deploy/remaining@std_msgs/Int32[ignition.msgs.Int32">
+        <remap from="/model/$(arg name)/breadcrumb/deploy/remaining" to="breadcrumb/remaining"/>
+      </node>
     </group>
   </group>
 </launch>

--- a/submitted_models/robotika_kloubak_sensor_config_1/launch/vehicle_topics.launch
+++ b/submitted_models/robotika_kloubak_sensor_config_1/launch/vehicle_topics.launch
@@ -287,6 +287,13 @@
         args="/model/$(arg name)/breadcrumb/deploy@std_msgs/Empty]ignition.msgs.Empty">
         <remap from="/model/$(arg name)/breadcrumb/deploy" to="breadcrumb/deploy"/>
       </node>
+      <node
+        pkg="ros_ign_bridge"
+        type="parameter_bridge"
+        name="ros_ign_bridge_breadcrumbs_remaining"
+        args="/model/$(arg name)/breadcrumb/deploy/remaining@std_msgs/Int32[ignition.msgs.Int32">
+        <remap from="/model/$(arg name)/breadcrumb/deploy/remaining" to="breadcrumb/remaining"/>
+      </node>
     </group>
   </group>
 </launch>

--- a/subt_ros/launch/vehicle_topics.launch
+++ b/subt_ros/launch/vehicle_topics.launch
@@ -255,6 +255,13 @@
           args="/model/$(arg name)/breadcrumb/deploy@std_msgs/Empty]ignition.msgs.Empty">
           <remap from="/model/$(arg name)/breadcrumb/deploy" to="breadcrumb/deploy"/>
         </node>
+        <node
+          pkg="ros_ign_bridge"
+          type="parameter_bridge"
+          name="ros_ign_bridge_breadcrumbs_remaining"
+          args="/model/$(arg name)/breadcrumb/deploy/remaining@std_msgs/Int32[ignition.msgs.Int32">
+          <remap from="/model/$(arg name)/breadcrumb/deploy/remaining" to="breadcrumb/remaining"/>
+        </node>
       </group>
     </group>
 


### PR DESCRIPTION
depends on https://github.com/ignitionrobotics/ros_ign/pull/138

workaround for https://github.com/osrf/subt/issues/655

This adds a `/<model>/breadcrumb/remaining` ROS topic that outputs the number of breadcrumbs remaining.

To test:

In one terminal, launch ign gazebo:

```
ign launch -v 4 competition.ign worldName:=finals_qual circuit:=finals robotName1:=X1 robotConfig1:=X1_SENSOR_CONFIG_7
```

In another terminal, echo the breadcrumb remaining topic:

```
rostopic echo /X1/breadcrumb/remaining
```

In a third terminal, publish a message to deploy the breadcrumb:

```
ign topic -t "/model/X1/breadcrumb/deploy" -m ignition.msgs.Empty -p "unused: true"
```

Go back to the 2nd terminal, you should see a new msg received showing the number of breadcrumbs remaining:

```
data: 11
---
```

Signed-off-by: Ian Chen <ichen@osrfoundation.org>