### PR TITLE
Fix marble hd2 pan_tilt camera & shafter pose

### DIFF
--- a/submitted_models/costar_shafter_sensor_config_1/model.sdf
+++ b/submitted_models/costar_shafter_sensor_config_1/model.sdf
@@ -1,3 +1,4 @@
+<?xml version='1.0' encoding='utf-8'?>
 <sdf version='1.6'>
     <model name='shafter'>
         <link name='base_link'>
@@ -180,7 +181,7 @@
             </visual>
           
             <sensor name="realsense_front" type="rgbd_camera">
-                <pose>0.17 0.0 -0.003 0 0 0</pose>
+                <pose>0.16 0.0 -0.02 0 0 0</pose>
                 <always_on>1</always_on>
                 <update_rate>30</update_rate>
                 <camera name="realsense_front">

--- a/submitted_models/marble_hd2_sensor_config_1/model.sdf
+++ b/submitted_models/marble_hd2_sensor_config_1/model.sdf
@@ -1036,8 +1036,7 @@
                       </camera>
                       <always_on>1</always_on>
                       <update_rate>30</update_rate>
-                      <!-- <pose frame="">0.424 0 0.542 0 0.0 0</pose>  -->
-                      <pose frame="">0.0 0 0.03 0 0.0 0</pose>
+                      <pose frame="">0.02 0 0.047725 0 0.0 0</pose>
                     </sensor>
 
                     <light name="flashlight_flashlight_light_source_lamp_light" type="spot">


### PR DESCRIPTION
Resolves issue #662. The camera location was causing clipping due to mesh obstruction.

see https://github.com/osrf/subt/issues/662#issuecomment-802102592

Signed-off-by: Nate Koenig <nate@openrobotics.org>