### PR TITLE
Add model.sdf files for robot models with a thermal camera

### DIFF
--- a/submitted_models/cerberus_m100_sensor_config_2/README.md
+++ b/submitted_models/cerberus_m100_sensor_config_2/README.md
@@ -2,4 +2,5 @@ This package spawns a `CERBERUS_M100_SENSOR_CONFIG_1` model with an additional
 thermal camera
 
 The `model.sdf` is not used but added here as a reference to show what is on
-the SubT Tech Repo. Please keep this `model.sdf` update-to-date
+the SubT Tech Repo. Please keep this `model.sdf` update-to-date with
+`CERBERUS_M100_SENSOR_CONFIG_1`

--- a/submitted_models/cerberus_m100_sensor_config_2/README.md
+++ b/submitted_models/cerberus_m100_sensor_config_2/README.md
@@ -1,4 +1,4 @@
-This package spawns a `MARBLE_HD2_SENSOR_CONFIG_1` model with an additional
+This package spawns a `CERBERUS_M100_SENSOR_CONFIG_1` model with an additional
 thermal camera
 
 The `model.sdf` is not used but added here as a reference to show what is on

--- a/submitted_models/cerberus_m100_sensor_config_2/model.sdf
+++ b/submitted_models/cerberus_m100_sensor_config_2/model.sdf
@@ -1,0 +1,608 @@
+<?xml version="1.0"?>
+<sdf version="1.6">
+    <model name="M100">
+        <pose>0 0 0.121078 0 0 0</pose>
+        <link name="base_link">
+            <pose frame="">0 0 0 0 -0 0</pose>
+            <inertial>
+                <pose frame="">0 0 0 0 -0 0</pose>
+                <mass>3.76</mass> <!--4.10-->
+                <inertia>
+                    <ixx>0.017</ixx>
+                    <ixy>0</ixy>
+                    <ixz>0</ixz>
+                    <iyy>0.018</iyy>
+                    <iyz>0</iyz>
+                    <izz>0.028</izz>
+                </inertia>
+            </inertial>
+            <collision name="base_link_inertia_collision">
+                <pose frame="">0 0 0 0 -0 0</pose>
+                <geometry>
+                    <box>
+                        <size>0.82 0.82 0.375</size>
+                    </box>
+                </geometry>
+            </collision>
+            <visual name="base_link_inertia_visual">
+                <pose frame="">0 0 0 0 -0 0</pose>
+                <geometry>
+                    <mesh>
+                        <scale>1 1 1</scale>
+                        <uri>meshes/m100.dae</uri>
+                    </mesh>
+                </geometry>
+            </visual>
+
+            <visual name="left_flashlight_led">
+                <pose frame="">0.247592 0.24728 -0.017556 0 0 2.35619</pose>
+                <geometry>
+                    <mesh>
+                        <scale>1 1 1</scale>
+                        <uri>meshes/cree_xhp70.dae</uri>
+                    </mesh>
+                </geometry>
+            </visual>
+            <visual name="right_flashlight_led">
+                <pose frame="">0.247592 -0.24728 -0.017556 0 0 0.785398</pose>
+                <geometry>
+                    <mesh>
+                        <scale>1 1 1</scale>
+                        <uri>meshes/cree_xhp70.dae</uri>
+                    </mesh>
+                </geometry>
+            </visual>
+            <light name="left_light_source" type="spot">
+                <pose frame="">0.15 0.2 0.07 3.131592653589795 -1.5107899999999999 -3.741592653589791</pose>
+                <attenuation>
+                    <range>15</range>
+                    <linear>0</linear>
+                    <constant>0.1</constant>
+                    <quadratic>0.01</quadratic>
+                </attenuation>
+                <diffuse>0.8 0.8 0.5 1</diffuse>
+                <specular>0.8 0.8 0.5 1</specular>
+                <spot>
+                    <inner_angle>1</inner_angle>
+                    <outer_angle>1.5</outer_angle>
+                    <falloff>1</falloff>
+                </spot>
+                <direction>0 0 -1</direction>
+                <cast_shadows>1</cast_shadows>
+            </light>
+            <light name="right_light_source" type="spot">
+                <pose frame="">0.15 -0.2 0.07 3.131592653589795 -1.5107899999999999 3.741592653589791</pose>
+                <attenuation>
+                    <range>15</range>
+                    <linear>0</linear>
+                    <constant>0.1</constant>
+                    <quadratic>0.01</quadratic>
+                </attenuation>
+                <diffuse>0.8 0.8 0.5 1</diffuse>
+                <specular>0.8 0.8 0.5 1</specular>
+                <spot>
+                    <inner_angle>1</inner_angle>
+                    <outer_angle>1.5</outer_angle>
+                    <falloff>1</falloff>
+                </spot>
+                <direction>0 0 -1</direction>
+                <cast_shadows>1</cast_shadows>
+            </light>
+            <sensor name="imu_sensor" type="imu">
+                <always_on>1</always_on>
+                <update_rate>200</update_rate>
+                <imu>
+                    <angular_velocity>
+                        <x>
+                            <noise type="gaussian">
+                                <mean>0</mean>
+                                <stddev>0.009</stddev>
+                                <bias_mean>0.00075</bias_mean>
+                                <bias_stddev>0.005</bias_stddev>
+                                <dynamic_bias_stddev>0.00002</dynamic_bias_stddev>
+                                <dynamic_bias_correlation_time>400.0</dynamic_bias_correlation_time>
+                                <precision>0.00025</precision>
+                            </noise>
+                        </x>
+                        <y>
+                            <noise type="gaussian">
+                                <mean>0</mean>
+                                <stddev>0.009</stddev>
+                                <bias_mean>0.00075</bias_mean>
+                                <bias_stddev>0.005</bias_stddev>
+                                <dynamic_bias_stddev>0.00002</dynamic_bias_stddev>
+                                <dynamic_bias_correlation_time>400.0</dynamic_bias_correlation_time>
+                                <precision>0.00025</precision>
+                            </noise>
+                        </y>
+                        <z>
+                            <noise type="gaussian">
+                                <mean>0</mean>
+                                <stddev>0.009</stddev>
+                                <bias_mean>0.00075</bias_mean>
+                                <bias_stddev>0.005</bias_stddev>
+                                <dynamic_bias_stddev>0.00002</dynamic_bias_stddev>
+                                <dynamic_bias_correlation_time>400.0</dynamic_bias_correlation_time>
+                                <precision>0.00025</precision>
+                            </noise>
+                        </z>
+                    </angular_velocity>
+                    <linear_acceleration>
+                        <x>
+                            <noise type="gaussian">
+                                <mean>0</mean>
+                                <stddev>0.021</stddev>
+                                <bias_mean>0.05</bias_mean>
+                                <bias_stddev>0.0075</bias_stddev>
+                                <dynamic_bias_stddev>0.000375</dynamic_bias_stddev>
+                                <dynamic_bias_correlation_time>175.0</dynamic_bias_correlation_time>
+                                <precision>0.005</precision>
+                            </noise>
+                        </x>
+                        <y>
+                            <noise type="gaussian">
+                                <mean>0</mean>
+                                <stddev>0.021</stddev>
+                                <bias_mean>0.05</bias_mean>
+                                <bias_stddev>0.0075</bias_stddev>
+                                <dynamic_bias_stddev>0.000375</dynamic_bias_stddev>
+                                <dynamic_bias_correlation_time>175.0</dynamic_bias_correlation_time>
+                                <precision>0.005</precision>
+                            </noise>
+                        </y>
+                        <z>
+                            <noise type="gaussian">
+                                <mean>0</mean>
+                                <stddev>0.021</stddev>
+                                <bias_mean>0.05</bias_mean>
+                                <bias_stddev>0.0075</bias_stddev>
+                                <dynamic_bias_stddev>0.000375</dynamic_bias_stddev>
+                                <dynamic_bias_correlation_time>175.0</dynamic_bias_correlation_time>
+                                <precision>0.005</precision>
+                            </noise>
+                        </z>
+                    </linear_acceleration>
+                </imu>
+	    </sensor>
+            <sensor name="air_pressure" type="air_pressure">
+                <always_on>1</always_on>
+                <update_rate>20</update_rate>
+                <air_pressure>
+                    <reference_altitude>0</reference_altitude>
+                    <noise type="gaussian">
+                        <mean>0.00000008</mean>
+                    </noise>
+                </air_pressure>
+            </sensor>
+            <sensor name="magnetometer" type="magnetometer">
+                <always_on>1</always_on>
+                <update_rate>20</update_rate>
+                <magnetometer>
+                    <x>
+                        <noise type="gaussian">
+                            <mean>0.000000080</mean>
+                            <bias_mean>0.000000400</bias_mean>
+                        </noise>
+                    </x>
+                    <y>
+                        <noise type="gaussian">
+                            <mean>0.000000080</mean>
+                            <bias_mean>0.000000400</bias_mean>
+                        </noise>
+                    </y>
+                    <z>
+                        <noise type="gaussian">
+                            <mean>0.000000080</mean>
+                            <bias_mean>0.000000400</bias_mean>
+                        </noise>
+                    </z>
+                </magnetometer>
+            </sensor>
+
+            <visual name="camera_visual">
+                <pose>0.192 -0.015 -0.023 0 0.174533 0</pose>
+                <geometry>
+                    <box>
+                        <size>0.02 0.025 0.025</size>
+                    </box>
+                </geometry>
+            </visual>
+            <sensor name="camera_front" type="camera">
+                <pose>0.192 -0.015 -0.023 0 0.174533 0</pose>
+                <always_on>1</always_on>
+                <update_rate>20</update_rate>
+                <camera name="camera_front">
+                    <horizontal_fov>2.0944</horizontal_fov>
+                    <lens>
+                        <intrinsics>
+                            <fx>1108.952913</fx>
+                            <fy>1110.658360</fy>
+                            <cx>729.533992</cx>
+                            <cy>544.985715</cy>
+                            <s>1</s>
+                        </intrinsics>
+                    </lens>
+                    <distortion>
+                        <k1>0.0</k1>
+                        <k2>0.0</k2>
+                        <k3>0.0</k3>
+                        <p1>0.0</p1>
+                        <p2>0.0</p2>
+                        <center>0.5 0.5</center>
+                    </distortion>
+                    <image>
+                        <width>1440</width>
+                        <height>1080</height>
+                        <format>R8G8B8</format>
+                    </image>
+                    <clip>
+                        <near>0.02</near>
+                        <far>100</far>
+                    </clip>
+                    <noise>
+                        <type>gaussian</type>
+                        <mean>0</mean>
+                        <stddev>0.007</stddev>
+                    </noise>
+                </camera>
+            </sensor>
+
+            <!-- thermal camera -->
+            <visual name="thermal_camera_visual">
+              <pose>0.192 0.015 -0.023 0 0.174533 0</pose>
+              <geometry>
+                <box>
+                  <size>0.02 0.025 0.025</size>
+                </box>
+              </geometry>
+            </visual>
+            <sensor name="thermal_camera" type="thermal">
+              <pose>0.192 0.015 -0.023 0 0.174533 0</pose>
+              <camera name="thermal_camera">
+                <horizontal_fov>1.5708</horizontal_fov>
+                <lens>
+                  <intrinsics>
+                    <!-- fx = fy = width / ( 2 * tan (hfov / 2 ) ) -->
+                    <fx>320.0</fx>
+                    <fy>320.0</fy>
+                    <!-- cx = ( width + 1 ) / 2 -->
+                    <cx>320.5</cx>
+                    <!-- cy = ( height + 1 ) / 2 -->
+                    <cy>256.5</cy>
+                    <s>0</s>
+                  </intrinsics>
+                </lens>
+                <image>
+                  <width>640</width>
+                  <height>512</height>
+                  <format>L8</format>
+                </image>
+                <clip>
+                  <near>0.1</near>
+                  <far>100</far>
+                </clip>
+              </camera>
+              <always_on>1</always_on>
+              <update_rate>30</update_rate>
+              <plugin
+                filename="ignition-gazebo-thermal-sensor-system"
+                name="ignition::gazebo::systems::ThermalSensor">
+                <min_temp>253.15</min_temp>
+                <max_temp>673.15</max_temp>
+                <resolution>1.6</resolution>
+              </plugin>
+            </sensor>
+
+            <visual name="laser_visual">
+                <pose>0 0 0.05 0 0 0</pose>
+                <geometry>
+                    <cylinder>
+                        <radius>0.03</radius>
+                        <length>0.1</length>
+                    </cylinder>
+                </geometry>
+            </visual>
+            <sensor name="front_laser" type="gpu_ray">
+				<!-- The laser is patterned off of the X1 medium range lidar.  
+					We believe this is based on a Velodyne Puck Lite 
+					which weighs 590 g -->
+                <pose>0 0 0.05 0 0 0</pose>
+                <update_rate>10</update_rate>
+                <lidar>
+                    <scan>
+                        <horizontal>
+                            <samples>1800</samples>
+                            <resolution>1</resolution>
+                            <min_angle>-3.1459</min_angle>
+                            <max_angle>3.1459</max_angle>
+                        </horizontal>
+                        <vertical>
+                            <samples>16</samples>
+                            <resolution>1</resolution>
+                            <min_angle>-0.261799</min_angle>
+                            <max_angle>0.261799</max_angle>
+                        </vertical>
+                    </scan>
+                    <range>
+                        <min>0.05</min>
+                        <max>100</max>
+                        <resolution>0.01</resolution>
+                    </range>
+                    <noise>
+                        <type>gaussian</type>
+                        <mean>0</mean>
+                        <stddev>0.03</stddev>
+                    </noise>
+                </lidar>
+            </sensor>
+        </link>
+        <link name="rotor_0">
+            <pose frame="">0.2263 -0.2263 0.038 0 0 0</pose>
+            <inertial>
+                <pose frame="">0 0 0 0 -0 0</pose>
+                <mass>0.005</mass>
+                <inertia>
+                    <ixx>9.75e-07</ixx>
+                    <ixy>0</ixy>
+                    <ixz>0</ixz>
+                    <iyy>8.13545e-05</iyy>
+                    <iyz>0</iyz>
+                    <izz>8.22545e-05</izz>
+                </inertia>
+            </inertial>
+            <collision name="rotor_0_collision">
+                <pose frame="">0 0 0 0 -0 0</pose>
+                <geometry>
+                    <cylinder>
+                        <length>0.005</length>
+                        <radius>0.175</radius>
+                    </cylinder>	
+                </geometry>
+                <surface>
+                    <contact>
+                        <ode/>
+                    </contact>
+                    <friction>
+                        <ode/>
+                    </friction>
+                </surface>
+            </collision>
+            <visual name="rotor_0_visual">
+                <pose frame="">0 0 0 0 -0 0</pose>
+                <geometry>
+                    <mesh>
+                        <scale>0.175 0.175 0.175</scale>
+                        <uri>meshes/m100_propeller_ccw.dae</uri>
+                    </mesh>
+                </geometry>
+                <material>
+                    <diffuse>1 0 0 1</diffuse>
+                    <script>
+                        <name>Gazebo/Red</name>
+                        <uri>file://media/materials/scripts/gazebo.material</uri>
+                    </script>
+                </material>
+                <cast_shadows>0</cast_shadows>
+            </visual>
+            <gravity>1</gravity>
+            <velocity_decay/>
+        </link>
+        <joint name="rotor_0_joint" type="revolute">
+            <child>rotor_0</child>
+            <parent>base_link</parent>
+            <axis>
+                <xyz>0 0 1</xyz>
+                <limit>
+                    <lower>-1e+16</lower>
+                    <upper>1e+16</upper>
+                </limit>
+                <dynamics>
+                    <spring_reference>0</spring_reference>
+                    <spring_stiffness>0</spring_stiffness>
+                </dynamics>
+                <use_parent_model_frame>1</use_parent_model_frame>
+            </axis>
+        </joint>
+        <link name="rotor_1">
+            <pose frame="">-0.2263 0.2263 0.038 0 0 0</pose>
+            <inertial>
+                <pose frame="">0 0 0 0 -0 0</pose>
+                <mass>0.005</mass>
+                <inertia>
+                    <ixx>9.75e-07</ixx>
+                    <ixy>0</ixy>
+                    <ixz>0</ixz>
+                    <iyy>8.13545e-05</iyy>
+                    <iyz>0</iyz>
+                    <izz>8.22545e-05</izz>
+                </inertia>
+            </inertial>
+            <collision name="rotor_1_collision">
+                <pose frame="">0 0 0 0 -0 0</pose>
+                <geometry>
+                    <cylinder>
+                        <length>0.005</length>
+                        <radius>0.175</radius>
+                    </cylinder>
+                </geometry>
+                <surface>
+                    <contact>
+                        <ode/>
+                    </contact>
+                    <friction>
+                        <ode/>
+                    </friction>
+                </surface>
+            </collision>
+            <visual name="rotor_1_visual">
+                <pose frame="">0 0 0 0 -0 0</pose>
+                <geometry>
+                    <mesh>
+                        <scale>0.175 0.175 0.175</scale>
+                        <uri>meshes/m100_propeller_ccw.dae</uri>
+                    </mesh>
+                </geometry>
+                <material>
+                    <diffuse>0 0 1 1</diffuse>
+                    <script>
+                        <name>Gazebo/Blue</name>
+                        <uri>file://media/materials/scripts/gazebo.material</uri>
+                    </script>
+                </material>
+                <cast_shadows>0</cast_shadows>
+            </visual>
+            <gravity>1</gravity>
+            <velocity_decay/>
+        </link>
+        <joint name="rotor_1_joint" type="revolute">
+            <child>rotor_1</child>
+            <parent>base_link</parent>
+            <axis>
+                <xyz>0 0 1</xyz>
+                <limit>
+                    <lower>-1e+16</lower>
+                    <upper>1e+16</upper>
+                </limit>
+                <dynamics>
+                    <spring_reference>0</spring_reference>
+                    <spring_stiffness>0</spring_stiffness>
+                </dynamics>
+                <use_parent_model_frame>1</use_parent_model_frame>
+            </axis>
+        </joint>
+        <link name="rotor_2">
+            <pose frame="">0.2263 0.2263 0.038 0 0 0</pose>
+            <inertial>
+                <pose frame="">0 0 0 0 -0 0</pose>
+                <mass>0.005</mass>
+                <inertia>
+                    <ixx>9.75e-07</ixx>
+                    <ixy>0</ixy>
+                    <ixz>0</ixz>
+                    <iyy>8.13545e-05</iyy>
+                    <iyz>0</iyz>
+                    <izz>8.22545e-05</izz>
+                </inertia>
+            </inertial>
+            <collision name="rotor_2_collision">
+                <pose frame="">0 0 0 0 -0 0</pose>
+                <geometry>
+                    <cylinder>
+                        <length>0.005</length>
+                        <radius>0.175</radius>
+                    </cylinder>
+                </geometry>
+                <surface>
+                    <contact>
+                        <ode/>
+                    </contact>
+                    <friction>
+                        <ode/>
+                    </friction>
+                </surface>
+            </collision>
+            <visual name="rotor_2_visual">
+                <pose frame="">0 0 0 0 -0 0</pose>
+                <geometry>
+                    <mesh>
+                        <scale>0.175 0.175 0.175</scale>
+                        <uri>meshes/m100_propeller_cw.dae</uri>
+                    </mesh>
+                </geometry>
+                <material>
+                    <diffuse>1 0 0 1</diffuse>
+                    <script>
+                        <name>Gazebo/Red</name>
+                        <uri>file://media/materials/scripts/gazebo.material</uri>
+                    </script>
+                </material>
+                <cast_shadows>0</cast_shadows>
+            </visual>
+            <gravity>1</gravity>
+            <velocity_decay/>
+        </link>
+        <joint name="rotor_2_joint" type="revolute">
+            <child>rotor_2</child>
+            <parent>base_link</parent>
+            <axis>
+                <xyz>0 0 1</xyz>
+                <limit>
+                    <lower>-1e+16</lower>
+                    <upper>1e+16</upper>
+                </limit>
+                <dynamics>
+                    <spring_reference>0</spring_reference>
+                    <spring_stiffness>0</spring_stiffness>
+                </dynamics>
+                <use_parent_model_frame>1</use_parent_model_frame>
+            </axis>
+        </joint>
+        <link name="rotor_3">
+            <pose frame="">-0.2263 -0.2263 0.038 0 0 0</pose>
+            <inertial>
+                <pose frame="">0 0 0 0 -0 0</pose>
+                <mass>0.005</mass>
+                <inertia>
+                    <ixx>9.75e-07</ixx>
+                    <ixy>0</ixy>
+                    <ixz>0</ixz>
+                    <iyy>8.13545e-05</iyy>
+                    <iyz>0</iyz>
+                    <izz>8.22545e-05</izz>
+                </inertia>
+            </inertial>
+            <collision name="rotor_3_collision">
+                <pose frame="">0 0 0 0 -0 0</pose>
+                <geometry>
+                    <cylinder>
+                        <length>0.005</length>
+                        <radius>0.175</radius>
+                    </cylinder>
+                </geometry>
+                <surface>
+                    <contact>
+                        <ode/>
+                    </contact>
+                    <friction>
+                        <ode/>
+                    </friction>
+                </surface>
+            </collision>
+            <visual name="rotor_3_visual">
+                <pose frame="">0 0 0 0 -0 0</pose>
+                <geometry>
+                    <mesh>
+                        <scale>0.175 0.175 0.175</scale>
+                        <uri>meshes/m100_propeller_cw.dae</uri>
+                    </mesh>
+                </geometry>
+                <material>
+                    <diffuse>0 0 1 1</diffuse>
+                    <script>
+                        <name>Gazebo/Blue</name>
+                        <uri>file://media/materials/scripts/gazebo.material</uri>
+                    </script>
+                </material>
+                <cast_shadows>0</cast_shadows>
+            </visual>
+            <gravity>1</gravity>
+            <velocity_decay/>
+        </link>
+        <joint name="rotor_3_joint" type="revolute">
+            <child>rotor_3</child>
+            <parent>base_link</parent>
+            <axis>
+                <xyz>0 0 1</xyz>
+                <limit>
+                    <lower>-1e+16</lower>
+                    <upper>1e+16</upper>
+                </limit>
+                <dynamics>
+                    <spring_reference>0</spring_reference>
+                    <spring_stiffness>0</spring_stiffness>
+                </dynamics>
+                <use_parent_model_frame>1</use_parent_model_frame>
+            </axis>
+        </joint>
+    </model>
+</sdf>

--- a/submitted_models/marble_hd2_sensor_config_1/model.sdf
+++ b/submitted_models/marble_hd2_sensor_config_1/model.sdf
@@ -154,9 +154,9 @@
           <specular>1.0 1.0 1.0</specular>
           <pbr>
             <metal>
-              <albedo_map>materials/textures/HD2_Albedo.png</albedo_map>
-              <metalness_map>materials/textures/HD2_Metalness.png</metalness_map>
-              <roughness_map>materials/textures/HD2_Roughness.png</roughness_map>
+              <albedo_map>materials/textures/HD2_Albedo.jpg</albedo_map>
+              <metalness_map>materials/textures/HD2_Metalness.jpg</metalness_map>
+              <roughness_map>materials/textures/HD2_Roughness.jpg</roughness_map>
             </metal>
           </pbr>
           <!-- fallback to script if no PBR support-->
@@ -913,9 +913,9 @@
                         <specular>1.0 1.0 1.0</specular>
                         <pbr>
                           <metal>
-                            <albedo_map>materials/textures/HD2_Albedo.png</albedo_map>
-                            <metalness_map>materials/textures/HD2_Metalness.png</metalness_map>
-                            <roughness_map>materials/textures/HD2_Roughness.png</roughness_map>
+                            <albedo_map>materials/textures/HD2_Albedo.jpg</albedo_map>
+                            <metalness_map>materials/textures/HD2_Metalness.jpg</metalness_map>
+                            <roughness_map>materials/textures/HD2_Roughness.jpg</roughness_map>
                           </metal>
                         </pbr>
                         <script>
