### PR TITLE
Fix segfault when a robot with flippers is a part of the world at startup

### DIFF
--- a/submitted_models/ctu_cras_norlab_absolem_sensor_config_1/src/flipper_control_plugin.cpp
+++ b/submitted_models/ctu_cras_norlab_absolem_sensor_config_1/src/flipper_control_plugin.cpp
@@ -127,7 +127,7 @@ class FlipperControlPlugin : public System, public ISystemConfigure, public ISys
         if (this->angularSpeed != 0.0 && velocity == 0.0)
         {
           auto pos = _ecm.Component<components::JointPosition>(this->joint);
-          if (pos)
+          if (pos && !pos->Data().empty())
           {
             this->staticAngle = pos->Data()[0];
           }
@@ -154,7 +154,7 @@ class FlipperControlPlugin : public System, public ISystemConfigure, public ISys
   // does not drift over time.
   protected: void correctStaticAnglePosition(const Entity& joint, const math::Angle& staticPos, EntityComponentManager& _ecm) {
     auto pos = _ecm.Component<components::JointPosition>(this->joint);
-    if (!pos)
+    if (!pos || pos->Data().empty())
       return;
 
     const math::Angle currentPos{pos->Data()[0]};


### PR DESCRIPTION
When I create a simple world with CTU_CRAS_NORLAB_ABSOLEM_SENSOR_CONFIG_1 included using the `<include>` SDF tag, gazebo segfaults. I tracked it down to the pose component being present but empty (probably a startup sequence issue, that's why it didn't manifest in SubT, because the robots are spawned into an existing world, as opposed to my case when the robot is a part of the world from the beginning). This PR adds additional checks to make sure empty pose component is skipped.