@@ -975,9 +975,9 @@
                         <specular>1.0 1.0 1.0</specular>
                         <pbr>
                           <metal>
-                            <albedo_map>materials/textures/HD2_Albedo.png</albedo_map>
-                            <metalness_map>materials/textures/HD2_Metalness.png</metalness_map>
-                            <roughness_map>materials/textures/HD2_Roughness.png</roughness_map>
+                            <albedo_map>materials/textures/HD2_Albedo.jpg</albedo_map>
+                            <metalness_map>materials/textures/HD2_Metalness.jpg</metalness_map>
+                            <roughness_map>materials/textures/HD2_Roughness.jpg</roughness_map>
                           </metal>
                         </pbr>
                         <!-- fallback to script if no PBR support-->
@@ -1087,33 +1087,33 @@
                         <lower>-1.5708</lower>
                         <!-- 90 degrees both direction (mechanical interference)-->
                         <upper>1.5708</upper>
-                    <effort>10</effort>
-                </limit>
-                <dynamics>
-                    <spring_reference>0</spring_reference>
-                    <spring_stiffness>0</spring_stiffness>
-                    <damping>0.5</damping>
-                </dynamics>
-                <use_parent_model_frame>1</use_parent_model_frame>
-              </axis>
-            </joint>
-            <!-- Gimbal Joints Plugins -->
-            <plugin filename="libignition-gazebo-joint-controller-system.so" name="ignition::gazebo::systems::JointController">
-              <joint_name>pan_gimbal_joint</joint_name>
-              <use_force_commands>true</use_force_commands>
-              <p_gain>0.4</p_gain>
-              <i_gain>10</i_gain>
-            </plugin>
-            <plugin filename="libignition-gazebo-joint-controller-system.so" name="ignition::gazebo::systems::JointController">
-              <joint_name>tilt_gimbal_joint</joint_name>
-              <use_force_commands>true</use_force_commands>
-              <p_gain>0.4</p_gain>
-              <i_gain>10</i_gain>
-            </plugin>
-            <plugin filename="libignition-gazebo-joint-state-publisher-system.so" name="ignition::gazebo::systems::JointStatePublisher">
-              <joint_name>pan_gimbal_joint</joint_name>
-              <joint_name>tilt_gimbal_joint</joint_name>
-            </plugin>
-            <static>0</static>
-          </model>
-        </sdf>
+                        <effort>10</effort>
+                      </limit>
+                      <dynamics>
+                        <spring_reference>0</spring_reference>
+                        <spring_stiffness>0</spring_stiffness>
+                        <damping>0.5</damping>
+                      </dynamics>
+                      <use_parent_model_frame>1</use_parent_model_frame>
+                    </axis>
+                  </joint>
+                  <!-- Gimbal Joints Plugins -->
+                  <plugin filename="libignition-gazebo-joint-controller-system.so" name="ignition::gazebo::systems::JointController">
+                    <joint_name>pan_gimbal_joint</joint_name>
+                    <use_force_commands>true</use_force_commands>
+                    <p_gain>0.4</p_gain>
+                    <i_gain>10</i_gain>
+                  </plugin>
+                  <plugin filename="libignition-gazebo-joint-controller-system.so" name="ignition::gazebo::systems::JointController">
+                    <joint_name>tilt_gimbal_joint</joint_name>
+                    <use_force_commands>true</use_force_commands>
+                    <p_gain>0.4</p_gain>
+                    <i_gain>10</i_gain>
+                  </plugin>
+                  <plugin filename="libignition-gazebo-joint-state-publisher-system.so" name="ignition::gazebo::systems::JointStatePublisher">
+                    <joint_name>pan_gimbal_joint</joint_name>
+                    <joint_name>tilt_gimbal_joint</joint_name>
+                  </plugin>
+                  <static>0</static>
+                </model>
+              </sdf>

--- a/submitted_models/marble_hd2_sensor_config_3/README.md
+++ b/submitted_models/marble_hd2_sensor_config_3/README.md
@@ -2,4 +2,5 @@ This package spawns a `MARBLE_HD2_SENSOR_CONFIG_1` model with an additional
 thermal camera
 
 The `model.sdf` is not used but added here as a reference to show what is on
-the SubT Tech Repo. Please keep this `model.sdf` update-to-date
+the SubT Tech Repo. Please keep this `model.sdf` update-to-date with
+`MARBLE_HD2_SENSOR_CONFIG_1`

--- a/submitted_models/marble_hd2_sensor_config_3/README.md
+++ b/submitted_models/marble_hd2_sensor_config_3/README.md
@@ -1,0 +1,5 @@
+This package spawns a `MARBLE_HD2_SENSOR_CONFIG_1` with an additional
+thermal camera
+
+The `model.sdf` is not used but added here as a reference to show what is on
+the SubT Tech Repo. Please keep this `model.sdf` update-to-date

--- a/submitted_models/marble_hd2_sensor_config_3/model.sdf
+++ b/submitted_models/marble_hd2_sensor_config_3/model.sdf
@@ -1,0 +1,1165 @@
+<?xml version='1.0' encoding='utf-8'?>
+<sdf version="1.6">
+  <model name="marble_hd2_sensor_config_3">
+    <link name="base_link">
+      <pose frame="">0 0 0 0 -0 0</pose>
+      <inertial>
+        <pose frame="">-0.000649 -0.084945 0.062329 0 -0 0</pose>
+        <mass>21.8194</mass>
+        <inertia>
+          <ixx>0.615397</ixx>
+          <ixy>-0.0240585</ixy>
+          <ixz>-0.120749</ixz>
+          <iyy>1.75388</iyy>
+          <iyz>-0.0028322</iyz>
+          <izz>2.03641</izz>
+        </inertia>
+      </inertial>
+      <collision name="base_link_collision">
+        <pose frame="">0 0 0.12 0 0 0</pose>
+        <geometry>
+          <box>
+            <size>0.9874 0.5709 0.05</size>
+          </box>
+        </geometry>
+      </collision>
+      <collision name="base_link_collision_bottom">
+        <pose frame="">0 0 0.046 0 0 0</pose>
+        <geometry>
+          <box>
+            <size>0.80 0.5709 0.2</size>
+          </box>
+        </geometry>
+      </collision>
+      <collision name="base_link_collision_1">
+        <pose frame="">0 0 0.185625 0 -0 0</pose>
+        <geometry>
+          <box>
+            <size>0.78992 0.5709 0.12375</size>
+          </box>
+        </geometry>
+      </collision>
+      <collision name="base_link_fixed_joint_lump__camera/camera_link_collision_1">
+        <pose frame="pan_gimbal_link">0 0 0.05 0 0.0 0</pose>
+        <geometry>
+          <box>
+            <size>0.0078 0.13 0.0192</size>
+          </box>
+        </geometry>
+        <surface>
+          <contact>
+            <ode>
+              <kp>1e+13</kp>
+              <kd>1</kd>
+            </ode>
+          </contact>
+          <friction>
+            <ode>
+              <mu2>1</mu2>
+              <fdir1>0 0 0</fdir1>
+            </ode>
+          </friction>
+        </surface>
+      </collision>
+      <collision name="base_link_fixed_joint_lump__camera/camera_link_collision_2">
+        <pose frame="">0.485 0 0.31 0 -0 0</pose>
+        <geometry>
+          <box>
+            <size>0.0078 0.13 0.0192</size>
+          </box>
+        </geometry>
+        <surface>
+          <contact>
+            <ode>
+              <kp>1e+13</kp>
+              <kd>1</kd>
+            </ode>
+          </contact>
+          <friction>
+            <ode>
+              <mu2>1</mu2>
+              <fdir1>0 0 0</fdir1>
+            </ode>
+          </friction>
+        </surface>
+      </collision>
+      <collision name="base_link_fixed_joint_lump__camera/camera_link_collision_3">
+        <pose frame="">0.473 0 0.260 0 0.5236 0</pose>
+        <geometry>
+          <box>
+            <size>0.0078 0.13 0.0192</size>
+          </box>
+        </geometry>
+        <surface>
+          <contact>
+            <ode>
+              <kp>1e+13</kp>
+              <kd>1</kd>
+            </ode>
+          </contact>
+          <friction>
+            <ode>
+              <mu2>1</mu2>
+              <fdir1>0 0 0</fdir1>
+            </ode>
+          </friction>
+        </surface>
+      </collision>
+      <collision name="base_link_fixed_joint_lump__velodyne_base_link_collision_6">
+        <pose frame="">0.403 0 0.36 0 -0 0</pose>
+        <geometry>
+          <cylinder>
+            <length>0.0717</length>
+            <radius>0.0516</radius>
+          </cylinder>
+        </geometry>
+      </collision>
+      <collision name="base_link_fixed_joint_lump__velodyne_gimbal_plate_base_link_collision_7">
+        <pose frame="">0.403 0 0.410 0 -0 0</pose>
+        <geometry>
+          <box>
+            <size>0.1 0.1 0.01</size>
+          </box>
+        </geometry>
+      </collision>
+      <collision name="base_link_fixed_joint_lump__sensor_tower_8">
+        <pose frame="">0.374 0 0.215 0 -0 0</pose>
+        <geometry>
+          <box>
+            <size>0.2 0.25 0.225</size>
+          </box>
+        </geometry>
+      </collision>
+      <collision name="base_link_fixed_joint_lump__computer_block_9">
+        <pose frame="">0.050 0 0.155 0 -0 0</pose>
+        <geometry>
+          <box>
+            <size>0.30 0.355 0.160</size>
+          </box>
+        </geometry>
+      </collision>
+      <visual name="Body_visual">
+        <pose>0 0 -0.135 0 0 1.57</pose>
+        <geometry>
+          <mesh>
+            <uri>meshes/hd2.dae</uri>
+            <submesh>
+              <name>Body</name>
+              <center>false</center>
+            </submesh>
+          </mesh>
+        </geometry>
+        <material>
+          <diffuse>1.0 1.0 1.0</diffuse>
+          <specular>1.0 1.0 1.0</specular>
+          <pbr>
+            <metal>
+              <albedo_map>materials/textures/HD2_Albedo.jpg</albedo_map>
+              <metalness_map>materials/textures/HD2_Metalness.jpg</metalness_map>
+              <roughness_map>materials/textures/HD2_Roughness.jpg</roughness_map>
+            </metal>
+          </pbr>
+          <!-- fallback to script if no PBR support-->
+          <script>
+            <uri>materials/scripts/</uri>
+            <uri>materials/textures/</uri>
+            <name>HD/HD2_Diffuse</name>
+          </script>
+        </material>
+      </visual>
+
+      <!-- thermal camera -->
+      <visual name="thermal_camera_visual">
+        <pose>0.435 -.01 0.125 0 0 0</pose>
+        <geometry>
+          <box>
+            <size>0.02 0.025 0.025</size>
+          </box>
+        </geometry>
+      </visual>
+      <sensor name="thermal_camera" type="thermal">
+        <pose>0.435 -.01 0.125 0 0 0</pose>
+        <camera name="thermal_camera">
+          <horizontal_fov>0.4922</horizontal_fov>
+          <lens>
+            <intrinsics>
+              <!-- fx = fy = width / ( 2 * tan (hfov / 2 ) ) -->
+              <fx>764.35630</fx>
+              <fy>764.35630</fy>
+              <!-- cx = ( width + 1 ) / 2 -->
+              <cx>192.5</cx>
+              <!-- cy = ( height + 1 ) / 2 -->
+              <cy>144.5</cy>
+              <s>0</s>
+            </intrinsics>
+          </lens>
+          <image>
+            <width>384</width>
+            <height>288</height>
+            <format>L8</format>
+          </image>
+          <clip>
+            <near>0.1</near>
+            <far>100</far>
+          </clip>
+        </camera>
+        <always_on>1</always_on>
+        <update_rate>25</update_rate>
+        <plugin
+          filename="ignition-gazebo-thermal-sensor-system"
+          name="ignition::gazebo::systems::ThermalSensor">
+          <min_temp>253.15</min_temp>
+          <max_temp>673.15</max_temp>
+          <resolution>1.6</resolution>
+        </plugin>
+      </sensor>
+
+      <!-- Based on Intel realsense D435 (intrinsics and distortion not modeled)-->
+      <sensor name="camera_front" type="rgbd_camera">
+        <camera name="camera_front">
+          <horizontal_fov>1.5184</horizontal_fov>
+          <lens>
+            <intrinsics>
+              <!-- fx = fy = width / ( 2 * tan (hfov / 2 ) ) -->
+              <fx>168.61097</fx>
+              <fy>168.61097</fy>
+              <!-- cx = ( width + 1 ) / 2 -->
+              <cx>160.5</cx>
+              <!-- cy = ( height + 1 ) / 2 -->
+              <cy>120.5</cy>
+              <s>0</s>
+            </intrinsics>
+          </lens>
+          <distortion>
+            <k1>0.0</k1>
+            <k2>0.0</k2>
+            <k3>0.0</k3>
+            <p1>0.0</p1>
+            <p2>0.0</p2>
+            <center>0.5 0.5</center>
+          </distortion>
+          <image>
+            <width>320</width>
+            <height>240</height>
+            <format>R8G8B8</format>
+          </image>
+          <clip>
+            <near>0.01</near>
+            <far>300</far>
+          </clip>
+          <depth_camera>
+            <clip>
+              <near>0.1</near>
+              <far>10</far>
+            </clip>
+          </depth_camera>
+          <noise>
+            <type>gaussian</type>
+            <mean>0</mean>
+            <stddev>0.007</stddev>
+          </noise>
+        </camera>
+        <always_on>1</always_on>
+        <update_rate>30</update_rate>
+        <pose frame="">0.485 0 0.31 0 -0 0</pose>
+      </sensor>
+      <gravity>1</gravity>
+      <velocity_decay/>
+      <!-- Based on Intel realsense D435 (intrinsics and distortion not modeled)-->
+      <sensor name="camera_down" type="rgbd_camera">
+        <camera name="camera_down">
+          <horizontal_fov>1.5184</horizontal_fov>
+          <lens>
+            <intrinsics>
+              <!-- fx = fy = width / ( 2 * tan (hfov / 2 ) ) -->
+              <fx>168.61097</fx>
+              <fy>168.61097</fy>
+              <!-- cx = ( width + 1 ) / 2 -->
+              <cx>160.5</cx>
+              <!-- cy = ( height + 1 ) / 2 -->
+              <cy>120.5</cy>
+              <s>0</s>
+            </intrinsics>
+          </lens>
+          <distortion>
+            <k1>0.0</k1>
+            <k2>0.0</k2>
+            <k3>0.0</k3>
+            <p1>0.0</p1>
+            <p2>0.0</p2>
+            <center>0.5 0.5</center>
+          </distortion>
+          <image>
+            <width>320</width>
+            <height>240</height>
+            <format>R8G8B8</format>
+          </image>
+          <clip>
+            <near>0.01</near>
+            <far>300</far>
+          </clip>
+          <depth_camera>
+            <clip>
+              <near>0.1</near>
+              <far>10</far>
+            </clip>
+          </depth_camera>
+          <noise>
+            <type>gaussian</type>
+            <mean>0</mean>
+            <stddev>0.007</stddev>
+          </noise>
+        </camera>
+        <always_on>1</always_on>
+        <update_rate>30</update_rate>
+        <pose frame="">0.473 0 0.260 0 0.5236 0</pose>
+        <!-- 30 degree download look-->
+      </sensor>
+      <gravity>1</gravity>
+      <velocity_decay/>
+      <!-- Based on RPLidar S1 -->
+      <sensor name="planar_laser" type="gpu_ray">
+        <pose>0.403 0 0.127 0 -0 0</pose>
+        <update_rate>10</update_rate>
+        <lidar>
+          <scan>
+            <horizontal>
+              <samples>920</samples>
+              <resolution>1</resolution>
+              <min_angle>-3.14159</min_angle>
+              <max_angle>3.14159</max_angle>
+            </horizontal>
+          </scan>
+          <range>
+            <min>0.04</min>
+            <max>25</max>
+            <resolution>0.03</resolution>
+          </range>
+          <noise>
+            <type>gaussian</type>
+            <mean>0</mean>
+            <stddev>0.01</stddev>
+          </noise>
+        </lidar>
+      </sensor>
+      <gravity>1</gravity>
+      <velocity_decay/>
+      <!-- OS1-64 3D Laser Configuration (10x2048 or 10x1024 or 20x1024 or 20x512 as possible (rate) x (hor. res.) configs)-->
+      <sensor name="front_laser" type="gpu_lidar">
+        <update_rate>20</update_rate>
+        <lidar>
+          <scan>
+            <horizontal>
+                            <samples>1024</samples>
+                            <resolution>1</resolution>
+                            <min_angle>-3.1459</min_angle>
+                            <max_angle>3.1459</max_angle>
+                          </horizontal>
+                          <vertical>
+                            <samples>64</samples>
+                            <resolution>1</resolution>
+                            <min_angle>-0.2897</min_angle>
+                            <max_angle>0.2897</max_angle>
+                          </vertical>
+                        </scan>
+                        <range>
+                          <min>0.8</min>
+                          <max>120</max>
+                          <resolution>0.003</resolution>
+                        </range>
+                        <noise>
+                          <type>gaussian</type>
+                          <mean>0</mean>
+                          <stddev>0.03</stddev>
+                        </noise>
+                      </lidar>
+                      <pose frame="">0.403 0 0.36 0 -0 0</pose>
+                    </sensor>
+                    <sensor name="imu_sensor" type="imu">
+                      <always_on>1</always_on>
+                      <update_rate>50</update_rate>
+                      <imu>
+                    <angular_velocity>
+                        <x>
+                            <noise type="gaussian">
+                                <mean>0</mean>
+                                <stddev>0.009</stddev>
+                                <bias_mean>0.00075</bias_mean>
+                                <bias_stddev>0.005</bias_stddev>
+                                <dynamic_bias_stddev>0.00002</dynamic_bias_stddev>
+                                <dynamic_bias_correlation_time>400.0</dynamic_bias_correlation_time>
+                                <precision>0.00025</precision>
+                            </noise>
+                        </x>
+                        <y>
+                            <noise type="gaussian">
+                                <mean>0</mean>
+                                <stddev>0.009</stddev>
+                                <bias_mean>0.00075</bias_mean>
+                                <bias_stddev>0.005</bias_stddev>
+                                <dynamic_bias_stddev>0.00002</dynamic_bias_stddev>
+                                <dynamic_bias_correlation_time>400.0</dynamic_bias_correlation_time>
+                                <precision>0.00025</precision>
+                            </noise>
+                        </y>
+                        <z>
+                            <noise type="gaussian">
+                                <mean>0</mean>
+                                <stddev>0.009</stddev>
+                                <bias_mean>0.00075</bias_mean>
+                                <bias_stddev>0.005</bias_stddev>
+                                <dynamic_bias_stddev>0.00002</dynamic_bias_stddev>
+                                <dynamic_bias_correlation_time>400.0</dynamic_bias_correlation_time>
+                                <precision>0.00025</precision>
+                            </noise>
+                        </z>
+                    </angular_velocity>
+                    <linear_acceleration>
+                        <x>
+                            <noise type="gaussian">
+                                <mean>0</mean>
+                                <stddev>0.021</stddev>
+                                <bias_mean>0.05</bias_mean>
+                                <bias_stddev>0.0075</bias_stddev>
+                                <dynamic_bias_stddev>0.000375</dynamic_bias_stddev>
+                                <dynamic_bias_correlation_time>175.0</dynamic_bias_correlation_time>
+                                <precision>0.005</precision>
+                            </noise>
+                        </x>
+                        <y>
+                            <noise type="gaussian">
+                                <mean>0</mean>
+                                <stddev>0.021</stddev>
+                                <bias_mean>0.05</bias_mean>
+                                <bias_stddev>0.0075</bias_stddev>
+                                <dynamic_bias_stddev>0.000375</dynamic_bias_stddev>
+                                <dynamic_bias_correlation_time>175.0</dynamic_bias_correlation_time>
+                                <precision>0.005</precision>
+                            </noise>
+                        </y>
+                        <z>
+                            <noise type="gaussian">
+                                <mean>0</mean>
+                                <stddev>0.021</stddev>
+                                <bias_mean>0.05</bias_mean>
+                                <bias_stddev>0.0075</bias_stddev>
+                                <dynamic_bias_stddev>0.000375</dynamic_bias_stddev>
+                                <dynamic_bias_correlation_time>175.0</dynamic_bias_correlation_time>
+                                <precision>0.005</precision>
+                            </noise>
+                        </z>
+                    </linear_acceleration>
+                </imu>
+                    </sensor>
+                  </link>
+                  <!-- Left Side Wheels  -->
+                  <link name="front_left_wheel_link">
+                    <pose frame="">0.360 0.26 0.00 0 -0 0</pose>
+                    <inertial>
+                      <pose frame="">0 0 0 0 -0 0</pose>
+                      <mass>1.5</mass>
+                      <inertia>
+                        <ixx>0.02467</ixx>
+                        <ixy>0</ixy>
+                        <ixz>0</ixz>
+                        <iyy>0.04411</iyy>
+                        <iyz>0</iyz>
+                        <izz>0.02467</izz>
+                      </inertia>
+                    </inertial>
+                    <collision name="front_left_wheel_link_collision">
+                      <pose frame="">0 0 0 1.5707963267948966 -0 0</pose>
+                      <geometry>
+                        <cylinder>
+                          <length>0.1</length>
+                          <radius>0.129</radius>
+                        </cylinder>
+                      </geometry>
+                      <surface>
+                        <contact>
+                          <ode>
+                            <kp>1e+07</kp>
+                            <kd>1</kd>
+                          </ode>
+                        </contact>
+                        <friction>
+                          <ode>
+                            <mu>0.5</mu>
+                            <mu2>1</mu2>
+                            <slip1>0.001</slip1>
+                            <slip2>0</slip2>
+                            <fdir1>0 0 1</fdir1>
+                          </ode>
+                        </friction>
+                      </surface>
+                    </collision>
+                  </link>
+                  <joint name="front_left_wheel_joint" type="revolute">
+                    <child>front_left_wheel_link</child>
+                    <parent>base_link</parent>
+                    <axis>
+                      <xyz>0 1 0</xyz>
+                      <limit>
+                        <lower>-1e+16</lower>
+                        <upper>1e+16</upper>
+                      </limit>
+                      <dynamics>
+                        <spring_reference>0</spring_reference>
+                        <spring_stiffness>0</spring_stiffness>
+                      </dynamics>
+                      <use_parent_model_frame>1</use_parent_model_frame>
+                    </axis>
+                  </joint>
+                  <link name="front_middle_left_wheel_link">
+                    <pose frame="">0.120 0.26 0.00 0 -0 0</pose>
+                    <inertial>
+                      <pose frame="">0 0 0 0 -0 0</pose>
+                      <mass>1.5</mass>
+                      <inertia>
+                        <ixx>0.02467</ixx>
+                        <ixy>0</ixy>
+                        <ixz>0</ixz>
+                        <iyy>0.04411</iyy>
+                        <iyz>0</iyz>
+                        <izz>0.02467</izz>
+                      </inertia>
+                    </inertial>
+                    <collision name="front_middle_left_wheel_link_collision">
+                      <pose frame="">0 0 0 1.5707963267948966 -0 0</pose>
+                      <geometry>
+                        <cylinder>
+                          <length>0.1</length>
+                          <radius>0.129</radius>
+                        </cylinder>
+                      </geometry>
+                      <surface>
+                        <contact>
+                          <ode>
+                            <kp>1e+07</kp>
+                            <kd>1</kd>
+                          </ode>
+                        </contact>
+                        <friction>
+                          <ode>
+                            <mu>0.5</mu>
+                            <mu2>1</mu2>
+                            <slip1>0.001</slip1>
+                            <slip2>0</slip2>
+                            <fdir1>0 0 1</fdir1>
+                          </ode>
+                        </friction>
+                      </surface>
+                    </collision>
+                  </link>
+                  <joint name="front_middle_left_wheel_joint" type="revolute">
+                    <child>front_middle_left_wheel_link</child>
+                    <parent>base_link</parent>
+                    <axis>
+                      <xyz>0 1 0</xyz>
+                      <limit>
+                        <lower>-1e+16</lower>
+                        <upper>1e+16</upper>
+                      </limit>
+                      <dynamics>
+                        <spring_reference>0</spring_reference>
+                        <spring_stiffness>0</spring_stiffness>
+                      </dynamics>
+                      <use_parent_model_frame>1</use_parent_model_frame>
+                    </axis>
+                  </joint>
+                  <link name="rear_middle_left_wheel_link">
+                    <pose frame="">-0.120 0.26 0.00 0 -0 0</pose>
+                    <inertial>
+                      <pose frame="">0 0 0 0 -0 0</pose>
+                      <mass>1.5</mass>
+                      <inertia>
+                        <ixx>0.02467</ixx>
+                        <ixy>0</ixy>
+                        <ixz>0</ixz>
+                        <iyy>0.04411</iyy>
+                        <iyz>0</iyz>
+                        <izz>0.02467</izz>
+                      </inertia>
+                    </inertial>
+                    <collision name="rear_middle_left_wheel_link_collision">
+                      <pose frame="">0 0 0 1.5707963267948966 -0 0</pose>
+                      <geometry>
+                        <cylinder>
+                          <length>0.1</length>
+                          <radius>0.129</radius>
+                        </cylinder>
+                      </geometry>
+                      <surface>
+                        <contact>
+                          <ode>
+                            <kp>1e+07</kp>
+                            <kd>1</kd>
+                          </ode>
+                        </contact>
+                        <friction>
+                          <ode>
+                            <mu>0.5</mu>
+                            <mu2>1</mu2>
+                            <slip1>0.001</slip1>
+                            <slip2>0</slip2>
+                            <fdir1>0 0 1</fdir1>
+                          </ode>
+                        </friction>
+                      </surface>
+                    </collision>
+                  </link>
+                  <joint name="rear_middle_left_wheel_joint" type="revolute">
+                    <child>rear_middle_left_wheel_link</child>
+                    <parent>base_link</parent>
+                    <axis>
+                      <xyz>0 1 0</xyz>
+                      <limit>
+                        <lower>-1e+16</lower>
+                        <upper>1e+16</upper>
+                      </limit>
+                      <dynamics>
+                        <spring_reference>0</spring_reference>
+                        <spring_stiffness>0</spring_stiffness>
+                      </dynamics>
+                      <use_parent_model_frame>1</use_parent_model_frame>
+                    </axis>
+                  </joint>
+                  <link name="rear_left_wheel_link">
+                    <pose frame="">-0.36 0.26 0.0 0 -0 0</pose>
+                    <inertial>
+                      <pose frame="">0 0 0 0 -0 0</pose>
+                      <mass>1.5</mass>
+                      <inertia>
+                        <ixx>0.02467</ixx>
+                        <ixy>0</ixy>
+                        <ixz>0</ixz>
+                        <iyy>0.04411</iyy>
+                        <iyz>0</iyz>
+                        <izz>0.02467</izz>
+                      </inertia>
+                    </inertial>
+                    <collision name="rear_left_wheel_link_collision">
+                      <pose frame="">0 0 0 1.5707963267948966 -0 0</pose>
+                      <geometry>
+                        <cylinder>
+                          <length>0.1</length>
+                          <radius>0.129</radius>
+                        </cylinder>
+                      </geometry>
+                      <surface>
+                        <contact>
+                          <ode>
+                            <kp>1e+07</kp>
+                            <kd>1</kd>
+                          </ode>
+                        </contact>
+                        <friction>
+                          <ode>
+                            <mu>0.5</mu>
+                            <mu2>1</mu2>
+                            <slip1>0.001</slip1>
+                            <slip2>0</slip2>
+                            <fdir1>0 0 1</fdir1>
+                          </ode>
+                        </friction>
+                      </surface>
+                    </collision>
+                  </link>
+                  <joint name="rear_left_wheel_joint" type="revolute">
+                    <child>rear_left_wheel_link</child>
+                    <parent>base_link</parent>
+                    <axis>
+                      <xyz>0 1 0</xyz>
+                      <limit>
+                        <lower>-1e+16</lower>
+                        <upper>1e+16</upper>
+                      </limit>
+                      <dynamics>
+                        <spring_reference>0</spring_reference>
+                        <spring_stiffness>0</spring_stiffness>
+                      </dynamics>
+                      <use_parent_model_frame>1</use_parent_model_frame>
+                    </axis>
+                  </joint>
+                  <!-- Right Side Wheels -->
+                  <link name="front_right_wheel_link">
+                    <pose frame="">0.360 -0.26 0.00 0 -0 0</pose>
+                    <inertial>
+                      <pose frame="">0 0 0 0 -0 0</pose>
+                      <mass>1.5</mass>
+                      <inertia>
+                        <ixx>0.02467</ixx>
+                        <ixy>0</ixy>
+                        <ixz>0</ixz>
+                        <iyy>0.04411</iyy>
+                        <iyz>0</iyz>
+                        <izz>0.02467</izz>
+                      </inertia>
+                    </inertial>
+                    <collision name="front_right_wheel_link_collision">
+                      <pose frame="">0 0 0 1.5707963267948966 -0 0</pose>
+                      <geometry>
+                        <cylinder>
+                          <length>0.1</length>
+                          <radius>0.129</radius>
+                        </cylinder>
+                      </geometry>
+                      <surface>
+                        <contact>
+                          <ode>
+                            <kp>1e+07</kp>
+                            <kd>1</kd>
+                          </ode>
+                        </contact>
+                        <friction>
+                          <ode>
+                            <mu>0.5</mu>
+                            <mu2>1</mu2>
+                            <slip1>0.001</slip1>
+                            <slip2>0</slip2>
+                            <fdir1>0 0 1</fdir1>
+                          </ode>
+                        </friction>
+                      </surface>
+                    </collision>
+                  </link>
+                  <joint name="front_right_wheel_joint" type="revolute">
+                    <child>front_right_wheel_link</child>
+                    <parent>base_link</parent>
+                    <axis>
+                      <xyz>0 1 0</xyz>
+                      <limit>
+                        <lower>-1e+16</lower>
+                        <upper>1e+16</upper>
+                      </limit>
+                      <dynamics>
+                        <spring_reference>0</spring_reference>
+                        <spring_stiffness>0</spring_stiffness>
+                      </dynamics>
+                      <use_parent_model_frame>1</use_parent_model_frame>
+                    </axis>
+                  </joint>
+                  <link name="front_middle_right_wheel_link">
+                    <pose frame="">0.120 -0.26 0.00 0 -0 0</pose>
+                    <inertial>
+                      <pose frame="">0 0 0 0 -0 0</pose>
+                      <mass>1.5</mass>
+                      <inertia>
+                        <ixx>0.02467</ixx>
+                        <ixy>0</ixy>
+                        <ixz>0</ixz>
+                        <iyy>0.04411</iyy>
+                        <iyz>0</iyz>
+                        <izz>0.02467</izz>
+                      </inertia>
+                    </inertial>
+                    <collision name="front_middle_right_wheel_link_collision">
+                      <pose frame="">0 0 0 1.5707963267948966 -0 0</pose>
+                      <geometry>
+                        <cylinder>
+                          <length>0.1</length>
+                          <radius>0.129</radius>
+                        </cylinder>
+                      </geometry>
+                      <surface>
+                        <contact>
+                          <ode>
+                            <kp>1e+07</kp>
+                            <kd>1</kd>
+                          </ode>
+                        </contact>
+                        <friction>
+                          <ode>
+                            <mu>0.5</mu>
+                            <mu2>1</mu2>
+                            <slip1>0.001</slip1>
+                            <slip2>0</slip2>
+                            <fdir1>0 0 1</fdir1>
+                          </ode>
+                        </friction>
+                      </surface>
+                    </collision>
+                  </link>
+                  <joint name="front_middle_right_wheel_joint" type="revolute">
+                    <child>front_middle_right_wheel_link</child>
+                    <parent>base_link</parent>
+                    <axis>
+                      <xyz>0 1 0</xyz>
+                      <limit>
+                        <lower>-1e+16</lower>
+                        <upper>1e+16</upper>
+                      </limit>
+                      <dynamics>
+                        <spring_reference>0</spring_reference>
+                        <spring_stiffness>0</spring_stiffness>
+                      </dynamics>
+                      <use_parent_model_frame>1</use_parent_model_frame>
+                    </axis>
+                  </joint>
+                  <link name="rear_middle_right_wheel_link">
+                    <pose frame="">-0.120 -0.26 0.00 0 -0 0</pose>
+                    <inertial>
+                      <pose frame="">0 0 0 0 -0 0</pose>
+                      <mass>1.5</mass>
+                      <inertia>
+                        <ixx>0.02467</ixx>
+                        <ixy>0</ixy>
+                        <ixz>0</ixz>
+                        <iyy>0.04411</iyy>
+                        <iyz>0</iyz>
+                        <izz>0.02467</izz>
+                      </inertia>
+                    </inertial>
+                    <collision name="rear_middle_right_wheel_link_collision">
+                      <pose frame="">0 0 0 1.5707963267948966 -0 0</pose>
+                      <geometry>
+                        <cylinder>
+                          <length>0.1</length>
+                          <radius>0.129</radius>
+                        </cylinder>
+                      </geometry>
+                      <surface>
+                        <contact>
+                          <ode>
+                            <kp>1e+07</kp>
+                            <kd>1</kd>
+                          </ode>
+                        </contact>
+                        <friction>
+                          <ode>
+                            <mu>0.5</mu>
+                            <mu2>1</mu2>
+                            <slip1>0.001</slip1>
+                            <slip2>0</slip2>
+                            <fdir1>0 0 1</fdir1>
+                          </ode>
+                        </friction>
+                      </surface>
+                    </collision>
+                  </link>
+                  <joint name="rear_middle_right_wheel_joint" type="revolute">
+                    <child>rear_middle_right_wheel_link</child>
+                    <parent>base_link</parent>
+                    <axis>
+                      <xyz>0 1 0</xyz>
+                      <limit>
+                        <lower>-1e+16</lower>
+                        <upper>1e+16</upper>
+                      </limit>
+                      <dynamics>
+                        <spring_reference>0</spring_reference>
+                        <spring_stiffness>0</spring_stiffness>
+                      </dynamics>
+                      <use_parent_model_frame>1</use_parent_model_frame>
+                    </axis>
+                  </joint>
+                  <link name="rear_right_wheel_link">
+                    <pose frame="">-0.36 -0.26 0.0 0 -0 0</pose>
+                    <inertial>
+                      <pose frame="">0 0 0 0 -0 0</pose>
+                      <mass>1.5</mass>
+                      <inertia>
+                        <ixx>0.02467</ixx>
+                        <ixy>0</ixy>
+                        <ixz>0</ixz>
+                        <iyy>0.04411</iyy>
+                        <iyz>0</iyz>
+                        <izz>0.02467</izz>
+                      </inertia>
+                    </inertial>
+                    <collision name="rear_right_wheel_link_collision">
+                      <pose frame="">0 0 0 1.5707963267948966 -0 0</pose>
+                      <geometry>
+                        <cylinder>
+                          <length>0.1</length>
+                          <radius>0.129</radius>
+                        </cylinder>
+                      </geometry>
+                      <surface>
+                        <contact>
+                          <ode>
+                            <kp>1e+07</kp>
+                            <kd>1</kd>
+                          </ode>
+                        </contact>
+                        <friction>
+                          <ode>
+                            <mu>0.5</mu>
+                            <mu2>1</mu2>
+                            <slip1>0.001</slip1>
+                            <slip2>0</slip2>
+                            <fdir1>0 0 1</fdir1>
+                          </ode>
+                        </friction>
+                      </surface>
+                    </collision>
+                  </link>
+                  <joint name="rear_right_wheel_joint" type="revolute">
+                    <child>rear_right_wheel_link</child>
+                    <parent>base_link</parent>
+                    <axis>
+                      <xyz>0 1 0</xyz>
+                      <limit>
+                        <lower>-1e+16</lower>
+                        <upper>1e+16</upper>
+                      </limit>
+                      <dynamics>
+                        <spring_reference>0</spring_reference>
+                        <spring_stiffness>0</spring_stiffness>
+                      </dynamics>
+                      <use_parent_model_frame>1</use_parent_model_frame>
+                    </axis>
+                  </joint>
+                  <!-- Gimbal Links + Joints -->
+                  <link name="pan_gimbal_link">
+                    <pose frame="">0.4056 -0.01122 0.4904 0 -0 0</pose>
+                    <inertial>
+                      <pose frame="">0 0 0 0 -0 0</pose>
+                      <mass>0.1</mass>
+                      <inertia>
+                        <ixx>0.000016875</ixx>
+                        <ixy>0</ixy>
+                        <ixz>0</ixz>
+                        <iyy>0.00000001</iyy>
+                        <iyz>0</iyz>
+                        <izz>0.000016875</izz>
+                      </inertia>
+                    </inertial>
+                    <collision name="pan_gimbal_link_collision">
+                      <pose frame="">0.0 0 0.0 0 -0 0</pose>
+                      <geometry>
+                        <cylinder>
+                          <length>0.045</length>
+                          <radius>0.014</radius>
+                        </cylinder>
+                      </geometry>
+                      <surface>
+                        <contact>
+                          <ode>
+                            <kp>1e+07</kp>
+                            <kd>1</kd>
+                          </ode>
+                        </contact>
+                      </surface>
+                    </collision>
+
+                    <visual name= "CameraPivot_visual">
+                      <pose>0 0 0 0 0 1.57</pose>
+                      <geometry>
+                        <mesh>
+                          <uri>meshes/hd2.dae</uri>
+                          <submesh>
+                            <name>CameraPivot</name>
+                            <center>true</center>
+                          </submesh>
+                        </mesh>
+                      </geometry>
+                      <material>
+                        <diffuse>1.0 1.0 1.0</diffuse>
+                        <specular>1.0 1.0 1.0</specular>
+                        <pbr>
+                          <metal>
+                            <albedo_map>materials/textures/HD2_Albedo.jpg</albedo_map>
+                            <metalness_map>materials/textures/HD2_Metalness.jpg</metalness_map>
+                            <roughness_map>materials/textures/HD2_Roughness.jpg</roughness_map>
+                          </metal>
+                        </pbr>
+                        <script>
+                          <uri>materials/scripts/</uri>
+                          <uri>materials/textures/</uri>
+                          <name>HD2/HD2_Diffuse</name>
+                        </script>
+                      </material>
+                    </visual>
+
+                  </link>
+                  <link name="tilt_gimbal_link">
+                    <pose frame="">0.409 -0.008 0.5013 0 -0 0</pose>
+                    <inertial>
+                      <pose frame="">0 0 0 1.570796 -0 0</pose>
+                      <mass>0.1</mass>
+                      <inertia>
+                        <ixx>0.000016875</ixx>
+                        <ixy>0</ixy>
+                        <ixz>0</ixz>
+                        <iyy>0.00000001</iyy>
+                        <iyz>0</iyz>
+                        <izz>0.000016875</izz>
+                      </inertia>
+                    </inertial>
+                    <collision name="tilt_gimbal_link_collision">
+                      <pose frame="">0.0 0 0.0 1.570796 -0 0</pose>
+                      <geometry>
+                        <cylinder>
+                          <length>0.045</length>
+                          <radius>0.014</radius>
+                        </cylinder>
+                      </geometry>
+                      <surface>
+                        <contact>
+                          <ode>
+                            <kp>1e+07</kp>
+                            <kd>1</kd>
+                          </ode>
+                        </contact>
+                      </surface>
+                    </collision>
+
+                    <visual name= "CameraTilt_visual">
+                      <pose>0.005 0.015 0.038 0 0 -1.570796</pose>
+                      <geometry>
+                        <mesh>
+                          <uri>meshes/hd2.dae</uri>
+                          <submesh>
+                            <name>CameraTilt</name>
+                            <center>true</center>
+                          </submesh>
+                        </mesh>
+                      </geometry>
+                      <material>
+                        <diffuse>1.0 1.0 1.0</diffuse>
+                        <specular>1.0 1.0 1.0</specular>
+                        <pbr>
+                          <metal>
+                            <albedo_map>materials/textures/HD2_Albedo.jpg</albedo_map>
+                            <metalness_map>materials/textures/HD2_Metalness.jpg</metalness_map>
+                            <roughness_map>materials/textures/HD2_Roughness.jpg</roughness_map>
+                          </metal>
+                        </pbr>
+                        <!-- fallback to script if no PBR support-->
+                        <script>
+                          <uri>materials/scripts/</uri>
+                          <uri>materials/textures/</uri>
+                          <name>HD/HD2_Diffuse</name>
+                        </script>
+                      </material>
+                    </visual>
+
+                    <!-- Based on Intel realsense D435 (intrinsics and distortion not modeled)-->
+                    <sensor name="camera_pan_tilt" type="rgbd_camera">
+                      <camera name="camera_pan_tilt">
+                        <horizontal_fov>1.5184</horizontal_fov>
+                        <lens>
+                          <intrinsics>
+                            <!-- fx = fy = width / ( 2 * tan (hfov / 2 ) ) -->
+                            <fx>337.22195</fx>
+                            <fy>337.22195</fy>
+                            <!-- cx = ( width + 1 ) / 2 -->
+                            <cx>320.5</cx>
+                            <!-- cy = ( height + 1 ) / 2 -->
+                            <cy>240.5</cy>
+                            <s>0</s>
+                          </intrinsics>
+                        </lens>
+                        <distortion>
+                          <k1>0.0</k1>
+                          <k2>0.0</k2>
+                          <k3>0.0</k3>
+                          <p1>0.0</p1>
+                          <p2>0.0</p2>
+                          <center>0.5 0.5</center>
+                        </distortion>
+                        <image>
+                          <width>640</width>
+                          <height>480</height>
+                          <format>R8G8B8</format>
+                        </image>
+                        <clip>
+                          <near>0.01</near>
+                          <far>300</far>
+                        </clip>
+                        <depth_camera>
+                          <clip>
+                            <near>0.1</near>
+                            <far>10</far>
+                          </clip>
+                        </depth_camera>
+                        <noise>
+                          <type>gaussian</type>
+                          <mean>0</mean>
+                          <stddev>0.007</stddev>
+                        </noise>
+                      </camera>
+                      <always_on>1</always_on>
+                      <update_rate>30</update_rate>
+                      <!-- <pose frame="">0.424 0 0.542 0 0.0 0</pose>  -->
+                      <pose frame="">0.0 0 0.03 0 0.0 0</pose>
+                    </sensor>
+
+                    <light name="flashlight_flashlight_light_source_lamp_light" type="spot">
+                      <pose frame="">0.02 -0.01 0.076 3.141592653589793 1.5707963267948966 -0.0015926535897931</pose>
+                      <attenuation>
+                        <range>50</range>
+                        <linear>0</linear>
+                        <constant>0.1</constant>
+                        <quadratic>0.0025</quadratic>
+                      </attenuation>
+                      <diffuse>0.8 0.8 0.5 1</diffuse>
+                      <specular>0.8 0.8 0.5 1</specular>
+                      <spot>
+                        <!-- The lights on the MARBLE ground vehicles are very wide angle, 100W LEDs -->
+                        <inner_angle>2.8</inner_angle>
+                        <outer_angle>2.9</outer_angle>
+                        <falloff>1</falloff>
+                      </spot>
+                      <direction>0 0 -1</direction>
+                    </light>
+                  </link>
+                  <joint name="pan_gimbal_joint" type="revolute">
+                    <child>pan_gimbal_link</child>
+                    <parent>base_link</parent>
+                    <axis>
+                      <xyz>0 0 1</xyz>
+                      <limit>
+                        <lower>-1e+16</lower>
+                        <upper>1e+16</upper>
+                        <effort>10</effort>
+                      </limit>
+                      <dynamics>
+                        <spring_reference>0</spring_reference>
+                        <spring_stiffness>0</spring_stiffness>
+                        <damping>0.5</damping>
+                        <friction>0.001</friction>
+                      </dynamics>
+                      <use_parent_model_frame>1</use_parent_model_frame>
+                    </axis>
+                  </joint>
+                  <joint name="tilt_gimbal_joint" type="revolute">
+                    <child>tilt_gimbal_link</child>
+                    <parent>pan_gimbal_link</parent>
+                    <axis>
+                      <xyz>0 1 0</xyz>
+                      <limit>
+                        <lower>-1.5708</lower>
+                        <!-- 90 degrees both direction (mechanical interference)-->
+                        <upper>1.5708</upper>
+                        <effort>10</effort>
+                      </limit>
+                      <dynamics>
+                        <spring_reference>0</spring_reference>
+                        <spring_stiffness>0</spring_stiffness>
+                        <damping>0.5</damping>
+                      </dynamics>
+                      <use_parent_model_frame>1</use_parent_model_frame>
+                    </axis>
+                  </joint>
+                  <!-- Gimbal Joints Plugins -->
+                  <plugin filename="libignition-gazebo-joint-controller-system.so" name="ignition::gazebo::systems::JointController">
+                    <joint_name>pan_gimbal_joint</joint_name>
+                    <use_force_commands>true</use_force_commands>
+                    <p_gain>0.4</p_gain>
+                    <i_gain>10</i_gain>
+                  </plugin>
+                  <plugin filename="libignition-gazebo-joint-controller-system.so" name="ignition::gazebo::systems::JointController">
+                    <joint_name>tilt_gimbal_joint</joint_name>
+                    <use_force_commands>true</use_force_commands>
+                    <p_gain>0.4</p_gain>
+                    <i_gain>10</i_gain>
+                  </plugin>
+                  <plugin filename="libignition-gazebo-joint-state-publisher-system.so" name="ignition::gazebo::systems::JointStatePublisher">
+                    <joint_name>pan_gimbal_joint</joint_name>
+                    <joint_name>tilt_gimbal_joint</joint_name>
+                  </plugin>
+                  <static>0</static>
+                </model>
+              </sdf>

--- a/submitted_models/marble_hd2_sensor_config_4/README.md
+++ b/submitted_models/marble_hd2_sensor_config_4/README.md
@@ -1,0 +1,5 @@
+This package spawns a `MARBLE_HD2_SENSOR_CONFIG_2` with an additional
+thermal camera
+
+The `model.sdf` is not used but added here as a reference to show what is on
+the SubT Tech Repo. Please keep this `model.sdf` update-to-date

--- a/submitted_models/marble_hd2_sensor_config_4/README.md
+++ b/submitted_models/marble_hd2_sensor_config_4/README.md
@@ -2,4 +2,5 @@ This package spawns a `MARBLE_HD2_SENSOR_CONFIG_2` robot with an additional
 thermal camera
 
 The `model.sdf` is not used but added here as a reference to show what is on
-the SubT Tech Repo. Please keep this `model.sdf` update-to-date
+the SubT Tech Repo. Please keep this `model.sdf` update-to-date with
+`MARBLE_HD2_SENSOR_CONFIG_2`

--- a/submitted_models/marble_hd2_sensor_config_4/README.md
+++ b/submitted_models/marble_hd2_sensor_config_4/README.md
@@ -1,4 +1,4 @@
-This package spawns a `MARBLE_HD2_SENSOR_CONFIG_2` with an additional
+This package spawns a `MARBLE_HD2_SENSOR_CONFIG_2` robot with an additional
 thermal camera
 
 The `model.sdf` is not used but added here as a reference to show what is on

--- a/submitted_models/marble_hd2_sensor_config_4/model.sdf
+++ b/submitted_models/marble_hd2_sensor_config_4/model.sdf
@@ -1,0 +1,1165 @@
+<?xml version='1.0' encoding='utf-8'?>
+<sdf version="1.6">
+  <model name="marble_hd2_sensor_config_4">
+    <link name="base_link">
+      <pose frame="">0 0 0 0 -0 0</pose>
+      <inertial>
+        <pose frame="">-0.000649 -0.084945 0.062329 0 -0 0</pose>
+        <mass>21.8194</mass>
+        <inertia>
+          <ixx>0.615397</ixx>
+          <ixy>-0.0240585</ixy>
+          <ixz>-0.120749</ixz>
+          <iyy>1.75388</iyy>
+          <iyz>-0.0028322</iyz>
+          <izz>2.03641</izz>
+        </inertia>
+      </inertial>
+      <collision name="base_link_collision">
+        <pose frame="">0 0 0.12 0 0 0</pose>
+        <geometry>
+          <box>
+            <size>0.9874 0.5709 0.05</size>
+          </box>
+        </geometry>
+      </collision>
+      <collision name="base_link_collision_bottom">
+        <pose frame="">0 0 0.046 0 0 0</pose>
+        <geometry>
+          <box>
+            <size>0.80 0.5709 0.2</size>
+          </box>
+        </geometry>
+      </collision>
+      <collision name="base_link_collision_1">
+        <pose frame="">0 0 0.185625 0 -0 0</pose>
+        <geometry>
+          <box>
+            <size>0.78992 0.5709 0.12375</size>
+          </box>
+        </geometry>
+      </collision>
+      <collision name="base_link_fixed_joint_lump__camera/camera_link_collision_1">
+        <pose frame="pan_gimbal_link">0 0 0.05 0 0.0 0</pose>
+        <geometry>
+          <box>
+            <size>0.0078 0.13 0.0192</size>
+          </box>
+        </geometry>
+        <surface>
+          <contact>
+            <ode>
+              <kp>1e+13</kp>
+              <kd>1</kd>
+            </ode>
+          </contact>
+          <friction>
+            <ode>
+              <mu2>1</mu2>
+              <fdir1>0 0 0</fdir1>
+            </ode>
+          </friction>
+        </surface>
+      </collision>
+      <collision name="base_link_fixed_joint_lump__camera/camera_link_collision_2">
+        <pose frame="">0.485 0 0.31 0 -0 0</pose>
+        <geometry>
+          <box>
+            <size>0.0078 0.13 0.0192</size>
+          </box>
+        </geometry>
+        <surface>
+          <contact>
+            <ode>
+              <kp>1e+13</kp>
+              <kd>1</kd>
+            </ode>
+          </contact>
+          <friction>
+            <ode>
+              <mu2>1</mu2>
+              <fdir1>0 0 0</fdir1>
+            </ode>
+          </friction>
+        </surface>
+      </collision>
+      <collision name="base_link_fixed_joint_lump__camera/camera_link_collision_3">
+        <pose frame="">0.473 0 0.260 0 0.5236 0</pose>
+        <geometry>
+          <box>
+            <size>0.0078 0.13 0.0192</size>
+          </box>
+        </geometry>
+        <surface>
+          <contact>
+            <ode>
+              <kp>1e+13</kp>
+              <kd>1</kd>
+            </ode>
+          </contact>
+          <friction>
+            <ode>
+              <mu2>1</mu2>
+              <fdir1>0 0 0</fdir1>
+            </ode>
+          </friction>
+        </surface>
+      </collision>
+      <collision name="base_link_fixed_joint_lump__velodyne_base_link_collision_6">
+        <pose frame="">0.403 0 0.36 0 -0 0</pose>
+        <geometry>
+          <cylinder>
+            <length>0.0717</length>
+            <radius>0.0516</radius>
+          </cylinder>
+        </geometry>
+      </collision>
+      <collision name="base_link_fixed_joint_lump__velodyne_gimbal_plate_base_link_collision_7">
+        <pose frame="">0.403 0 0.410 0 -0 0</pose>
+        <geometry>
+          <box>
+            <size>0.1 0.1 0.01</size>
+          </box>
+        </geometry>
+      </collision>
+      <collision name="base_link_fixed_joint_lump__sensor_tower_8">
+        <pose frame="">0.374 0 0.215 0 -0 0</pose>
+        <geometry>
+          <box>
+            <size>0.2 0.25 0.225</size>
+          </box>
+        </geometry>
+      </collision>
+      <collision name="base_link_fixed_joint_lump__computer_block_9">
+        <pose frame="">0.050 0 0.155 0 -0 0</pose>
+        <geometry>
+          <box>
+            <size>0.30 0.355 0.160</size>
+          </box>
+        </geometry>
+      </collision>
+      <visual name="Body_visual">
+        <pose>0 0 -0.135 0 0 1.57</pose>
+        <geometry>
+          <mesh>
+            <uri>meshes/hd2.dae</uri>
+            <submesh>
+              <name>Body</name>
+              <center>false</center>
+            </submesh>
+          </mesh>
+        </geometry>
+        <material>
+          <diffuse>1.0 1.0 1.0</diffuse>
+          <specular>1.0 1.0 1.0</specular>
+          <pbr>
+            <metal>
+              <albedo_map>materials/textures/HD2_Albedo.jpg</albedo_map>
+              <metalness_map>materials/textures/HD2_Metalness.jpg</metalness_map>
+              <roughness_map>materials/textures/HD2_Roughness.jpg</roughness_map>
+            </metal>
+          </pbr>
+          <!-- fallback to script if no PBR support-->
+          <script>
+            <uri>materials/scripts/</uri>
+            <uri>materials/textures/</uri>
+            <name>HD/HD2_Diffuse</name>
+          </script>
+        </material>
+      </visual>
+
+      <!-- thermal camera -->
+      <visual name="thermal_camera_visual">
+        <pose>0.435 -.01 0.125 0 0 0</pose>
+        <geometry>
+          <box>
+            <size>0.02 0.025 0.025</size>
+          </box>
+        </geometry>
+      </visual>
+      <sensor name="thermal_camera" type="thermal">
+        <pose>0.435 -.01 0.125 0 0 0</pose>
+        <camera name="thermal_camera">
+          <horizontal_fov>0.4922</horizontal_fov>
+          <lens>
+            <intrinsics>
+              <!-- fx = fy = width / ( 2 * tan (hfov / 2 ) ) -->
+              <fx>764.35630</fx>
+              <fy>764.35630</fy>
+              <!-- cx = ( width + 1 ) / 2 -->
+              <cx>192.5</cx>
+              <!-- cy = ( height + 1 ) / 2 -->
+              <cy>144.5</cy>
+              <s>0</s>
+            </intrinsics>
+          </lens>
+          <image>
+            <width>384</width>
+            <height>288</height>
+            <format>L8</format>
+          </image>
+          <clip>
+            <near>0.1</near>
+            <far>100</far>
+          </clip>
+        </camera>
+        <always_on>1</always_on>
+        <update_rate>25</update_rate>
+        <plugin
+          filename="ignition-gazebo-thermal-sensor-system"
+          name="ignition::gazebo::systems::ThermalSensor">
+          <min_temp>253.15</min_temp>
+          <max_temp>673.15</max_temp>
+          <resolution>1.6</resolution>
+        </plugin>
+      </sensor>
+
+      <!-- Based on Intel realsense D435 (intrinsics and distortion not modeled)-->
+      <sensor name="camera_front" type="rgbd_camera">
+        <camera name="camera_front">
+          <horizontal_fov>1.5184</horizontal_fov>
+          <lens>
+            <intrinsics>
+              <!-- fx = fy = width / ( 2 * tan (hfov / 2 ) ) -->
+              <fx>168.61097</fx>
+              <fy>168.61097</fy>
+              <!-- cx = ( width + 1 ) / 2 -->
+              <cx>160.5</cx>
+              <!-- cy = ( height + 1 ) / 2 -->
+              <cy>120.5</cy>
+              <s>0</s>
+            </intrinsics>
+          </lens>
+          <distortion>
+            <k1>0.0</k1>
+            <k2>0.0</k2>
+            <k3>0.0</k3>
+            <p1>0.0</p1>
+            <p2>0.0</p2>
+            <center>0.5 0.5</center>
+          </distortion>
+          <image>
+            <width>320</width>
+            <height>240</height>
+            <format>R8G8B8</format>
+          </image>
+          <clip>
+            <near>0.01</near>
+            <far>300</far>
+          </clip>
+          <depth_camera>
+            <clip>
+              <near>0.1</near>
+              <far>10</far>
+            </clip>
+          </depth_camera>
+          <noise>
+            <type>gaussian</type>
+            <mean>0</mean>
+            <stddev>0.007</stddev>
+          </noise>
+        </camera>
+        <always_on>1</always_on>
+        <update_rate>30</update_rate>
+        <pose frame="">0.485 0 0.31 0 -0 0</pose>
+      </sensor>
+      <gravity>1</gravity>
+      <velocity_decay/>
+      <!-- Based on Intel realsense D435 (intrinsics and distortion not modeled)-->
+      <sensor name="camera_down" type="rgbd_camera">
+        <camera name="camera_down">
+          <horizontal_fov>1.5184</horizontal_fov>
+          <lens>
+            <intrinsics>
+              <!-- fx = fy = width / ( 2 * tan (hfov / 2 ) ) -->
+              <fx>168.61097</fx>
+              <fy>168.61097</fy>
+              <!-- cx = ( width + 1 ) / 2 -->
+              <cx>160.5</cx>
+              <!-- cy = ( height + 1 ) / 2 -->
+              <cy>120.5</cy>
+              <s>0</s>
+            </intrinsics>
+          </lens>
+          <distortion>
+            <k1>0.0</k1>
+            <k2>0.0</k2>
+            <k3>0.0</k3>
+            <p1>0.0</p1>
+            <p2>0.0</p2>
+            <center>0.5 0.5</center>
+          </distortion>
+          <image>
+            <width>320</width>
+            <height>240</height>
+            <format>R8G8B8</format>
+          </image>
+          <clip>
+            <near>0.01</near>
+            <far>300</far>
+          </clip>
+          <depth_camera>
+            <clip>
+              <near>0.1</near>
+              <far>10</far>
+            </clip>
+          </depth_camera>
+          <noise>
+            <type>gaussian</type>
+            <mean>0</mean>
+            <stddev>0.007</stddev>
+          </noise>
+        </camera>
+        <always_on>1</always_on>
+        <update_rate>30</update_rate>
+        <pose frame="">0.473 0 0.260 0 0.5236 0</pose>
+        <!-- 30 degree download look-->
+      </sensor>
+      <gravity>1</gravity>
+      <velocity_decay/>
+      <!-- Based on RPLidar S1 -->
+      <sensor name="planar_laser" type="gpu_ray">
+        <pose>0.403 0 0.127 0 -0 0</pose>
+        <update_rate>10</update_rate>
+        <lidar>
+          <scan>
+            <horizontal>
+              <samples>920</samples>
+              <resolution>1</resolution>
+              <min_angle>-3.14159</min_angle>
+              <max_angle>3.14159</max_angle>
+            </horizontal>
+          </scan>
+          <range>
+            <min>0.04</min>
+            <max>25</max>
+            <resolution>0.03</resolution>
+          </range>
+          <noise>
+            <type>gaussian</type>
+            <mean>0</mean>
+            <stddev>0.01</stddev>
+          </noise>
+        </lidar>
+      </sensor>
+      <gravity>1</gravity>
+      <velocity_decay/>
+      <!-- OS1-64 3D Laser Configuration (10x2048 or 10x1024 or 20x1024 or 20x512 as possible (rate) x (hor. res.) configs)-->
+      <sensor name="front_laser" type="gpu_lidar">
+        <update_rate>20</update_rate>
+        <lidar>
+          <scan>
+            <horizontal>
+                            <samples>1024</samples>
+                            <resolution>1</resolution>
+                            <min_angle>-3.1459</min_angle>
+                            <max_angle>3.1459</max_angle>
+                          </horizontal>
+                          <vertical>
+                            <samples>64</samples>
+                            <resolution>1</resolution>
+                            <min_angle>-0.2897</min_angle>
+                            <max_angle>0.2897</max_angle>
+                          </vertical>
+                        </scan>
+                        <range>
+                          <min>0.8</min>
+                          <max>120</max>
+                          <resolution>0.003</resolution>
+                        </range>
+                        <noise>
+                          <type>gaussian</type>
+                          <mean>0</mean>
+                          <stddev>0.03</stddev>
+                        </noise>
+                      </lidar>
+                      <pose frame="">0.403 0 0.36 0 -0 0</pose>
+                    </sensor>
+                    <sensor name="imu_sensor" type="imu">
+                      <always_on>1</always_on>
+                      <update_rate>50</update_rate>
+                      <imu>
+                    <angular_velocity>
+                        <x>
+                            <noise type="gaussian">
+                                <mean>0</mean>
+                                <stddev>0.009</stddev>
+                                <bias_mean>0.00075</bias_mean>
+                                <bias_stddev>0.005</bias_stddev>
+                                <dynamic_bias_stddev>0.00002</dynamic_bias_stddev>
+                                <dynamic_bias_correlation_time>400.0</dynamic_bias_correlation_time>
+                                <precision>0.00025</precision>
+                            </noise>
+                        </x>
+                        <y>
+                            <noise type="gaussian">
+                                <mean>0</mean>
+                                <stddev>0.009</stddev>
+                                <bias_mean>0.00075</bias_mean>
+                                <bias_stddev>0.005</bias_stddev>
+                                <dynamic_bias_stddev>0.00002</dynamic_bias_stddev>
+                                <dynamic_bias_correlation_time>400.0</dynamic_bias_correlation_time>
+                                <precision>0.00025</precision>
+                            </noise>
+                        </y>
+                        <z>
+                            <noise type="gaussian">
+                                <mean>0</mean>
+                                <stddev>0.009</stddev>
+                                <bias_mean>0.00075</bias_mean>
+                                <bias_stddev>0.005</bias_stddev>
+                                <dynamic_bias_stddev>0.00002</dynamic_bias_stddev>
+                                <dynamic_bias_correlation_time>400.0</dynamic_bias_correlation_time>
+                                <precision>0.00025</precision>
+                            </noise>
+                        </z>
+                    </angular_velocity>
+                    <linear_acceleration>
+                        <x>
+                            <noise type="gaussian">
+                                <mean>0</mean>
+                                <stddev>0.021</stddev>
+                                <bias_mean>0.05</bias_mean>
+                                <bias_stddev>0.0075</bias_stddev>
+                                <dynamic_bias_stddev>0.000375</dynamic_bias_stddev>
+                                <dynamic_bias_correlation_time>175.0</dynamic_bias_correlation_time>
+                                <precision>0.005</precision>
+                            </noise>
+                        </x>
+                        <y>
+                            <noise type="gaussian">
+                                <mean>0</mean>
+                                <stddev>0.021</stddev>
+                                <bias_mean>0.05</bias_mean>
+                                <bias_stddev>0.0075</bias_stddev>
+                                <dynamic_bias_stddev>0.000375</dynamic_bias_stddev>
+                                <dynamic_bias_correlation_time>175.0</dynamic_bias_correlation_time>
+                                <precision>0.005</precision>
+                            </noise>
+                        </y>
+                        <z>
+                            <noise type="gaussian">
+                                <mean>0</mean>
+                                <stddev>0.021</stddev>
+                                <bias_mean>0.05</bias_mean>
+                                <bias_stddev>0.0075</bias_stddev>
+                                <dynamic_bias_stddev>0.000375</dynamic_bias_stddev>
+                                <dynamic_bias_correlation_time>175.0</dynamic_bias_correlation_time>
+                                <precision>0.005</precision>
+                            </noise>
+                        </z>
+                    </linear_acceleration>
+                </imu>
+                    </sensor>
+                  </link>
+                  <!-- Left Side Wheels  -->
+                  <link name="front_left_wheel_link">
+                    <pose frame="">0.360 0.26 0.00 0 -0 0</pose>
+                    <inertial>
+                      <pose frame="">0 0 0 0 -0 0</pose>
+                      <mass>1.5</mass>
+                      <inertia>
+                        <ixx>0.02467</ixx>
+                        <ixy>0</ixy>
+                        <ixz>0</ixz>
+                        <iyy>0.04411</iyy>
+                        <iyz>0</iyz>
+                        <izz>0.02467</izz>
+                      </inertia>
+                    </inertial>
+                    <collision name="front_left_wheel_link_collision">
+                      <pose frame="">0 0 0 1.5707963267948966 -0 0</pose>
+                      <geometry>
+                        <cylinder>
+                          <length>0.1</length>
+                          <radius>0.129</radius>
+                        </cylinder>
+                      </geometry>
+                      <surface>
+                        <contact>
+                          <ode>
+                            <kp>1e+07</kp>
+                            <kd>1</kd>
+                          </ode>
+                        </contact>
+                        <friction>
+                          <ode>
+                            <mu>0.5</mu>
+                            <mu2>1</mu2>
+                            <slip1>0.001</slip1>
+                            <slip2>0</slip2>
+                            <fdir1>0 0 1</fdir1>
+                          </ode>
+                        </friction>
+                      </surface>
+                    </collision>
+                  </link>
+                  <joint name="front_left_wheel_joint" type="revolute">
+                    <child>front_left_wheel_link</child>
+                    <parent>base_link</parent>
+                    <axis>
+                      <xyz>0 1 0</xyz>
+                      <limit>
+                        <lower>-1e+16</lower>
+                        <upper>1e+16</upper>
+                      </limit>
+                      <dynamics>
+                        <spring_reference>0</spring_reference>
+                        <spring_stiffness>0</spring_stiffness>
+                      </dynamics>
+                      <use_parent_model_frame>1</use_parent_model_frame>
+                    </axis>
+                  </joint>
+                  <link name="front_middle_left_wheel_link">
+                    <pose frame="">0.120 0.26 0.00 0 -0 0</pose>
+                    <inertial>
+                      <pose frame="">0 0 0 0 -0 0</pose>
+                      <mass>1.5</mass>
+                      <inertia>
+                        <ixx>0.02467</ixx>
+                        <ixy>0</ixy>
+                        <ixz>0</ixz>
+                        <iyy>0.04411</iyy>
+                        <iyz>0</iyz>
+                        <izz>0.02467</izz>
+                      </inertia>
+                    </inertial>
+                    <collision name="front_middle_left_wheel_link_collision">
+                      <pose frame="">0 0 0 1.5707963267948966 -0 0</pose>
+                      <geometry>
+                        <cylinder>
+                          <length>0.1</length>
+                          <radius>0.129</radius>
+                        </cylinder>
+                      </geometry>
+                      <surface>
+                        <contact>
+                          <ode>
+                            <kp>1e+07</kp>
+                            <kd>1</kd>
+                          </ode>
+                        </contact>
+                        <friction>
+                          <ode>
+                            <mu>0.5</mu>
+                            <mu2>1</mu2>
+                            <slip1>0.001</slip1>
+                            <slip2>0</slip2>
+                            <fdir1>0 0 1</fdir1>
+                          </ode>
+                        </friction>
+                      </surface>
+                    </collision>
+                  </link>
+                  <joint name="front_middle_left_wheel_joint" type="revolute">
+                    <child>front_middle_left_wheel_link</child>
+                    <parent>base_link</parent>
+                    <axis>
+                      <xyz>0 1 0</xyz>
+                      <limit>
+                        <lower>-1e+16</lower>
+                        <upper>1e+16</upper>
+                      </limit>
+                      <dynamics>
+                        <spring_reference>0</spring_reference>
+                        <spring_stiffness>0</spring_stiffness>
+                      </dynamics>
+                      <use_parent_model_frame>1</use_parent_model_frame>
+                    </axis>
+                  </joint>
+                  <link name="rear_middle_left_wheel_link">
+                    <pose frame="">-0.120 0.26 0.00 0 -0 0</pose>
+                    <inertial>
+                      <pose frame="">0 0 0 0 -0 0</pose>
+                      <mass>1.5</mass>
+                      <inertia>
+                        <ixx>0.02467</ixx>
+                        <ixy>0</ixy>
+                        <ixz>0</ixz>
+                        <iyy>0.04411</iyy>
+                        <iyz>0</iyz>
+                        <izz>0.02467</izz>
+                      </inertia>
+                    </inertial>
+                    <collision name="rear_middle_left_wheel_link_collision">
+                      <pose frame="">0 0 0 1.5707963267948966 -0 0</pose>
+                      <geometry>
+                        <cylinder>
+                          <length>0.1</length>
+                          <radius>0.129</radius>
+                        </cylinder>
+                      </geometry>
+                      <surface>
+                        <contact>
+                          <ode>
+                            <kp>1e+07</kp>
+                            <kd>1</kd>
+                          </ode>
+                        </contact>
+                        <friction>
+                          <ode>
+                            <mu>0.5</mu>
+                            <mu2>1</mu2>
+                            <slip1>0.001</slip1>
+                            <slip2>0</slip2>
+                            <fdir1>0 0 1</fdir1>
+                          </ode>
+                        </friction>
+                      </surface>
+                    </collision>
+                  </link>
+                  <joint name="rear_middle_left_wheel_joint" type="revolute">
+                    <child>rear_middle_left_wheel_link</child>
+                    <parent>base_link</parent>
+                    <axis>
+                      <xyz>0 1 0</xyz>
+                      <limit>
+                        <lower>-1e+16</lower>
+                        <upper>1e+16</upper>
+                      </limit>
+                      <dynamics>
+                        <spring_reference>0</spring_reference>
+                        <spring_stiffness>0</spring_stiffness>
+                      </dynamics>
+                      <use_parent_model_frame>1</use_parent_model_frame>
+                    </axis>
+                  </joint>
+                  <link name="rear_left_wheel_link">
+                    <pose frame="">-0.36 0.26 0.0 0 -0 0</pose>
+                    <inertial>
+                      <pose frame="">0 0 0 0 -0 0</pose>
+                      <mass>1.5</mass>
+                      <inertia>
+                        <ixx>0.02467</ixx>
+                        <ixy>0</ixy>
+                        <ixz>0</ixz>
+                        <iyy>0.04411</iyy>
+                        <iyz>0</iyz>
+                        <izz>0.02467</izz>
+                      </inertia>
+                    </inertial>
+                    <collision name="rear_left_wheel_link_collision">
+                      <pose frame="">0 0 0 1.5707963267948966 -0 0</pose>
+                      <geometry>
+                        <cylinder>
+                          <length>0.1</length>
+                          <radius>0.129</radius>
+                        </cylinder>
+                      </geometry>
+                      <surface>
+                        <contact>
+                          <ode>
+                            <kp>1e+07</kp>
+                            <kd>1</kd>
+                          </ode>
+                        </contact>
+                        <friction>
+                          <ode>
+                            <mu>0.5</mu>
+                            <mu2>1</mu2>
+                            <slip1>0.001</slip1>
+                            <slip2>0</slip2>
+                            <fdir1>0 0 1</fdir1>
+                          </ode>
+                        </friction>
+                      </surface>
+                    </collision>
+                  </link>
+                  <joint name="rear_left_wheel_joint" type="revolute">
+                    <child>rear_left_wheel_link</child>
+                    <parent>base_link</parent>
+                    <axis>
+                      <xyz>0 1 0</xyz>
+                      <limit>
+                        <lower>-1e+16</lower>
+                        <upper>1e+16</upper>
+                      </limit>
+                      <dynamics>
+                        <spring_reference>0</spring_reference>
+                        <spring_stiffness>0</spring_stiffness>
+                      </dynamics>
+                      <use_parent_model_frame>1</use_parent_model_frame>
+                    </axis>
+                  </joint>
+                  <!-- Right Side Wheels -->
+                  <link name="front_right_wheel_link">
+                    <pose frame="">0.360 -0.26 0.00 0 -0 0</pose>
+                    <inertial>
+                      <pose frame="">0 0 0 0 -0 0</pose>
+                      <mass>1.5</mass>
+                      <inertia>
+                        <ixx>0.02467</ixx>
+                        <ixy>0</ixy>
+                        <ixz>0</ixz>
+                        <iyy>0.04411</iyy>
+                        <iyz>0</iyz>
+                        <izz>0.02467</izz>
+                      </inertia>
+                    </inertial>
+                    <collision name="front_right_wheel_link_collision">
+                      <pose frame="">0 0 0 1.5707963267948966 -0 0</pose>
+                      <geometry>
+                        <cylinder>
+                          <length>0.1</length>
+                          <radius>0.129</radius>
+                        </cylinder>
+                      </geometry>
+                      <surface>
+                        <contact>
+                          <ode>
+                            <kp>1e+07</kp>
+                            <kd>1</kd>
+                          </ode>
+                        </contact>
+                        <friction>
+                          <ode>
+                            <mu>0.5</mu>
+                            <mu2>1</mu2>
+                            <slip1>0.001</slip1>
+                            <slip2>0</slip2>
+                            <fdir1>0 0 1</fdir1>
+                          </ode>
+                        </friction>
+                      </surface>
+                    </collision>
+                  </link>
+                  <joint name="front_right_wheel_joint" type="revolute">
+                    <child>front_right_wheel_link</child>
+                    <parent>base_link</parent>
+                    <axis>
+                      <xyz>0 1 0</xyz>
+                      <limit>
+                        <lower>-1e+16</lower>
+                        <upper>1e+16</upper>
+                      </limit>
+                      <dynamics>
+                        <spring_reference>0</spring_reference>
+                        <spring_stiffness>0</spring_stiffness>
+                      </dynamics>
+                      <use_parent_model_frame>1</use_parent_model_frame>
+                    </axis>
+                  </joint>
+                  <link name="front_middle_right_wheel_link">
+                    <pose frame="">0.120 -0.26 0.00 0 -0 0</pose>
+                    <inertial>
+                      <pose frame="">0 0 0 0 -0 0</pose>
+                      <mass>1.5</mass>
+                      <inertia>
+                        <ixx>0.02467</ixx>
+                        <ixy>0</ixy>
+                        <ixz>0</ixz>
+                        <iyy>0.04411</iyy>
+                        <iyz>0</iyz>
+                        <izz>0.02467</izz>
+                      </inertia>
+                    </inertial>
+                    <collision name="front_middle_right_wheel_link_collision">
+                      <pose frame="">0 0 0 1.5707963267948966 -0 0</pose>
+                      <geometry>
+                        <cylinder>
+                          <length>0.1</length>
+                          <radius>0.129</radius>
+                        </cylinder>
+                      </geometry>
+                      <surface>
+                        <contact>
+                          <ode>
+                            <kp>1e+07</kp>
+                            <kd>1</kd>
+                          </ode>
+                        </contact>
+                        <friction>
+                          <ode>
+                            <mu>0.5</mu>
+                            <mu2>1</mu2>
+                            <slip1>0.001</slip1>
+                            <slip2>0</slip2>
+                            <fdir1>0 0 1</fdir1>
+                          </ode>
+                        </friction>
+                      </surface>
+                    </collision>
+                  </link>
+                  <joint name="front_middle_right_wheel_joint" type="revolute">
+                    <child>front_middle_right_wheel_link</child>
+                    <parent>base_link</parent>
+                    <axis>
+                      <xyz>0 1 0</xyz>
+                      <limit>
+                        <lower>-1e+16</lower>
+                        <upper>1e+16</upper>
+                      </limit>
+                      <dynamics>
+                        <spring_reference>0</spring_reference>
+                        <spring_stiffness>0</spring_stiffness>
+                      </dynamics>
+                      <use_parent_model_frame>1</use_parent_model_frame>
+                    </axis>
+                  </joint>
+                  <link name="rear_middle_right_wheel_link">
+                    <pose frame="">-0.120 -0.26 0.00 0 -0 0</pose>
+                    <inertial>
+                      <pose frame="">0 0 0 0 -0 0</pose>
+                      <mass>1.5</mass>
+                      <inertia>
+                        <ixx>0.02467</ixx>
+                        <ixy>0</ixy>
+                        <ixz>0</ixz>
+                        <iyy>0.04411</iyy>
+                        <iyz>0</iyz>
+                        <izz>0.02467</izz>
+                      </inertia>
+                    </inertial>
+                    <collision name="rear_middle_right_wheel_link_collision">
+                      <pose frame="">0 0 0 1.5707963267948966 -0 0</pose>
+                      <geometry>
+                        <cylinder>
+                          <length>0.1</length>
+                          <radius>0.129</radius>
+                        </cylinder>
+                      </geometry>
+                      <surface>
+                        <contact>
+                          <ode>
+                            <kp>1e+07</kp>
+                            <kd>1</kd>
+                          </ode>
+                        </contact>
+                        <friction>
+                          <ode>
+                            <mu>0.5</mu>
+                            <mu2>1</mu2>
+                            <slip1>0.001</slip1>
+                            <slip2>0</slip2>
+                            <fdir1>0 0 1</fdir1>
+                          </ode>
+                        </friction>
+                      </surface>
+                    </collision>
+                  </link>
+                  <joint name="rear_middle_right_wheel_joint" type="revolute">
+                    <child>rear_middle_right_wheel_link</child>
+                    <parent>base_link</parent>
+                    <axis>
+                      <xyz>0 1 0</xyz>
+                      <limit>
+                        <lower>-1e+16</lower>
+                        <upper>1e+16</upper>
+                      </limit>
+                      <dynamics>
+                        <spring_reference>0</spring_reference>
+                        <spring_stiffness>0</spring_stiffness>
+                      </dynamics>
+                      <use_parent_model_frame>1</use_parent_model_frame>
+                    </axis>
+                  </joint>
+                  <link name="rear_right_wheel_link">
+                    <pose frame="">-0.36 -0.26 0.0 0 -0 0</pose>
+                    <inertial>
+                      <pose frame="">0 0 0 0 -0 0</pose>
+                      <mass>1.5</mass>
+                      <inertia>
+                        <ixx>0.02467</ixx>
+                        <ixy>0</ixy>
+                        <ixz>0</ixz>
+                        <iyy>0.04411</iyy>
+                        <iyz>0</iyz>
+                        <izz>0.02467</izz>
+                      </inertia>
+                    </inertial>
+                    <collision name="rear_right_wheel_link_collision">
+                      <pose frame="">0 0 0 1.5707963267948966 -0 0</pose>
+                      <geometry>
+                        <cylinder>
+                          <length>0.1</length>
+                          <radius>0.129</radius>
+                        </cylinder>
+                      </geometry>
+                      <surface>
+                        <contact>
+                          <ode>
+                            <kp>1e+07</kp>
+                            <kd>1</kd>
+                          </ode>
+                        </contact>
+                        <friction>
+                          <ode>
+                            <mu>0.5</mu>
+                            <mu2>1</mu2>
+                            <slip1>0.001</slip1>
+                            <slip2>0</slip2>
+                            <fdir1>0 0 1</fdir1>
+                          </ode>
+                        </friction>
+                      </surface>
+                    </collision>
+                  </link>
+                  <joint name="rear_right_wheel_joint" type="revolute">
+                    <child>rear_right_wheel_link</child>
+                    <parent>base_link</parent>
+                    <axis>
+                      <xyz>0 1 0</xyz>
+                      <limit>
+                        <lower>-1e+16</lower>
+                        <upper>1e+16</upper>
+                      </limit>
+                      <dynamics>
+                        <spring_reference>0</spring_reference>
+                        <spring_stiffness>0</spring_stiffness>
+                      </dynamics>
+                      <use_parent_model_frame>1</use_parent_model_frame>
+                    </axis>
+                  </joint>
+                  <!-- Gimbal Links + Joints -->
+                  <link name="pan_gimbal_link">
+                    <pose frame="">0.4056 -0.01122 0.4904 0 -0 0</pose>
+                    <inertial>
+                      <pose frame="">0 0 0 0 -0 0</pose>
+                      <mass>0.1</mass>
+                      <inertia>
+                        <ixx>0.000016875</ixx>
+                        <ixy>0</ixy>
+                        <ixz>0</ixz>
+                        <iyy>0.00000001</iyy>
+                        <iyz>0</iyz>
+                        <izz>0.000016875</izz>
+                      </inertia>
+                    </inertial>
+                    <collision name="pan_gimbal_link_collision">
+                      <pose frame="">0.0 0 0.0 0 -0 0</pose>
+                      <geometry>
+                        <cylinder>
+                          <length>0.045</length>
+                          <radius>0.014</radius>
+                        </cylinder>
+                      </geometry>
+                      <surface>
+                        <contact>
+                          <ode>
+                            <kp>1e+07</kp>
+                            <kd>1</kd>
+                          </ode>
+                        </contact>
+                      </surface>
+                    </collision>
+
+                    <visual name= "CameraPivot_visual">
+                      <pose>0 0 0 0 0 1.57</pose>
+                      <geometry>
+                        <mesh>
+                          <uri>meshes/hd2.dae</uri>
+                          <submesh>
+                            <name>CameraPivot</name>
+                            <center>true</center>
+                          </submesh>
+                        </mesh>
+                      </geometry>
+                      <material>
+                        <diffuse>1.0 1.0 1.0</diffuse>
+                        <specular>1.0 1.0 1.0</specular>
+                        <pbr>
+                          <metal>
+                            <albedo_map>materials/textures/HD2_Albedo.jpg</albedo_map>
+                            <metalness_map>materials/textures/HD2_Metalness.jpg</metalness_map>
+                            <roughness_map>materials/textures/HD2_Roughness.jpg</roughness_map>
+                          </metal>
+                        </pbr>
+                        <script>
+                          <uri>materials/scripts/</uri>
+                          <uri>materials/textures/</uri>
+                          <name>HD2/HD2_Diffuse</name>
+                        </script>
+                      </material>
+                    </visual>
+
+                  </link>
+                  <link name="tilt_gimbal_link">
+                    <pose frame="">0.409 -0.008 0.5013 0 -0 0</pose>
+                    <inertial>
+                      <pose frame="">0 0 0 1.570796 -0 0</pose>
+                      <mass>0.1</mass>
+                      <inertia>
+                        <ixx>0.000016875</ixx>
+                        <ixy>0</ixy>
+                        <ixz>0</ixz>
+                        <iyy>0.00000001</iyy>
+                        <iyz>0</iyz>
+                        <izz>0.000016875</izz>
+                      </inertia>
+                    </inertial>
+                    <collision name="tilt_gimbal_link_collision">
+                      <pose frame="">0.0 0 0.0 1.570796 -0 0</pose>
+                      <geometry>
+                        <cylinder>
+                          <length>0.045</length>
+                          <radius>0.014</radius>
+                        </cylinder>
+                      </geometry>
+                      <surface>
+                        <contact>
+                          <ode>
+                            <kp>1e+07</kp>
+                            <kd>1</kd>
+                          </ode>
+                        </contact>
+                      </surface>
+                    </collision>
+
+                    <visual name= "CameraTilt_visual">
+                      <pose>0.005 0.015 0.038 0 0 -1.570796</pose>
+                      <geometry>
+                        <mesh>
+                          <uri>meshes/hd2.dae</uri>
+                          <submesh>
+                            <name>CameraTilt</name>
+                            <center>true</center>
+                          </submesh>
+                        </mesh>
+                      </geometry>
+                      <material>
+                        <diffuse>1.0 1.0 1.0</diffuse>
+                        <specular>1.0 1.0 1.0</specular>
+                        <pbr>
+                          <metal>
+                            <albedo_map>materials/textures/HD2_Albedo.jpg</albedo_map>
+                            <metalness_map>materials/textures/HD2_Metalness.jpg</metalness_map>
+                            <roughness_map>materials/textures/HD2_Roughness.jpg</roughness_map>
+                          </metal>
+                        </pbr>
+                        <!-- fallback to script if no PBR support-->
+                        <script>
+                          <uri>materials/scripts/</uri>
+                          <uri>materials/textures/</uri>
+                          <name>HD/HD2_Diffuse</name>
+                        </script>
+                      </material>
+                    </visual>
+
+                    <!-- Based on Intel realsense D435 (intrinsics and distortion not modeled)-->
+                    <sensor name="camera_pan_tilt" type="rgbd_camera">
+                      <camera name="camera_pan_tilt">
+                        <horizontal_fov>1.5184</horizontal_fov>
+                        <lens>
+                          <intrinsics>
+                            <!-- fx = fy = width / ( 2 * tan (hfov / 2 ) ) -->
+                            <fx>337.22195</fx>
+                            <fy>337.22195</fy>
+                            <!-- cx = ( width + 1 ) / 2 -->
+                            <cx>320.5</cx>
+                            <!-- cy = ( height + 1 ) / 2 -->
+                            <cy>240.5</cy>
+                            <s>0</s>
+                          </intrinsics>
+                        </lens>
+                        <distortion>
+                          <k1>0.0</k1>
+                          <k2>0.0</k2>
+                          <k3>0.0</k3>
+                          <p1>0.0</p1>
+                          <p2>0.0</p2>
+                          <center>0.5 0.5</center>
+                        </distortion>
+                        <image>
+                          <width>640</width>
+                          <height>480</height>
+                          <format>R8G8B8</format>
+                        </image>
+                        <clip>
+                          <near>0.01</near>
+                          <far>300</far>
+                        </clip>
+                        <depth_camera>
+                          <clip>
+                            <near>0.1</near>
+                            <far>10</far>
+                          </clip>
+                        </depth_camera>
+                        <noise>
+                          <type>gaussian</type>
+                          <mean>0</mean>
+                          <stddev>0.007</stddev>
+                        </noise>
+                      </camera>
+                      <always_on>1</always_on>
+                      <update_rate>30</update_rate>
+                      <!-- <pose frame="">0.424 0 0.542 0 0.0 0</pose>  -->
+                      <pose frame="">0.0 0 0.03 0 0.0 0</pose>
+                    </sensor>
+
+                    <light name="flashlight_flashlight_light_source_lamp_light" type="spot">
+                      <pose frame="">0.02 -0.01 0.076 3.141592653589793 1.5707963267948966 -0.0015926535897931</pose>
+                      <attenuation>
+                        <range>50</range>
+                        <linear>0</linear>
+                        <constant>0.1</constant>
+                        <quadratic>0.0025</quadratic>
+                      </attenuation>
+                      <diffuse>0.8 0.8 0.5 1</diffuse>
+                      <specular>0.8 0.8 0.5 1</specular>
+                      <spot>
+                        <!-- The lights on the MARBLE ground vehicles are very wide angle, 100W LEDs -->
+                        <inner_angle>2.8</inner_angle>
+                        <outer_angle>2.9</outer_angle>
+                        <falloff>1</falloff>
+                      </spot>
+                      <direction>0 0 -1</direction>
+                    </light>
+                  </link>
+                  <joint name="pan_gimbal_joint" type="revolute">
+                    <child>pan_gimbal_link</child>
+                    <parent>base_link</parent>
+                    <axis>
+                      <xyz>0 0 1</xyz>
+                      <limit>
+                        <lower>-1e+16</lower>
+                        <upper>1e+16</upper>
+                        <effort>10</effort>
+                      </limit>
+                      <dynamics>
+                        <spring_reference>0</spring_reference>
+                        <spring_stiffness>0</spring_stiffness>
+                        <damping>0.5</damping>
+                        <friction>0.001</friction>
+                      </dynamics>
+                      <use_parent_model_frame>1</use_parent_model_frame>
+                    </axis>
+                  </joint>
+                  <joint name="tilt_gimbal_joint" type="revolute">
+                    <child>tilt_gimbal_link</child>
+                    <parent>pan_gimbal_link</parent>
+                    <axis>
+                      <xyz>0 1 0</xyz>
+                      <limit>
+                        <lower>-1.5708</lower>
+                        <!-- 90 degrees both direction (mechanical interference)-->
+                        <upper>1.5708</upper>
+                        <effort>10</effort>
+                      </limit>
+                      <dynamics>
+                        <spring_reference>0</spring_reference>
+                        <spring_stiffness>0</spring_stiffness>
+                        <damping>0.5</damping>
+                      </dynamics>
+                      <use_parent_model_frame>1</use_parent_model_frame>
+                    </axis>
+                  </joint>
+                  <!-- Gimbal Joints Plugins -->
+                  <plugin filename="libignition-gazebo-joint-controller-system.so" name="ignition::gazebo::systems::JointController">
+                    <joint_name>pan_gimbal_joint</joint_name>
+                    <use_force_commands>true</use_force_commands>
+                    <p_gain>0.4</p_gain>
+                    <i_gain>10</i_gain>
+                  </plugin>
+                  <plugin filename="libignition-gazebo-joint-controller-system.so" name="ignition::gazebo::systems::JointController">
+                    <joint_name>tilt_gimbal_joint</joint_name>
+                    <use_force_commands>true</use_force_commands>
+                    <p_gain>0.4</p_gain>
+                    <i_gain>10</i_gain>
+                  </plugin>
+                  <plugin filename="libignition-gazebo-joint-state-publisher-system.so" name="ignition::gazebo::systems::JointStatePublisher">
+                    <joint_name>pan_gimbal_joint</joint_name>
+                    <joint_name>tilt_gimbal_joint</joint_name>
+                  </plugin>
+                  <static>0</static>
+                </model>
+              </sdf>

--- a/submitted_models/marble_husky_sensor_config_3/README.md
+++ b/submitted_models/marble_husky_sensor_config_3/README.md
@@ -1,4 +1,4 @@
-This package spawns a `MARBLE_HUSKY_SENSOR_CONFIG_1` with an additional
+This package spawns a `MARBLE_HUSKY_SENSOR_CONFIG_1` robot with an additional
 thermal camera
 
 The `model.sdf` is not used but added here as a reference to show what is on

--- a/submitted_models/marble_husky_sensor_config_3/README.md
+++ b/submitted_models/marble_husky_sensor_config_3/README.md
@@ -1,0 +1,5 @@
+This package spawns a `MARBLE_HUSKY_SENSOR_CONFIG_1` with an additional
+thermal camera
+
+The `model.sdf` is not used but added here as a reference to show what is on
+the SubT Tech Repo. Please keep this `model.sdf` update-to-date

--- a/submitted_models/marble_husky_sensor_config_3/README.md
+++ b/submitted_models/marble_husky_sensor_config_3/README.md
@@ -2,4 +2,5 @@ This package spawns a `MARBLE_HUSKY_SENSOR_CONFIG_1` robot with an additional
 thermal camera
 
 The `model.sdf` is not used but added here as a reference to show what is on
-the SubT Tech Repo. Please keep this `model.sdf` update-to-date
+the SubT Tech Repo. Please keep this `model.sdf` update-to-date with
+`MARBLE_HUSKY_SENSOR_CONFIG_1`

--- a/submitted_models/marble_husky_sensor_config_3/model.sdf
+++ b/submitted_models/marble_husky_sensor_config_3/model.sdf
@@ -1,0 +1,1090 @@
+<?xml version='1.0' encoding='utf-8'?>
+<sdf version="1.6">
+  <model name="marble_husky_sensor_config_3">
+    <link name="base_link">
+      <pose frame="">0 0 0 0 -0 0</pose>
+      <inertial>
+        <pose frame="">-0.000543 -0.084945 0.062329 0 -0 0</pose>
+        <mass>46.064</mass>
+        <inertia>
+          <ixx>0.615397</ixx>
+          <ixy>-0.0240585</ixy>
+          <ixz>-0.120749</ixz>
+          <iyy>1.75388</iyy>
+          <iyz>-0.0028322</iyz>
+          <izz>2.03641</izz>
+        </inertia>
+      </inertial>
+      <collision name="base_link_collision">
+        <pose frame="">0 0 0.12 0 0 0</pose>
+        <geometry>
+          <box>
+            <size>0.9874 0.5709 0.05</size>
+          </box>
+        </geometry>
+      </collision>
+      <collision name="base_link_collision_bottom">
+        <pose frame="">0 0 0.046 0 0 0</pose>
+        <geometry>
+          <box>
+            <size>0.80 0.5709 0.095</size>
+          </box>
+        </geometry>
+      </collision>
+      <collision name="base_link_collision_1">
+        <pose frame="">0 0 0.185625 0 -0 0</pose>
+        <geometry>
+          <box>
+            <size>0.78992 0.5709 0.12375</size>
+          </box>
+        </geometry>
+      </collision>
+      <collision name="base_link_fixed_joint_lump__camera/camera_link_collision_1">
+        <pose frame="pan_gimbal_link">0 0 0.05 0 0.0 0</pose>
+        <geometry>
+          <box>
+            <size>0.0078 0.13 0.0192</size>
+          </box>
+        </geometry>
+        <surface>
+          <contact>
+            <ode>
+              <kp>1e+13</kp>
+              <kd>1</kd>
+            </ode>
+          </contact>
+          <friction>
+            <ode>
+              <mu2>1</mu2>
+              <fdir1>0 0 0</fdir1>
+            </ode>
+          </friction>
+        </surface>
+      </collision>
+      <collision name="base_link_fixed_joint_lump__camera/camera_link_collision_2">
+        <pose frame="">0.478 0 0.285 0 -0 0</pose>
+        <geometry>
+          <box>
+            <size>0.0078 0.13 0.0192</size>
+          </box>
+        </geometry>
+        <surface>
+          <contact>
+            <ode>
+              <kp>1e+13</kp>
+              <kd>1</kd>
+            </ode>
+          </contact>
+          <friction>
+            <ode>
+              <mu2>1</mu2>
+              <fdir1>0 0 0</fdir1>
+            </ode>
+          </friction>
+        </surface>
+      </collision>
+      <collision name="base_link_fixed_joint_lump__camera/camera_link_collision_3">
+        <pose frame="">0.473 0 0.260 0 0.5236 0</pose>
+        <geometry>
+          <box>
+            <size>0.0078 0.13 0.0192</size>
+          </box>
+        </geometry>
+        <surface>
+          <contact>
+            <ode>
+              <kp>1e+13</kp>
+              <kd>1</kd>
+            </ode>
+          </contact>
+          <friction>
+            <ode>
+              <mu2>1</mu2>
+              <fdir1>0 0 0</fdir1>
+            </ode>
+          </friction>
+        </surface>
+      </collision>
+      <collision name="base_link_fixed_joint_lump__velodyne_base_link_collision_6">
+        <pose frame="">0.424 0 0.327 0 -0 0</pose>
+        <geometry>
+          <cylinder>
+            <length>0.0717</length>
+            <radius>0.0516</radius>
+          </cylinder>
+        </geometry>
+      </collision>
+      <collision name="base_link_fixed_joint_lump__velodyne_gimbal_plate_base_link_collision_7">
+        <pose frame="">0.424 0 0.400 0 -0 0</pose>
+        <geometry>
+          <box>
+            <size>0.1 0.1 0.01</size>
+          </box>
+        </geometry>
+      </collision>
+      <collision name="base_link_fixed_joint_lump__sensor_tower_8">
+       <pose frame="">0.374 0 0.215 0 -0 0</pose>
+        <geometry>
+          <box>
+            <size>0.2 0.25 0.225</size>
+          </box>
+        </geometry>
+      </collision>
+      <collision name="base_link_fixed_joint_lump__computer_block_9">
+       <pose frame="">0.050 0 0.185 0 -0 0</pose>
+        <geometry>
+          <box>
+            <size>0.30 0.355 0.175</size>
+          </box>
+        </geometry>
+      </collision>
+      <visual name="base_link_visual">
+        <pose frame="">0 0 0 0 -0 0</pose>
+        <geometry>
+          <mesh>
+            <scale>1 1 1</scale>
+            <uri>meshes/base_link.dae</uri>
+          </mesh>
+        </geometry>
+      </visual>
+      <visual name="base_link_fixed_joint_lump__camera/camera_link_visual_1">
+        <pose frame="">0.478 0 0.260 0 0.5236 0</pose>
+        <geometry>
+          <mesh>
+            <uri>meshes/realsense.dae</uri>
+          </mesh>
+        </geometry>
+      </visual>
+      <visual name="base_link_fixed_joint_lump__camera/camera_link_visual_2">
+        <pose frame="">0.478 0 0.285 0 -0 0</pose>
+        <geometry>
+          <mesh>
+            <uri>meshes/realsense.dae</uri>
+          </mesh>
+        </geometry>
+      </visual>
+      <visual name="base_link_fixed_joint_lump__front_bumper_link_visual_3">
+        <pose frame="">0.48 0 0.091 0 -0 0</pose>
+        <geometry>
+          <mesh>
+            <scale>1 1 1</scale>
+            <uri>meshes/bumper.dae</uri>
+          </mesh>
+        </geometry>
+      </visual>
+      <visual name="base_link_fixed_joint_lump__rear_bumper_link_visual_4">
+        <pose frame="">-0.48 0 0.091 0 -0 3.14159</pose>
+        <geometry>
+          <mesh>
+            <scale>1 1 1</scale>
+            <uri>meshes/bumper.dae</uri>
+          </mesh>
+        </geometry>
+      </visual>
+      <visual name="base_link_fixed_joint_lump__top_chassis_link_visual_5">
+        <pose frame="">0 0 0 0 -0 0</pose>
+        <geometry>
+          <mesh>
+            <scale>1 1 1</scale>
+            <uri>meshes/top_chassis.dae</uri>
+          </mesh>
+        </geometry>
+      </visual>
+      <!-- Bottom cylinder of Ouster/Velodyne 3D Lidar -->
+      <visual name="base_link_fixed_joint_lump__velodyne_base_link_visual_10">
+        <pose frame="">0.424 0 0.327 0 -0 0</pose>
+        <geometry>
+          <mesh>
+            <scale>1 1 1</scale>
+            <uri>meshes/VLP16_base_1.dae</uri>
+          </mesh>
+        </geometry>
+      </visual>
+      <!-- Top cylinder of Ouster/Velodyne 3D Lidar -->
+      <visual name="base_link_fixed_joint_lump__velodyne_base_link_visual_11">
+        <pose frame="">0.424 0 0.327 0 -0 0</pose>
+        <geometry>
+          <mesh>
+            <scale>1 1 1</scale>
+            <uri>meshes/VLP16_base_2.dae</uri>
+          </mesh>
+        </geometry>
+      </visual>
+      <!-- Main cylinder of Ouster/Velodyne 3D Lidar -->
+      <visual name="base_link_fixed_joint_lump__velodyne_visual_12">
+        <pose frame="">0.424 0 0.327 0 -0 0</pose>
+        <geometry>
+          <mesh>
+            <scale>1 1 1</scale>
+            <uri>meshes/VLP16_scan.dae</uri>
+          </mesh>
+        </geometry>
+      </visual>
+      <!-- Rail on top of husky -->
+      <visual name="base_link_fixed_joint_lump__user_rail_link_visual_13">
+        <pose frame="">0.272 0 0.245 0 -0 0</pose>
+        <geometry>
+          <mesh>
+            <scale>1 1 1</scale>
+            <uri>meshes/user_rail.dae</uri>
+          </mesh>
+        </geometry>
+      </visual>
+      <!-- 2D planar lidar at bottom of sensor suite -->
+      <visual name="base_link_fixed_joint_lump__planar_lidar_link_visual_14">
+        <pose frame="">0.474 0 0.127 0 -0 0</pose>
+        <geometry>
+          <cylinder>
+              <radius>0.045</radius>
+              <length>0.05</length>
+          </cylinder>
+        </geometry>
+      </visual>
+      <visual name="base_link_fixed_joint_lump__velodyne_gimbal_plate_15">
+       <pose frame="">0.424 0 0.400 0 -0 0</pose>
+        <geometry>
+          <box>
+            <size>0.06 0.06 0.01</size>
+          </box>
+        </geometry>
+      </visual>
+      <visual name="base_link_fixed_joint_lump__sensor_tower_16">
+       <pose frame="">0.374 0 0.215 0 -0 0</pose>
+        <geometry>
+          <box>
+            <size>0.2 0.25 0.225</size>
+          </box>
+        </geometry>
+      </visual>
+      <visual name="base_link_fixed_joint_lump__computer_block_17">
+       <pose frame="">0.050 0 0.185 0 -0 0</pose>
+        <geometry>
+          <box>
+            <size>0.30 0.355 0.175</size>
+          </box>
+        </geometry>
+      </visual>
+
+      <velocity_decay/>
+      <self_collide>0</self_collide>
+      <enable_wind>0</enable_wind>
+      <kinematic>0</kinematic>
+
+      <!-- thermal camera -->
+      <visual name="thermal_camera_visual">
+        <pose >0.485 0 0.169 0 0 0</pose>
+        <geometry>
+          <box>
+            <size>0.02 0.025 0.025</size>
+          </box>
+        </geometry>
+      </visual>
+      <sensor name="thermal_camera" type="thermal">
+        <pose >0.485 0 0.169 0 0 0</pose>
+        <camera name="thermal_camera">
+          <horizontal_fov>0.4922</horizontal_fov>
+          <lens>
+            <intrinsics>
+              <!-- fx = fy = width / ( 2 * tan (hfov / 2 ) ) -->
+              <fx>764.35630</fx>
+              <fy>764.35630</fy>
+              <!-- cx = ( width + 1 ) / 2 -->
+              <cx>192.5</cx>
+              <!-- cy = ( height + 1 ) / 2 -->
+              <cy>144.5</cy>
+              <s>0</s>
+            </intrinsics>
+          </lens>
+          <image>
+            <width>384</width>
+            <height>288</height>
+            <format>L8</format>
+          </image>
+          <clip>
+            <near>0.1</near>
+            <far>100</far>
+          </clip>
+        </camera>
+        <always_on>1</always_on>
+        <update_rate>25</update_rate>
+        <plugin
+          filename="ignition-gazebo-thermal-sensor-system"
+          name="ignition::gazebo::systems::ThermalSensor">
+          <min_temp>253.15</min_temp>
+          <max_temp>673.15</max_temp>
+          <resolution>1.6</resolution>
+        </plugin>
+      </sensor>
+
+      <!-- Based on Intel realsense D435 (intrinsics and distortion not modeled)-->
+      <sensor name="camera_front" type="rgbd_camera">
+        <camera name="camera_front">
+            <horizontal_fov>1.5184</horizontal_fov>
+            <lens>
+                <intrinsics>
+                    <!-- fx = fy = width / ( 2 * tan (hfov / 2 ) ) -->
+                    <fx>168.61097</fx>
+                    <fy>168.61097</fy>
+                    <!-- cx = ( width + 1 ) / 2 -->
+                    <cx>160.5</cx>
+                    <!-- cy = ( height + 1 ) / 2 -->
+                    <cy>120.5</cy>
+                    <s>0</s>
+                </intrinsics>
+            </lens>
+            <distortion>
+                <k1>0.0</k1>
+                <k2>0.0</k2>
+                <k3>0.0</k3>
+                <p1>0.0</p1>
+                <p2>0.0</p2>
+                <center>0.5 0.5</center>
+            </distortion>
+            <image>
+                <width>320</width>
+                <height>240</height>
+                <format>R8G8B8</format>
+            </image>
+            <clip>
+                <near>0.01</near>
+                <far>300</far>
+            </clip>
+            <depth_camera>
+              <clip>
+                <near>0.1</near>
+                <far>10</far>
+              </clip>
+            </depth_camera>
+            <noise>
+                <type>gaussian</type>
+                <mean>0</mean>
+                <stddev>0.007</stddev>
+            </noise>
+        </camera>
+        <always_on>1</always_on>
+        <update_rate>30</update_rate>
+        <visualize>0</visualize>
+        <pose frame="">0.468 0 0.360 0 -0 0</pose>
+      </sensor>
+      <gravity>1</gravity>
+      <velocity_decay/>
+      <!-- Based on Intel realsense D435 (intrinsics and distortion not modeled)-->
+      <sensor name="camera_down" type="rgbd_camera">
+        <camera name="camera_down">
+            <horizontal_fov>1.5184</horizontal_fov>
+            <lens>
+                <intrinsics>
+                    <!-- fx = fy = width / ( 2 * tan (hfov / 2 ) ) -->
+                    <fx>168.61097</fx>
+                    <fy>168.61097</fy>
+                    <!-- cx = ( width + 1 ) / 2 -->
+                    <cx>160.5</cx>
+                    <!-- cy = ( height + 1 ) / 2 -->
+                    <cy>120.5</cy>
+                    <s>0</s>
+                </intrinsics>
+            </lens>
+            <distortion>
+                <k1>0.0</k1>
+                <k2>0.0</k2>
+                <k3>0.0</k3>
+                <p1>0.0</p1>
+                <p2>0.0</p2>
+                <center>0.5 0.5</center>
+            </distortion>
+            <image>
+                <width>320</width>
+                <height>240</height>
+                <format>R8G8B8</format>
+            </image>
+            <clip>
+                <near>0.01</near>
+                <far>300</far>
+            </clip>
+            <depth_camera>
+              <clip>
+                <near>0.1</near>
+                <far>10</far>
+              </clip>
+            </depth_camera>
+            <noise>
+                <type>gaussian</type>
+                <mean>0</mean>
+                <stddev>0.007</stddev>
+            </noise>
+        </camera>
+        <always_on>1</always_on>
+        <update_rate>30</update_rate>
+        <visualize>0</visualize>
+        <pose frame="">0.468 0 0.335 0 0.5236 0</pose>
+      </sensor>
+      <gravity>1</gravity>
+      <velocity_decay/>
+      <!-- Based on RPLidar S1 -->
+      <sensor name="planar_laser" type="gpu_ray">
+          <pose>0.474 0 0.127 0 -0 0</pose>
+          <update_rate>10</update_rate>
+          <lidar>
+              <scan>
+                  <horizontal>
+                      <samples>920</samples>
+                      <resolution>1</resolution>
+                      <min_angle>-3.14159</min_angle>
+                      <max_angle>3.14159</max_angle>
+                  </horizontal>
+              </scan>
+              <range>
+                  <min>0.04</min>
+                  <max>25</max>
+                  <resolution>0.03</resolution>
+              </range>
+              <noise>
+                  <type>gaussian</type>
+                  <mean>0</mean>
+                  <stddev>0.01</stddev>
+              </noise>
+          </lidar>
+      </sensor>
+      <gravity>1</gravity>
+      <velocity_decay/>
+
+      <!-- OS1-64 3D Laser Configuration (10x2048 or 10x1024 or 20x1024 or 20x512 as possible (rate) x (hor. res.) configs)-->
+      <sensor name="front_laser" type="gpu_lidar">
+        <visualize>0</visualize>
+        <update_rate>20</update_rate>
+        <lidar>
+          <scan>
+            <horizontal>
+              <samples>1024</samples>
+              <resolution>1</resolution>
+              <min_angle>-3.1459</min_angle>
+              <max_angle>3.1459</max_angle>
+            </horizontal>
+            <vertical>
+              <samples>64</samples>
+              <resolution>1</resolution>
+              <min_angle>-0.2897</min_angle>
+              <max_angle>0.2897</max_angle>
+            </vertical>
+          </scan>
+          <range>
+            <min>0.8</min>
+            <max>120</max>
+            <resolution>0.003</resolution>
+          </range>
+          <noise>
+            <type>gaussian</type>
+            <mean>0</mean>
+            <stddev>0.03</stddev>
+          </noise>
+        </lidar>
+        <pose frame="">0.424 0 0.387 0 -0 0</pose>
+      </sensor>
+
+
+      <sensor name="imu_sensor" type="imu">
+        <always_on>1</always_on>
+        <update_rate>50</update_rate>
+        <imu>
+                    <angular_velocity>
+                        <x>
+                            <noise type="gaussian">
+                                <mean>0</mean>
+                                <stddev>0.009</stddev>
+                                <bias_mean>0.00075</bias_mean>
+                                <bias_stddev>0.005</bias_stddev>
+                                <dynamic_bias_stddev>0.00002</dynamic_bias_stddev>
+                                <dynamic_bias_correlation_time>400.0</dynamic_bias_correlation_time>
+                                <precision>0.00025</precision>
+                            </noise>
+                        </x>
+                        <y>
+                            <noise type="gaussian">
+                                <mean>0</mean>
+                                <stddev>0.009</stddev>
+                                <bias_mean>0.00075</bias_mean>
+                                <bias_stddev>0.005</bias_stddev>
+                                <dynamic_bias_stddev>0.00002</dynamic_bias_stddev>
+                                <dynamic_bias_correlation_time>400.0</dynamic_bias_correlation_time>
+                                <precision>0.00025</precision>
+                            </noise>
+                        </y>
+                        <z>
+                            <noise type="gaussian">
+                                <mean>0</mean>
+                                <stddev>0.009</stddev>
+                                <bias_mean>0.00075</bias_mean>
+                                <bias_stddev>0.005</bias_stddev>
+                                <dynamic_bias_stddev>0.00002</dynamic_bias_stddev>
+                                <dynamic_bias_correlation_time>400.0</dynamic_bias_correlation_time>
+                                <precision>0.00025</precision>
+                            </noise>
+                        </z>
+                    </angular_velocity>
+                    <linear_acceleration>
+                        <x>
+                            <noise type="gaussian">
+                                <mean>0</mean>
+                                <stddev>0.021</stddev>
+                                <bias_mean>0.05</bias_mean>
+                                <bias_stddev>0.0075</bias_stddev>
+                                <dynamic_bias_stddev>0.000375</dynamic_bias_stddev>
+                                <dynamic_bias_correlation_time>175.0</dynamic_bias_correlation_time>
+                                <precision>0.005</precision>
+                            </noise>
+                        </x>
+                        <y>
+                            <noise type="gaussian">
+                                <mean>0</mean>
+                                <stddev>0.021</stddev>
+                                <bias_mean>0.05</bias_mean>
+                                <bias_stddev>0.0075</bias_stddev>
+                                <dynamic_bias_stddev>0.000375</dynamic_bias_stddev>
+                                <dynamic_bias_correlation_time>175.0</dynamic_bias_correlation_time>
+                                <precision>0.005</precision>
+                            </noise>
+                        </y>
+                        <z>
+                            <noise type="gaussian">
+                                <mean>0</mean>
+                                <stddev>0.021</stddev>
+                                <bias_mean>0.05</bias_mean>
+                                <bias_stddev>0.0075</bias_stddev>
+                                <dynamic_bias_stddev>0.000375</dynamic_bias_stddev>
+                                <dynamic_bias_correlation_time>175.0</dynamic_bias_correlation_time>
+                                <precision>0.005</precision>
+                            </noise>
+                        </z>
+                    </linear_acceleration>
+                </imu>
+      </sensor>
+    </link>
+    <link name="front_left_wheel_link">
+      <pose frame="">0.256 0.2854 0.03282 0 -0 0</pose>
+      <inertial>
+        <pose frame="">0 0 0 0 -0 0</pose>
+        <mass>2.637</mass>
+        <inertia>
+          <ixx>0.02467</ixx>
+          <ixy>0</ixy>
+          <ixz>0</ixz>
+          <iyy>0.04411</iyy>
+          <iyz>0</iyz>
+          <izz>0.02467</izz>
+        </inertia>
+      </inertial>
+      <collision name="front_left_wheel_link_collision">
+        <pose frame="">0 0 0 1.5707963267948966 -0 0</pose>
+        <geometry>
+          <cylinder>
+            <length>0.1143</length>
+            <radius>0.1651</radius>
+          </cylinder>
+        </geometry>
+        <surface>
+          <contact>
+            <ode>
+              <kp>1e+07</kp>
+              <kd>1</kd>
+            </ode>
+          </contact>
+          <friction>
+            <ode>
+              <mu>0.5</mu>
+              <mu2>1</mu2>
+              <slip1>0.00062</slip1>
+              <slip2>0</slip2>
+              <fdir1>0 0 1</fdir1>
+            </ode>
+          </friction>
+        </surface>
+      </collision>
+      <visual name="front_left_wheel_link_visual">
+        <pose frame="">0 0 0 0 -0 0</pose>
+        <geometry>
+          <mesh>
+            <scale>1 1 1</scale>
+            <uri>meshes/wheel.dae</uri>
+          </mesh>
+        </geometry>
+      </visual>
+      <gravity>1</gravity>
+      <velocity_decay/>
+    </link>
+    <joint name="front_left_wheel_joint" type="revolute">
+      <child>front_left_wheel_link</child>
+      <parent>base_link</parent>
+      <axis>
+        <xyz>0 1 0</xyz>
+        <limit>
+          <lower>-1e+16</lower>
+          <upper>1e+16</upper>
+        </limit>
+        <dynamics>
+          <spring_reference>0</spring_reference>
+          <spring_stiffness>0</spring_stiffness>
+        </dynamics>
+        <use_parent_model_frame>1</use_parent_model_frame>
+      </axis>
+    </joint>
+    <link name="front_right_wheel_link">
+      <pose frame="">0.256 -0.2854 0.03282 0 -0 0</pose>
+      <inertial>
+        <pose frame="">0 0 0 0 -0 0</pose>
+        <mass>2.637</mass>
+        <inertia>
+          <ixx>0.02467</ixx>
+          <ixy>0</ixy>
+          <ixz>0</ixz>
+          <iyy>0.04411</iyy>
+          <iyz>0</iyz>
+          <izz>0.02467</izz>
+        </inertia>
+      </inertial>
+      <collision name="front_right_wheel_link_collision">
+        <pose frame="">0 0 0 1.5707963267948966 -0 0</pose>
+        <geometry>
+          <cylinder>
+            <length>0.1143</length>
+            <radius>0.1651</radius>
+          </cylinder>
+        </geometry>
+        <surface>
+          <contact>
+            <ode>
+              <kp>1e+07</kp>
+              <kd>1</kd>
+            </ode>
+          </contact>
+          <friction>
+            <ode>
+              <mu>0.5</mu>
+              <mu2>1</mu2>
+              <slip1>0.00062</slip1>
+              <slip2>0</slip2>
+              <fdir1>0 0 1</fdir1>
+            </ode>
+          </friction>
+        </surface>
+      </collision>
+      <visual name="front_right_wheel_link_visual">
+        <pose frame="">0 0 0 0 -0 0</pose>
+        <geometry>
+          <mesh>
+            <scale>1 1 1</scale>
+            <uri>meshes/wheel.dae</uri>
+          </mesh>
+        </geometry>
+      </visual>
+      <gravity>1</gravity>
+      <velocity_decay/>
+    </link>
+    <joint name="front_right_wheel_joint" type="revolute">
+      <child>front_right_wheel_link</child>
+      <parent>base_link</parent>
+      <axis>
+        <xyz>0 1 0</xyz>
+        <limit>
+          <lower>-1e+16</lower>
+          <upper>1e+16</upper>
+        </limit>
+        <dynamics>
+          <spring_reference>0</spring_reference>
+          <spring_stiffness>0</spring_stiffness>
+        </dynamics>
+        <use_parent_model_frame>1</use_parent_model_frame>
+      </axis>
+    </joint>
+    <link name="rear_left_wheel_link">
+      <pose frame="">-0.256 0.2854 0.03282 0 -0 0</pose>
+      <inertial>
+        <pose frame="">0 0 0 0 -0 0</pose>
+        <mass>2.637</mass>
+        <inertia>
+          <ixx>0.02467</ixx>
+          <ixy>0</ixy>
+          <ixz>0</ixz>
+          <iyy>0.04411</iyy>
+          <iyz>0</iyz>
+          <izz>0.02467</izz>
+        </inertia>
+      </inertial>
+      <collision name="rear_left_wheel_link_collision">
+        <pose frame="">0 0 0 1.5707963267948966 -0 0</pose>
+        <geometry>
+          <cylinder>
+            <length>0.1143</length>
+            <radius>0.1651</radius>
+          </cylinder>
+        </geometry>
+        <surface>
+          <contact>
+            <ode>
+              <kp>1e+07</kp>
+              <kd>1</kd>
+            </ode>
+          </contact>
+          <friction>
+            <ode>
+              <mu>0.5</mu>
+              <mu2>1</mu2>
+              <slip1>0.00062</slip1>
+              <slip2>0</slip2>
+              <fdir1>0 0 1</fdir1>
+            </ode>
+          </friction>
+        </surface>
+      </collision>
+      <visual name="rear_left_wheel_link_visual">
+        <pose frame="">0 0 0 0 -0 0</pose>
+        <geometry>
+          <mesh>
+            <scale>1 1 1</scale>
+            <uri>meshes/wheel.dae</uri>
+          </mesh>
+        </geometry>
+      </visual>
+      <gravity>1</gravity>
+      <velocity_decay/>
+    </link>
+    <joint name="rear_left_wheel_joint" type="revolute">
+      <child>rear_left_wheel_link</child>
+      <parent>base_link</parent>
+      <axis>
+        <xyz>0 1 0</xyz>
+        <limit>
+          <lower>-1e+16</lower>
+          <upper>1e+16</upper>
+        </limit>
+        <dynamics>
+          <spring_reference>0</spring_reference>
+          <spring_stiffness>0</spring_stiffness>
+        </dynamics>
+        <use_parent_model_frame>1</use_parent_model_frame>
+      </axis>
+    </joint>
+    <link name="rear_right_wheel_link">
+      <pose frame="">-0.256 -0.2854 0.03282 0 -0 0</pose>
+      <inertial>
+        <pose frame="">0 0 0 0 -0 0</pose>
+        <mass>2.637</mass>
+        <inertia>
+          <ixx>0.02467</ixx>
+          <ixy>0</ixy>
+          <ixz>0</ixz>
+          <iyy>0.04411</iyy>
+          <iyz>0</iyz>
+          <izz>0.02467</izz>
+        </inertia>
+      </inertial>
+      <collision name="rear_right_wheel_link_collision">
+        <pose frame="">0 0 0 1.5707963267948966 -0 0</pose>
+        <geometry>
+          <cylinder>
+            <length>0.1143</length>
+            <radius>0.1651</radius>
+          </cylinder>
+        </geometry>
+        <surface>
+          <contact>
+            <ode>
+              <kp>1e+07</kp>
+              <kd>1</kd>
+            </ode>
+          </contact>
+          <friction>
+            <ode>
+              <mu>0.5</mu>
+              <mu2>1</mu2>
+              <slip1>0.00062</slip1>
+              <slip2>0</slip2>
+              <fdir1>0 0 1</fdir1>
+            </ode>
+          </friction>
+        </surface>
+      </collision>
+      <visual name="rear_right_wheel_link_visual">
+        <pose frame="">0 0 0 0 -0 0</pose>
+        <geometry>
+          <mesh>
+            <scale>1 1 1</scale>
+            <uri>meshes/wheel.dae</uri>
+          </mesh>
+        </geometry>
+      </visual>
+      <gravity>1</gravity>
+      <velocity_decay/>
+    </link>
+    <joint name="rear_right_wheel_joint" type="revolute">
+      <child>rear_right_wheel_link</child>
+      <parent>base_link</parent>
+      <axis>
+        <xyz>0 1 0</xyz>
+        <limit>
+          <lower>-1e+16</lower>
+          <upper>1e+16</upper>
+        </limit>
+        <dynamics>
+          <spring_reference>0</spring_reference>
+          <spring_stiffness>0</spring_stiffness>
+        </dynamics>
+        <use_parent_model_frame>1</use_parent_model_frame>
+      </axis>
+    </joint>
+    <link name="pan_gimbal_link">
+      <pose frame="">0.424 0 0.427 0 -0 0</pose>
+      <inertial>
+        <pose frame="">0 0 0 0 -0 0</pose>
+        <mass>0.1</mass>
+        <inertia>
+          <ixx>0.000016875</ixx>
+          <ixy>0</ixy>
+          <ixz>0</ixz>
+          <iyy>0.00000001</iyy>
+          <iyz>0</iyz>
+          <izz>0.000016875</izz>
+        </inertia>
+      </inertial>
+      <collision name="pan_gimbal_link_collision">
+      <pose frame="">0.0 0 0.0 0 -0 0</pose>
+      <geometry>
+        <cylinder>
+          <length>0.045</length>
+          <radius>0.014</radius>
+        </cylinder>
+      </geometry>
+      <surface>
+        <contact>
+          <ode>
+            <kp>1e+07</kp>
+            <kd>1</kd>
+          </ode>
+        </contact>
+      </surface>
+      </collision>
+      <visual name="pan_gimbal_link_visual">
+        <pose frame="">0.0 0 0.0 0 -0 0</pose>
+        <geometry>
+          <cylinder>
+            <length>0.045</length>
+            <radius>0.014</radius>
+          </cylinder>
+        </geometry>
+      </visual>
+    </link>
+    <link name="tilt_gimbal_link">
+      <pose frame="">0.424 0 0.460 0 -0 0</pose>
+      <inertial>
+        <pose frame="">0 0 0 1.570796 -0 0</pose>
+        <mass>0.1</mass>
+         <inertia>
+          <ixx>0.000016875</ixx>
+          <ixy>0</ixy>
+          <ixz>0</ixz>
+          <iyy>0.00000001</iyy>
+          <iyz>0</iyz>
+          <izz>0.000016875</izz>
+        </inertia>
+      </inertial>
+
+      <collision name="tilt_gimbal_link_collision">
+      <pose frame="">0.0 0 0.0 1.570796 -0 0</pose>
+      <geometry>
+        <cylinder>
+          <length>0.045</length>
+          <radius>0.014</radius>
+        </cylinder>
+      </geometry>
+      <surface>
+        <contact>
+          <ode>
+            <kp>1e+07</kp>
+            <kd>1</kd>
+          </ode>
+        </contact>
+      </surface>
+      </collision>
+      <visual name="tilt_gimbal_link_visual">
+        <pose frame="">0.0 0 0.0 1.570796 -0 0</pose>
+        <geometry>
+          <cylinder>
+            <length>0.045</length>
+            <radius>0.014</radius>
+          </cylinder>
+        </geometry>
+      </visual>
+      <!-- Based on Intel realsense D435 (intrinsics and distortion not modeled)-->
+      <sensor name="camera_pan_tilt" type="rgbd_camera">
+        <camera name="camera_pan_tilt">
+            <horizontal_fov>1.5184</horizontal_fov>
+            <lens>
+                <intrinsics>
+                    <!-- fx = fy = width / ( 2 * tan (hfov / 2 ) ) -->
+                    <fx>337.22195</fx>
+                    <fy>337.22195</fy>
+                    <!-- cx = ( width + 1 ) / 2 -->
+                    <cx>320.5</cx>
+                    <!-- cy = ( height + 1 ) / 2 -->
+                    <cy>240.5</cy>
+                    <s>0</s>
+                </intrinsics>
+            </lens>
+            <distortion>
+                <k1>0.0</k1>
+                <k2>0.0</k2>
+                <k3>0.0</k3>
+                <p1>0.0</p1>
+                <p2>0.0</p2>
+                <center>0.5 0.5</center>
+            </distortion>
+            <image>
+                <width>640</width>
+                <height>480</height>
+                <format>R8G8B8</format>
+            </image>
+            <clip>
+                <near>0.01</near>
+                <far>300</far>
+            </clip>
+            <depth_camera>
+              <clip>
+                <near>0.1</near>
+                <far>10</far>
+              </clip>
+            </depth_camera>
+            <noise>
+                <type>gaussian</type>
+                <mean>0</mean>
+                <stddev>0.007</stddev>
+            </noise>
+        </camera>
+        <always_on>1</always_on>
+        <update_rate>30</update_rate>
+        <visualize>0</visualize>
+
+        <pose frame="">0.0 0 0.03 0 0.0 0</pose>
+      </sensor>
+      <gravity>1</gravity>
+      <velocity_decay/>
+      <visual name="tilt_gimbal_link_fixed_joint_lump__camera/camera_link_visual_0">
+        <pose frame="">0 0 0.03 0 0.0 0</pose>
+        <geometry>
+          <mesh>
+            <uri>meshes/realsense.dae</uri>
+          </mesh>
+        </geometry>
+      </visual>
+      <visual name="tilt_gimbal_link_fixed_joint_lump_bot_camera_plate_link_visual_1">
+       <pose frame="">0 0 0.017 0 -0 0</pose>
+        <geometry>
+          <box>
+            <size>0.025 0.13 0.007</size>
+          </box>
+        </geometry>
+      </visual>
+      <visual name="tilt_gimbal_link_fixed_joint_lump_bot_camera_plate_link_visual_2">
+       <pose frame="">0 0 0.042 0 -0 0</pose>
+        <geometry>
+          <box>
+            <size>0.025 0.13 0.007</size>
+          </box>
+        </geometry>
+      </visual>
+      <light name="flashlight_flashlight_light_source_lamp_light" type="spot">
+        <pose frame="">0.0 0.0 0.065 3.141592653589793 1.5707963267948966 -0.0015926535897931</pose>
+        <attenuation>
+          <range>50</range>
+          <linear>0</linear>
+          <constant>0.1</constant>
+          <quadratic>0.0025</quadratic>
+        </attenuation>
+        <diffuse>0.8 0.8 0.5 1</diffuse>
+        <specular>0.8 0.8 0.5 1</specular>
+        <spot>
+          <!-- The lights on the MARBLE ground vehicles are very wide angle, 100W LEDs -->
+          <inner_angle>2.8</inner_angle>
+          <outer_angle>2.9</outer_angle>
+          <falloff>1</falloff>
+        </spot>
+        <direction>0 0 -1</direction>
+      </light>
+      <visual name="flashlight_flashlight_light_source_lamp_viz_visual">
+        <pose>0.0 0.0 0.065 3.141592653589793 1.5707963267948966 -0.0015926535897931</pose>
+        <geometry>
+          <cylinder>
+            <radius>0.019</radius>
+            <length>0.005</length>
+          </cylinder>
+        </geometry>
+        <transparency>0</transparency>
+        <material>
+          <ambient>1 1 1 1</ambient>
+          <diffuse>1 1 1 1</diffuse>
+          <specular>1 1 1 1</specular>
+          <emissive>1 1 1 1</emissive>
+        </material>
+      </visual>
+    </link>
+    <joint name="pan_gimbal_joint" type="revolute">
+      <child>pan_gimbal_link</child>
+      <parent>base_link</parent>
+      <axis>
+        <xyz>0 0 1</xyz>
+        <limit>
+          <lower>-1e+16</lower>
+          <upper>1e+16</upper>
+          <effort>10</effort>
+        </limit>
+        <dynamics>
+          <spring_reference>0</spring_reference>
+          <spring_stiffness>0</spring_stiffness>
+          <damping>0.5</damping>
+        </dynamics>
+        <use_parent_model_frame>1</use_parent_model_frame>
+      </axis>
+    </joint>
+    <joint name="tilt_gimbal_joint" type="revolute">
+      <child>tilt_gimbal_link</child>
+      <parent>pan_gimbal_link</parent>
+      <axis>
+        <xyz>0 1 0</xyz>
+        <limit>
+          <lower>-1.5708</lower> <!-- 90 degrees both direction (mechanical interference)-->
+          <upper>1.5708</upper>
+          <effort>10</effort>
+        </limit>
+        <dynamics>
+          <spring_reference>0</spring_reference>
+          <spring_stiffness>0</spring_stiffness>
+          <damping>0.5</damping>
+        </dynamics>
+        <use_parent_model_frame>1</use_parent_model_frame>
+      </axis>
+    </joint>
+    <!-- Gimbal Joints Plugins -->
+    <plugin
+      filename="libignition-gazebo-joint-controller-system.so"
+      name="ignition::gazebo::systems::JointController">
+      <joint_name>pan_gimbal_joint</joint_name>
+      <use_force_commands>true</use_force_commands>
+      <p_gain>0.4</p_gain>
+      <i_gain>10</i_gain>
+    </plugin>
+    <plugin
+      filename="libignition-gazebo-joint-controller-system.so"
+      name="ignition::gazebo::systems::JointController">
+      <joint_name>tilt_gimbal_joint</joint_name>
+      <use_force_commands>true</use_force_commands>
+      <p_gain>0.4</p_gain>
+      <i_gain>10</i_gain>
+    </plugin>
+    <plugin
+      filename="libignition-gazebo-joint-state-publisher-system.so"
+      name="ignition::gazebo::systems::JointStatePublisher">
+      <joint_name>pan_gimbal_joint</joint_name>
+      <joint_name>tilt_gimbal_joint</joint_name>
+    </plugin>
+    <static>0</static>
+  </model>
+</sdf>
+

--- a/submitted_models/marble_husky_sensor_config_4/README.md
+++ b/submitted_models/marble_husky_sensor_config_4/README.md
@@ -1,0 +1,5 @@
+This package spawns a `MARBLE_HUSKY_SENSOR_CONFIG_2` with an additional
+thermal camera
+
+The `model.sdf` is not used but added here as a reference to show what is on
+the SubT Tech Repo. Please keep this `model.sdf` update-to-date

--- a/submitted_models/marble_husky_sensor_config_4/README.md
+++ b/submitted_models/marble_husky_sensor_config_4/README.md
@@ -1,4 +1,4 @@
-This package spawns a `MARBLE_HUSKY_SENSOR_CONFIG_2` with an additional
+This package spawns a `MARBLE_HUSKY_SENSOR_CONFIG_2` robot with an additional
 thermal camera
 
 The `model.sdf` is not used but added here as a reference to show what is on

--- a/submitted_models/marble_husky_sensor_config_4/README.md
+++ b/submitted_models/marble_husky_sensor_config_4/README.md
@@ -2,4 +2,5 @@ This package spawns a `MARBLE_HUSKY_SENSOR_CONFIG_2` robot with an additional
 thermal camera
 
 The `model.sdf` is not used but added here as a reference to show what is on
-the SubT Tech Repo. Please keep this `model.sdf` update-to-date
+the SubT Tech Repo. Please keep this `model.sdf` update-to-date with
+`MARBLE_HUSKY_SENSOR_CONFIG_2`

--- a/submitted_models/marble_husky_sensor_config_4/model.sdf
+++ b/submitted_models/marble_husky_sensor_config_4/model.sdf
@@ -1,0 +1,1090 @@
+<?xml version='1.0' encoding='utf-8'?>
+<sdf version="1.6">
+  <model name="marble_husky_sensor_config_4">
+    <link name="base_link">
+      <pose frame="">0 0 0 0 -0 0</pose>
+      <inertial>
+        <pose frame="">-0.000543 -0.084945 0.062329 0 -0 0</pose>
+        <mass>46.064</mass>
+        <inertia>
+          <ixx>0.615397</ixx>
+          <ixy>-0.0240585</ixy>
+          <ixz>-0.120749</ixz>
+          <iyy>1.75388</iyy>
+          <iyz>-0.0028322</iyz>
+          <izz>2.03641</izz>
+        </inertia>
+      </inertial>
+      <collision name="base_link_collision">
+        <pose frame="">0 0 0.12 0 0 0</pose>
+        <geometry>
+          <box>
+            <size>0.9874 0.5709 0.05</size>
+          </box>
+        </geometry>
+      </collision>
+      <collision name="base_link_collision_bottom">
+        <pose frame="">0 0 0.046 0 0 0</pose>
+        <geometry>
+          <box>
+            <size>0.80 0.5709 0.095</size>
+          </box>
+        </geometry>
+      </collision>
+      <collision name="base_link_collision_1">
+        <pose frame="">0 0 0.185625 0 -0 0</pose>
+        <geometry>
+          <box>
+            <size>0.78992 0.5709 0.12375</size>
+          </box>
+        </geometry>
+      </collision>
+      <collision name="base_link_fixed_joint_lump__camera/camera_link_collision_1">
+        <pose frame="pan_gimbal_link">0 0 0.05 0 0.0 0</pose>
+        <geometry>
+          <box>
+            <size>0.0078 0.13 0.0192</size>
+          </box>
+        </geometry>
+        <surface>
+          <contact>
+            <ode>
+              <kp>1e+13</kp>
+              <kd>1</kd>
+            </ode>
+          </contact>
+          <friction>
+            <ode>
+              <mu2>1</mu2>
+              <fdir1>0 0 0</fdir1>
+            </ode>
+          </friction>
+        </surface>
+      </collision>
+      <collision name="base_link_fixed_joint_lump__camera/camera_link_collision_2">
+        <pose frame="">0.478 0 0.285 0 -0 0</pose>
+        <geometry>
+          <box>
+            <size>0.0078 0.13 0.0192</size>
+          </box>
+        </geometry>
+        <surface>
+          <contact>
+            <ode>
+              <kp>1e+13</kp>
+              <kd>1</kd>
+            </ode>
+          </contact>
+          <friction>
+            <ode>
+              <mu2>1</mu2>
+              <fdir1>0 0 0</fdir1>
+            </ode>
+          </friction>
+        </surface>
+      </collision>
+      <collision name="base_link_fixed_joint_lump__camera/camera_link_collision_3">
+        <pose frame="">0.473 0 0.260 0 0.5236 0</pose>
+        <geometry>
+          <box>
+            <size>0.0078 0.13 0.0192</size>
+          </box>
+        </geometry>
+        <surface>
+          <contact>
+            <ode>
+              <kp>1e+13</kp>
+              <kd>1</kd>
+            </ode>
+          </contact>
+          <friction>
+            <ode>
+              <mu2>1</mu2>
+              <fdir1>0 0 0</fdir1>
+            </ode>
+          </friction>
+        </surface>
+      </collision>
+      <collision name="base_link_fixed_joint_lump__velodyne_base_link_collision_6">
+        <pose frame="">0.424 0 0.327 0 -0 0</pose>
+        <geometry>
+          <cylinder>
+            <length>0.0717</length>
+            <radius>0.0516</radius>
+          </cylinder>
+        </geometry>
+      </collision>
+      <collision name="base_link_fixed_joint_lump__velodyne_gimbal_plate_base_link_collision_7">
+        <pose frame="">0.424 0 0.400 0 -0 0</pose>
+        <geometry>
+          <box>
+            <size>0.1 0.1 0.01</size>
+          </box>
+        </geometry>
+      </collision>
+      <collision name="base_link_fixed_joint_lump__sensor_tower_8">
+       <pose frame="">0.374 0 0.215 0 -0 0</pose>
+        <geometry>
+          <box>
+            <size>0.2 0.25 0.225</size>
+          </box>
+        </geometry>
+      </collision>
+      <collision name="base_link_fixed_joint_lump__computer_block_9">
+       <pose frame="">0.050 0 0.185 0 -0 0</pose>
+        <geometry>
+          <box>
+            <size>0.30 0.355 0.175</size>
+          </box>
+        </geometry>
+      </collision>
+      <visual name="base_link_visual">
+        <pose frame="">0 0 0 0 -0 0</pose>
+        <geometry>
+          <mesh>
+            <scale>1 1 1</scale>
+            <uri>meshes/base_link.dae</uri>
+          </mesh>
+        </geometry>
+      </visual>
+      <visual name="base_link_fixed_joint_lump__camera/camera_link_visual_1">
+        <pose frame="">0.478 0 0.260 0 0.5236 0</pose>
+        <geometry>
+          <mesh>
+            <uri>meshes/realsense.dae</uri>
+          </mesh>
+        </geometry>
+      </visual>
+      <visual name="base_link_fixed_joint_lump__camera/camera_link_visual_2">
+        <pose frame="">0.478 0 0.285 0 -0 0</pose>
+        <geometry>
+          <mesh>
+            <uri>meshes/realsense.dae</uri>
+          </mesh>
+        </geometry>
+      </visual>
+      <visual name="base_link_fixed_joint_lump__front_bumper_link_visual_3">
+        <pose frame="">0.48 0 0.091 0 -0 0</pose>
+        <geometry>
+          <mesh>
+            <scale>1 1 1</scale>
+            <uri>meshes/bumper.dae</uri>
+          </mesh>
+        </geometry>
+      </visual>
+      <visual name="base_link_fixed_joint_lump__rear_bumper_link_visual_4">
+        <pose frame="">-0.48 0 0.091 0 -0 3.14159</pose>
+        <geometry>
+          <mesh>
+            <scale>1 1 1</scale>
+            <uri>meshes/bumper.dae</uri>
+          </mesh>
+        </geometry>
+      </visual>
+      <visual name="base_link_fixed_joint_lump__top_chassis_link_visual_5">
+        <pose frame="">0 0 0 0 -0 0</pose>
+        <geometry>
+          <mesh>
+            <scale>1 1 1</scale>
+            <uri>meshes/top_chassis.dae</uri>
+          </mesh>
+        </geometry>
+      </visual>
+      <!-- Bottom cylinder of Ouster/Velodyne 3D Lidar -->
+      <visual name="base_link_fixed_joint_lump__velodyne_base_link_visual_10">
+        <pose frame="">0.424 0 0.327 0 -0 0</pose>
+        <geometry>
+          <mesh>
+            <scale>1 1 1</scale>
+            <uri>meshes/VLP16_base_1.dae</uri>
+          </mesh>
+        </geometry>
+      </visual>
+      <!-- Top cylinder of Ouster/Velodyne 3D Lidar -->
+      <visual name="base_link_fixed_joint_lump__velodyne_base_link_visual_11">
+        <pose frame="">0.424 0 0.327 0 -0 0</pose>
+        <geometry>
+          <mesh>
+            <scale>1 1 1</scale>
+            <uri>meshes/VLP16_base_2.dae</uri>
+          </mesh>
+        </geometry>
+      </visual>
+      <!-- Main cylinder of Ouster/Velodyne 3D Lidar -->
+      <visual name="base_link_fixed_joint_lump__velodyne_visual_12">
+        <pose frame="">0.424 0 0.327 0 -0 0</pose>
+        <geometry>
+          <mesh>
+            <scale>1 1 1</scale>
+            <uri>meshes/VLP16_scan.dae</uri>
+          </mesh>
+        </geometry>
+      </visual>
+      <!-- Rail on top of husky -->
+      <visual name="base_link_fixed_joint_lump__user_rail_link_visual_13">
+        <pose frame="">0.272 0 0.245 0 -0 0</pose>
+        <geometry>
+          <mesh>
+            <scale>1 1 1</scale>
+            <uri>meshes/user_rail.dae</uri>
+          </mesh>
+        </geometry>
+      </visual>
+      <!-- 2D planar lidar at bottom of sensor suite -->
+      <visual name="base_link_fixed_joint_lump__planar_lidar_link_visual_14">
+        <pose frame="">0.474 0 0.127 0 -0 0</pose>
+        <geometry>
+          <cylinder>
+              <radius>0.045</radius>
+              <length>0.05</length>
+          </cylinder>
+        </geometry>
+      </visual>
+      <visual name="base_link_fixed_joint_lump__velodyne_gimbal_plate_15">
+       <pose frame="">0.424 0 0.400 0 -0 0</pose>
+        <geometry>
+          <box>
+            <size>0.06 0.06 0.01</size>
+          </box>
+        </geometry>
+      </visual>
+      <visual name="base_link_fixed_joint_lump__sensor_tower_16">
+       <pose frame="">0.374 0 0.215 0 -0 0</pose>
+        <geometry>
+          <box>
+            <size>0.2 0.25 0.225</size>
+          </box>
+        </geometry>
+      </visual>
+      <visual name="base_link_fixed_joint_lump__computer_block_17">
+       <pose frame="">0.050 0 0.185 0 -0 0</pose>
+        <geometry>
+          <box>
+            <size>0.30 0.355 0.175</size>
+          </box>
+        </geometry>
+      </visual>
+
+      <velocity_decay/>
+      <self_collide>0</self_collide>
+      <enable_wind>0</enable_wind>
+      <kinematic>0</kinematic>
+
+      <!-- thermal camera -->
+      <visual name="thermal_camera_visual">
+        <pose >0.485 0 0.169 0 0 0</pose>
+        <geometry>
+          <box>
+            <size>0.02 0.025 0.025</size>
+          </box>
+        </geometry>
+      </visual>
+      <sensor name="thermal_camera" type="thermal">
+        <pose >0.485 0 0.169 0 0 0</pose>
+        <camera name="thermal_camera">
+          <horizontal_fov>0.4922</horizontal_fov>
+          <lens>
+            <intrinsics>
+              <!-- fx = fy = width / ( 2 * tan (hfov / 2 ) ) -->
+              <fx>764.35630</fx>
+              <fy>764.35630</fy>
+              <!-- cx = ( width + 1 ) / 2 -->
+              <cx>192.5</cx>
+              <!-- cy = ( height + 1 ) / 2 -->
+              <cy>144.5</cy>
+              <s>0</s>
+            </intrinsics>
+          </lens>
+          <image>
+            <width>384</width>
+            <height>288</height>
+            <format>L8</format>
+          </image>
+          <clip>
+            <near>0.1</near>
+            <far>100</far>
+          </clip>
+        </camera>
+        <always_on>1</always_on>
+        <update_rate>25</update_rate>
+        <plugin
+          filename="ignition-gazebo-thermal-sensor-system"
+          name="ignition::gazebo::systems::ThermalSensor">
+          <min_temp>253.15</min_temp>
+          <max_temp>673.15</max_temp>
+          <resolution>1.6</resolution>
+        </plugin>
+      </sensor>
+
+      <!-- Based on Intel realsense D435 (intrinsics and distortion not modeled)-->
+      <sensor name="camera_front" type="rgbd_camera">
+        <camera name="camera_front">
+            <horizontal_fov>1.5184</horizontal_fov>
+            <lens>
+                <intrinsics>
+                    <!-- fx = fy = width / ( 2 * tan (hfov / 2 ) ) -->
+                    <fx>168.61097</fx>
+                    <fy>168.61097</fy>
+                    <!-- cx = ( width + 1 ) / 2 -->
+                    <cx>160.5</cx>
+                    <!-- cy = ( height + 1 ) / 2 -->
+                    <cy>120.5</cy>
+                    <s>0</s>
+                </intrinsics>
+            </lens>
+            <distortion>
+                <k1>0.0</k1>
+                <k2>0.0</k2>
+                <k3>0.0</k3>
+                <p1>0.0</p1>
+                <p2>0.0</p2>
+                <center>0.5 0.5</center>
+            </distortion>
+            <image>
+                <width>320</width>
+                <height>240</height>
+                <format>R8G8B8</format>
+            </image>
+            <clip>
+                <near>0.01</near>
+                <far>300</far>
+            </clip>
+            <depth_camera>
+              <clip>
+                <near>0.1</near>
+                <far>10</far>
+              </clip>
+            </depth_camera>
+            <noise>
+                <type>gaussian</type>
+                <mean>0</mean>
+                <stddev>0.007</stddev>
+            </noise>
+        </camera>
+        <always_on>1</always_on>
+        <update_rate>30</update_rate>
+        <visualize>0</visualize>
+        <pose frame="">0.468 0 0.360 0 -0 0</pose>
+      </sensor>
+      <gravity>1</gravity>
+      <velocity_decay/>
+      <!-- Based on Intel realsense D435 (intrinsics and distortion not modeled)-->
+      <sensor name="camera_down" type="rgbd_camera">
+        <camera name="camera_down">
+            <horizontal_fov>1.5184</horizontal_fov>
+            <lens>
+                <intrinsics>
+                    <!-- fx = fy = width / ( 2 * tan (hfov / 2 ) ) -->
+                    <fx>168.61097</fx>
+                    <fy>168.61097</fy>
+                    <!-- cx = ( width + 1 ) / 2 -->
+                    <cx>160.5</cx>
+                    <!-- cy = ( height + 1 ) / 2 -->
+                    <cy>120.5</cy>
+                    <s>0</s>
+                </intrinsics>
+            </lens>
+            <distortion>
+                <k1>0.0</k1>
+                <k2>0.0</k2>
+                <k3>0.0</k3>
+                <p1>0.0</p1>
+                <p2>0.0</p2>
+                <center>0.5 0.5</center>
+            </distortion>
+            <image>
+                <width>320</width>
+                <height>240</height>
+                <format>R8G8B8</format>
+            </image>
+            <clip>
+                <near>0.01</near>
+                <far>300</far>
+            </clip>
+            <depth_camera>
+              <clip>
+                <near>0.1</near>
+                <far>10</far>
+              </clip>
+            </depth_camera>
+            <noise>
+                <type>gaussian</type>
+                <mean>0</mean>
+                <stddev>0.007</stddev>
+            </noise>
+        </camera>
+        <always_on>1</always_on>
+        <update_rate>30</update_rate>
+        <visualize>0</visualize>
+        <pose frame="">0.468 0 0.335 0 0.5236 0</pose>
+      </sensor>
+      <gravity>1</gravity>
+      <velocity_decay/>
+      <!-- Based on RPLidar S1 -->
+      <sensor name="planar_laser" type="gpu_ray">
+          <pose>0.474 0 0.127 0 -0 0</pose>
+          <update_rate>10</update_rate>
+          <lidar>
+              <scan>
+                  <horizontal>
+                      <samples>920</samples>
+                      <resolution>1</resolution>
+                      <min_angle>-3.14159</min_angle>
+                      <max_angle>3.14159</max_angle>
+                  </horizontal>
+              </scan>
+              <range>
+                  <min>0.04</min>
+                  <max>25</max>
+                  <resolution>0.03</resolution>
+              </range>
+              <noise>
+                  <type>gaussian</type>
+                  <mean>0</mean>
+                  <stddev>0.01</stddev>
+              </noise>
+          </lidar>
+      </sensor>
+      <gravity>1</gravity>
+      <velocity_decay/>
+
+      <!-- OS1-64 3D Laser Configuration (10x2048 or 10x1024 or 20x1024 or 20x512 as possible (rate) x (hor. res.) configs)-->
+      <sensor name="front_laser" type="gpu_lidar">
+        <visualize>0</visualize>
+        <update_rate>20</update_rate>
+        <lidar>
+          <scan>
+            <horizontal>
+              <samples>1024</samples>
+              <resolution>1</resolution>
+              <min_angle>-3.1459</min_angle>
+              <max_angle>3.1459</max_angle>
+            </horizontal>
+            <vertical>
+              <samples>64</samples>
+              <resolution>1</resolution>
+              <min_angle>-0.2897</min_angle>
+              <max_angle>0.2897</max_angle>
+            </vertical>
+          </scan>
+          <range>
+            <min>0.8</min>
+            <max>120</max>
+            <resolution>0.003</resolution>
+          </range>
+          <noise>
+            <type>gaussian</type>
+            <mean>0</mean>
+            <stddev>0.03</stddev>
+          </noise>
+        </lidar>
+        <pose frame="">0.424 0 0.387 0 -0 0</pose>
+      </sensor>
+
+
+      <sensor name="imu_sensor" type="imu">
+        <always_on>1</always_on>
+        <update_rate>50</update_rate>
+        <imu>
+                    <angular_velocity>
+                        <x>
+                            <noise type="gaussian">
+                                <mean>0</mean>
+                                <stddev>0.009</stddev>
+                                <bias_mean>0.00075</bias_mean>
+                                <bias_stddev>0.005</bias_stddev>
+                                <dynamic_bias_stddev>0.00002</dynamic_bias_stddev>
+                                <dynamic_bias_correlation_time>400.0</dynamic_bias_correlation_time>
+                                <precision>0.00025</precision>
+                            </noise>
+                        </x>
+                        <y>
+                            <noise type="gaussian">
+                                <mean>0</mean>
+                                <stddev>0.009</stddev>
+                                <bias_mean>0.00075</bias_mean>
+                                <bias_stddev>0.005</bias_stddev>
+                                <dynamic_bias_stddev>0.00002</dynamic_bias_stddev>
+                                <dynamic_bias_correlation_time>400.0</dynamic_bias_correlation_time>
+                                <precision>0.00025</precision>
+                            </noise>
+                        </y>
+                        <z>
+                            <noise type="gaussian">
+                                <mean>0</mean>
+                                <stddev>0.009</stddev>
+                                <bias_mean>0.00075</bias_mean>
+                                <bias_stddev>0.005</bias_stddev>
+                                <dynamic_bias_stddev>0.00002</dynamic_bias_stddev>
+                                <dynamic_bias_correlation_time>400.0</dynamic_bias_correlation_time>
+                                <precision>0.00025</precision>
+                            </noise>
+                        </z>
+                    </angular_velocity>
+                    <linear_acceleration>
+                        <x>
+                            <noise type="gaussian">
+                                <mean>0</mean>
+                                <stddev>0.021</stddev>
+                                <bias_mean>0.05</bias_mean>
+                                <bias_stddev>0.0075</bias_stddev>
+                                <dynamic_bias_stddev>0.000375</dynamic_bias_stddev>
+                                <dynamic_bias_correlation_time>175.0</dynamic_bias_correlation_time>
+                                <precision>0.005</precision>
+                            </noise>
+                        </x>
+                        <y>
+                            <noise type="gaussian">
+                                <mean>0</mean>
+                                <stddev>0.021</stddev>
+                                <bias_mean>0.05</bias_mean>
+                                <bias_stddev>0.0075</bias_stddev>
+                                <dynamic_bias_stddev>0.000375</dynamic_bias_stddev>
+                                <dynamic_bias_correlation_time>175.0</dynamic_bias_correlation_time>
+                                <precision>0.005</precision>
+                            </noise>
+                        </y>
+                        <z>
+                            <noise type="gaussian">
+                                <mean>0</mean>
+                                <stddev>0.021</stddev>
+                                <bias_mean>0.05</bias_mean>
+                                <bias_stddev>0.0075</bias_stddev>
+                                <dynamic_bias_stddev>0.000375</dynamic_bias_stddev>
+                                <dynamic_bias_correlation_time>175.0</dynamic_bias_correlation_time>
+                                <precision>0.005</precision>
+                            </noise>
+                        </z>
+                    </linear_acceleration>
+                </imu>
+      </sensor>
+    </link>
+    <link name="front_left_wheel_link">
+      <pose frame="">0.256 0.2854 0.03282 0 -0 0</pose>
+      <inertial>
+        <pose frame="">0 0 0 0 -0 0</pose>
+        <mass>2.637</mass>
+        <inertia>
+          <ixx>0.02467</ixx>
+          <ixy>0</ixy>
+          <ixz>0</ixz>
+          <iyy>0.04411</iyy>
+          <iyz>0</iyz>
+          <izz>0.02467</izz>
+        </inertia>
+      </inertial>
+      <collision name="front_left_wheel_link_collision">
+        <pose frame="">0 0 0 1.5707963267948966 -0 0</pose>
+        <geometry>
+          <cylinder>
+            <length>0.1143</length>
+            <radius>0.1651</radius>
+          </cylinder>
+        </geometry>
+        <surface>
+          <contact>
+            <ode>
+              <kp>1e+07</kp>
+              <kd>1</kd>
+            </ode>
+          </contact>
+          <friction>
+            <ode>
+              <mu>0.5</mu>
+              <mu2>1</mu2>
+              <slip1>0.00062</slip1>
+              <slip2>0</slip2>
+              <fdir1>0 0 1</fdir1>
+            </ode>
+          </friction>
+        </surface>
+      </collision>
+      <visual name="front_left_wheel_link_visual">
+        <pose frame="">0 0 0 0 -0 0</pose>
+        <geometry>
+          <mesh>
+            <scale>1 1 1</scale>
+            <uri>meshes/wheel.dae</uri>
+          </mesh>
+        </geometry>
+      </visual>
+      <gravity>1</gravity>
+      <velocity_decay/>
+    </link>
+    <joint name="front_left_wheel_joint" type="revolute">
+      <child>front_left_wheel_link</child>
+      <parent>base_link</parent>
+      <axis>
+        <xyz>0 1 0</xyz>
+        <limit>
+          <lower>-1e+16</lower>
+          <upper>1e+16</upper>
+        </limit>
+        <dynamics>
+          <spring_reference>0</spring_reference>
+          <spring_stiffness>0</spring_stiffness>
+        </dynamics>
+        <use_parent_model_frame>1</use_parent_model_frame>
+      </axis>
+    </joint>
+    <link name="front_right_wheel_link">
+      <pose frame="">0.256 -0.2854 0.03282 0 -0 0</pose>
+      <inertial>
+        <pose frame="">0 0 0 0 -0 0</pose>
+        <mass>2.637</mass>
+        <inertia>
+          <ixx>0.02467</ixx>
+          <ixy>0</ixy>
+          <ixz>0</ixz>
+          <iyy>0.04411</iyy>
+          <iyz>0</iyz>
+          <izz>0.02467</izz>
+        </inertia>
+      </inertial>
+      <collision name="front_right_wheel_link_collision">
+        <pose frame="">0 0 0 1.5707963267948966 -0 0</pose>
+        <geometry>
+          <cylinder>
+            <length>0.1143</length>
+            <radius>0.1651</radius>
+          </cylinder>
+        </geometry>
+        <surface>
+          <contact>
+            <ode>
+              <kp>1e+07</kp>
+              <kd>1</kd>
+            </ode>
+          </contact>
+          <friction>
+            <ode>
+              <mu>0.5</mu>
+              <mu2>1</mu2>
+              <slip1>0.00062</slip1>
+              <slip2>0</slip2>
+              <fdir1>0 0 1</fdir1>
+            </ode>
+          </friction>
+        </surface>
+      </collision>
+      <visual name="front_right_wheel_link_visual">
+        <pose frame="">0 0 0 0 -0 0</pose>
+        <geometry>
+          <mesh>
+            <scale>1 1 1</scale>
+            <uri>meshes/wheel.dae</uri>
+          </mesh>
+        </geometry>
+      </visual>
+      <gravity>1</gravity>
+      <velocity_decay/>
+    </link>
+    <joint name="front_right_wheel_joint" type="revolute">
+      <child>front_right_wheel_link</child>
+      <parent>base_link</parent>
+      <axis>
+        <xyz>0 1 0</xyz>
+        <limit>
+          <lower>-1e+16</lower>
+          <upper>1e+16</upper>
+        </limit>
+        <dynamics>
+          <spring_reference>0</spring_reference>
+          <spring_stiffness>0</spring_stiffness>
+        </dynamics>
+        <use_parent_model_frame>1</use_parent_model_frame>
+      </axis>
+    </joint>
+    <link name="rear_left_wheel_link">
+      <pose frame="">-0.256 0.2854 0.03282 0 -0 0</pose>
+      <inertial>
+        <pose frame="">0 0 0 0 -0 0</pose>
+        <mass>2.637</mass>
+        <inertia>
+          <ixx>0.02467</ixx>
+          <ixy>0</ixy>
+          <ixz>0</ixz>
+          <iyy>0.04411</iyy>
+          <iyz>0</iyz>
+          <izz>0.02467</izz>
+        </inertia>
+      </inertial>
+      <collision name="rear_left_wheel_link_collision">
+        <pose frame="">0 0 0 1.5707963267948966 -0 0</pose>
+        <geometry>
+          <cylinder>
+            <length>0.1143</length>
+            <radius>0.1651</radius>
+          </cylinder>
+        </geometry>
+        <surface>
+          <contact>
+            <ode>
+              <kp>1e+07</kp>
+              <kd>1</kd>
+            </ode>
+          </contact>
+          <friction>
+            <ode>
+              <mu>0.5</mu>
+              <mu2>1</mu2>
+              <slip1>0.00062</slip1>
+              <slip2>0</slip2>
+              <fdir1>0 0 1</fdir1>
+            </ode>
+          </friction>
+        </surface>
+      </collision>
+      <visual name="rear_left_wheel_link_visual">
+        <pose frame="">0 0 0 0 -0 0</pose>
+        <geometry>
+          <mesh>
+            <scale>1 1 1</scale>
+            <uri>meshes/wheel.dae</uri>
+          </mesh>
+        </geometry>
+      </visual>
+      <gravity>1</gravity>
+      <velocity_decay/>
+    </link>
+    <joint name="rear_left_wheel_joint" type="revolute">
+      <child>rear_left_wheel_link</child>
+      <parent>base_link</parent>
+      <axis>
+        <xyz>0 1 0</xyz>
+        <limit>
+          <lower>-1e+16</lower>
+          <upper>1e+16</upper>
+        </limit>
+        <dynamics>
+          <spring_reference>0</spring_reference>
+          <spring_stiffness>0</spring_stiffness>
+        </dynamics>
+        <use_parent_model_frame>1</use_parent_model_frame>
+      </axis>
+    </joint>
+    <link name="rear_right_wheel_link">
+      <pose frame="">-0.256 -0.2854 0.03282 0 -0 0</pose>
+      <inertial>
+        <pose frame="">0 0 0 0 -0 0</pose>
+        <mass>2.637</mass>
+        <inertia>
+          <ixx>0.02467</ixx>
+          <ixy>0</ixy>
+          <ixz>0</ixz>
+          <iyy>0.04411</iyy>
+          <iyz>0</iyz>
+          <izz>0.02467</izz>
+        </inertia>
+      </inertial>
+      <collision name="rear_right_wheel_link_collision">
+        <pose frame="">0 0 0 1.5707963267948966 -0 0</pose>
+        <geometry>
+          <cylinder>
+            <length>0.1143</length>
+            <radius>0.1651</radius>
+          </cylinder>
+        </geometry>
+        <surface>
+          <contact>
+            <ode>
+              <kp>1e+07</kp>
+              <kd>1</kd>
+            </ode>
+          </contact>
+          <friction>
+            <ode>
+              <mu>0.5</mu>
+              <mu2>1</mu2>
+              <slip1>0.00062</slip1>
+              <slip2>0</slip2>
+              <fdir1>0 0 1</fdir1>
+            </ode>
+          </friction>
+        </surface>
+      </collision>
+      <visual name="rear_right_wheel_link_visual">
+        <pose frame="">0 0 0 0 -0 0</pose>
+        <geometry>
+          <mesh>
+            <scale>1 1 1</scale>
+            <uri>meshes/wheel.dae</uri>
+          </mesh>
+        </geometry>
+      </visual>
+      <gravity>1</gravity>
+      <velocity_decay/>
+    </link>
+    <joint name="rear_right_wheel_joint" type="revolute">
+      <child>rear_right_wheel_link</child>
+      <parent>base_link</parent>
+      <axis>
+        <xyz>0 1 0</xyz>
+        <limit>
+          <lower>-1e+16</lower>
+          <upper>1e+16</upper>
+        </limit>
+        <dynamics>
+          <spring_reference>0</spring_reference>
+          <spring_stiffness>0</spring_stiffness>
+        </dynamics>
+        <use_parent_model_frame>1</use_parent_model_frame>
+      </axis>
+    </joint>
+    <link name="pan_gimbal_link">
+      <pose frame="">0.424 0 0.427 0 -0 0</pose>
+      <inertial>
+        <pose frame="">0 0 0 0 -0 0</pose>
+        <mass>0.1</mass>
+        <inertia>
+          <ixx>0.000016875</ixx>
+          <ixy>0</ixy>
+          <ixz>0</ixz>
+          <iyy>0.00000001</iyy>
+          <iyz>0</iyz>
+          <izz>0.000016875</izz>
+        </inertia>
+      </inertial>
+      <collision name="pan_gimbal_link_collision">
+      <pose frame="">0.0 0 0.0 0 -0 0</pose>
+      <geometry>
+        <cylinder>
+          <length>0.045</length>
+          <radius>0.014</radius>
+        </cylinder>
+      </geometry>
+      <surface>
+        <contact>
+          <ode>
+            <kp>1e+07</kp>
+            <kd>1</kd>
+          </ode>
+        </contact>
+      </surface>
+      </collision>
+      <visual name="pan_gimbal_link_visual">
+        <pose frame="">0.0 0 0.0 0 -0 0</pose>
+        <geometry>
+          <cylinder>
+            <length>0.045</length>
+            <radius>0.014</radius>
+          </cylinder>
+        </geometry>
+      </visual>
+    </link>
+    <link name="tilt_gimbal_link">
+      <pose frame="">0.424 0 0.460 0 -0 0</pose>
+      <inertial>
+        <pose frame="">0 0 0 1.570796 -0 0</pose>
+        <mass>0.1</mass>
+         <inertia>
+          <ixx>0.000016875</ixx>
+          <ixy>0</ixy>
+          <ixz>0</ixz>
+          <iyy>0.00000001</iyy>
+          <iyz>0</iyz>
+          <izz>0.000016875</izz>
+        </inertia>
+      </inertial>
+
+      <collision name="tilt_gimbal_link_collision">
+      <pose frame="">0.0 0 0.0 1.570796 -0 0</pose>
+      <geometry>
+        <cylinder>
+          <length>0.045</length>
+          <radius>0.014</radius>
+        </cylinder>
+      </geometry>
+      <surface>
+        <contact>
+          <ode>
+            <kp>1e+07</kp>
+            <kd>1</kd>
+          </ode>
+        </contact>
+      </surface>
+      </collision>
+      <visual name="tilt_gimbal_link_visual">
+        <pose frame="">0.0 0 0.0 1.570796 -0 0</pose>
+        <geometry>
+          <cylinder>
+            <length>0.045</length>
+            <radius>0.014</radius>
+          </cylinder>
+        </geometry>
+      </visual>
+      <!-- Based on Intel realsense D435 (intrinsics and distortion not modeled)-->
+      <sensor name="camera_pan_tilt" type="rgbd_camera">
+        <camera name="camera_pan_tilt">
+            <horizontal_fov>1.5184</horizontal_fov>
+            <lens>
+                <intrinsics>
+                    <!-- fx = fy = width / ( 2 * tan (hfov / 2 ) ) -->
+                    <fx>337.22195</fx>
+                    <fy>337.22195</fy>
+                    <!-- cx = ( width + 1 ) / 2 -->
+                    <cx>320.5</cx>
+                    <!-- cy = ( height + 1 ) / 2 -->
+                    <cy>240.5</cy>
+                    <s>0</s>
+                </intrinsics>
+            </lens>
+            <distortion>
+                <k1>0.0</k1>
+                <k2>0.0</k2>
+                <k3>0.0</k3>
+                <p1>0.0</p1>
+                <p2>0.0</p2>
+                <center>0.5 0.5</center>
+            </distortion>
+            <image>
+                <width>640</width>
+                <height>480</height>
+                <format>R8G8B8</format>
+            </image>
+            <clip>
+                <near>0.01</near>
+                <far>300</far>
+            </clip>
+            <depth_camera>
+              <clip>
+                <near>0.1</near>
+                <far>10</far>
+              </clip>
+            </depth_camera>
+            <noise>
+                <type>gaussian</type>
+                <mean>0</mean>
+                <stddev>0.007</stddev>
+            </noise>
+        </camera>
+        <always_on>1</always_on>
+        <update_rate>30</update_rate>
+        <visualize>0</visualize>
+
+        <pose frame="">0.0 0 0.03 0 0.0 0</pose>
+      </sensor>
+      <gravity>1</gravity>
+      <velocity_decay/>
+      <visual name="tilt_gimbal_link_fixed_joint_lump__camera/camera_link_visual_0">
+        <pose frame="">0 0 0.03 0 0.0 0</pose>
+        <geometry>
+          <mesh>
+            <uri>meshes/realsense.dae</uri>
+          </mesh>
+        </geometry>
+      </visual>
+      <visual name="tilt_gimbal_link_fixed_joint_lump_bot_camera_plate_link_visual_1">
+       <pose frame="">0 0 0.017 0 -0 0</pose>
+        <geometry>
+          <box>
+            <size>0.025 0.13 0.007</size>
+          </box>
+        </geometry>
+      </visual>
+      <visual name="tilt_gimbal_link_fixed_joint_lump_bot_camera_plate_link_visual_2">
+       <pose frame="">0 0 0.042 0 -0 0</pose>
+        <geometry>
+          <box>
+            <size>0.025 0.13 0.007</size>
+          </box>
+        </geometry>
+      </visual>
+      <light name="flashlight_flashlight_light_source_lamp_light" type="spot">
+        <pose frame="">0.0 0.0 0.065 3.141592653589793 1.5707963267948966 -0.0015926535897931</pose>
+        <attenuation>
+          <range>50</range>
+          <linear>0</linear>
+          <constant>0.1</constant>
+          <quadratic>0.0025</quadratic>
+        </attenuation>
+        <diffuse>0.8 0.8 0.5 1</diffuse>
+        <specular>0.8 0.8 0.5 1</specular>
+        <spot>
+          <!-- The lights on the MARBLE ground vehicles are very wide angle, 100W LEDs -->
+          <inner_angle>2.8</inner_angle>
+          <outer_angle>2.9</outer_angle>
+          <falloff>1</falloff>
+        </spot>
+        <direction>0 0 -1</direction>
+      </light>
+      <visual name="flashlight_flashlight_light_source_lamp_viz_visual">
+        <pose>0.0 0.0 0.065 3.141592653589793 1.5707963267948966 -0.0015926535897931</pose>
+        <geometry>
+          <cylinder>
+            <radius>0.019</radius>
+            <length>0.005</length>
+          </cylinder>
+        </geometry>
+        <transparency>0</transparency>
+        <material>
+          <ambient>1 1 1 1</ambient>
+          <diffuse>1 1 1 1</diffuse>
+          <specular>1 1 1 1</specular>
+          <emissive>1 1 1 1</emissive>
+        </material>
+      </visual>
+    </link>
+    <joint name="pan_gimbal_joint" type="revolute">
+      <child>pan_gimbal_link</child>
+      <parent>base_link</parent>
+      <axis>
+        <xyz>0 0 1</xyz>
+        <limit>
+          <lower>-1e+16</lower>
+          <upper>1e+16</upper>
+          <effort>10</effort>
+        </limit>
+        <dynamics>
+          <spring_reference>0</spring_reference>
+          <spring_stiffness>0</spring_stiffness>
+          <damping>0.5</damping>
+        </dynamics>
+        <use_parent_model_frame>1</use_parent_model_frame>
+      </axis>
+    </joint>
+    <joint name="tilt_gimbal_joint" type="revolute">
+      <child>tilt_gimbal_link</child>
+      <parent>pan_gimbal_link</parent>
+      <axis>
+        <xyz>0 1 0</xyz>
+        <limit>
+          <lower>-1.5708</lower> <!-- 90 degrees both direction (mechanical interference)-->
+          <upper>1.5708</upper>
+          <effort>10</effort>
+        </limit>
+        <dynamics>
+          <spring_reference>0</spring_reference>
+          <spring_stiffness>0</spring_stiffness>
+          <damping>0.5</damping>
+        </dynamics>
+        <use_parent_model_frame>1</use_parent_model_frame>
+      </axis>
+    </joint>
+    <!-- Gimbal Joints Plugins -->
+    <plugin
+      filename="libignition-gazebo-joint-controller-system.so"
+      name="ignition::gazebo::systems::JointController">
+      <joint_name>pan_gimbal_joint</joint_name>
+      <use_force_commands>true</use_force_commands>
+      <p_gain>0.4</p_gain>
+      <i_gain>10</i_gain>
+    </plugin>
+    <plugin
+      filename="libignition-gazebo-joint-controller-system.so"
+      name="ignition::gazebo::systems::JointController">
+      <joint_name>tilt_gimbal_joint</joint_name>
+      <use_force_commands>true</use_force_commands>
+      <p_gain>0.4</p_gain>
+      <i_gain>10</i_gain>
+    </plugin>
+    <plugin
+      filename="libignition-gazebo-joint-state-publisher-system.so"
+      name="ignition::gazebo::systems::JointStatePublisher">
+      <joint_name>pan_gimbal_joint</joint_name>
+      <joint_name>tilt_gimbal_joint</joint_name>
+    </plugin>
+    <static>0</static>
+  </model>
+</sdf>
+


### PR DESCRIPTION
This pull request is a proposal to keep track of the model.sdf files for:
* MARBLE_HUSKY_SENSOR_CONFIG_3
* MARBLE_HUSKY_SENSOR_CONFIG_4
* MARBLE_HD2_SENSOR_CONFIG_3
* MARBLE_HD2_SENSOR_CONFIG_4
* CERBERUS_M100_SENSOR_CONFIG_2

motivated by issue #821 

Currently the marble sensor config 3 and 4 models are equivalent to the sensor config 1 and 2 models + a thermal camera., and the cerberus sensor config 2 is a copy of config 1 with a thermal camera. They currently do not have their `model.sdf` files in the subt repo. Issue #812 due to us overriding the thermal changes in the `model.sdf`s on Fuel with changes from https://github.com/osrf/subt/pull/798

This is a proposal to keep a reference copy in the repo so we can track its changes better with git. Note this may help with version control but adds extra maintenance effort.

Signed-off-by: Ian Chen <ichen@osrfoundation.org>