### PR TITLE
Fix rgbd_camera.launch set_rate topic path

### DIFF
--- a/subt_ros/launch/models_common/rgb_camera.launch
+++ b/subt_ros/launch/models_common/rgb_camera.launch
@@ -5,6 +5,7 @@
     <arg name="gazebo_topic" doc="The Gazebo 'base' topic (i.e. the prefix before /image and /camera_info)." />
     <arg name="ros_topic" doc="The ROS topic to publish the camera on (prefix without /image_raw or /camera_info)." />
     <arg name="node_name_suffix" doc="Suffix of the generated nodes. Use to disambiguate if multiple cameras of any type are used." />
+    <arg name="set_rate_ign_service" default="$(arg gazebo_topic)/image/set_rate" doc="Gazebo service for setting rate of the camera. Keep the default when using RGB cameras." />
 
     <arg name="publish_optical_frame" default="1" doc="If true, optical frame publisher will be created. Otherwise you have to provide the optical publisher by some other means." />
 
@@ -35,7 +36,7 @@
     <!-- Allow slowing down framerate of the camera. -->
     <include file="$(dirname)/set_rate_relay.launch">
       <arg name="name" value="ros_ign_bridge_$(arg node_name_suffix)_set_rate" />
-      <arg name="ign_service" value="$(arg gazebo_topic)/image/set_rate" />
+      <arg name="ign_service" value="$(arg set_rate_ign_service)" />
       <arg name="ros_service" value="$(arg ros_topic)/set_rate" />
     </include>
 </launch>

--- a/subt_ros/launch/models_common/rgbd_camera.launch
+++ b/subt_ros/launch/models_common/rgbd_camera.launch
@@ -10,7 +10,10 @@
     <arg name="publish_optical_frame" default="1" doc="If true, optical frame publisher will be created. Otherwise you have to provide the optical publisher by some other means." />
 
     <!-- RGB camera -->
-    <include file="$(dirname)/rgb_camera.launch" pass_all_args="true" />
+    <include file="$(dirname)/rgb_camera.launch" pass_all_args="true">
+      <!-- rgbd_camera does not put the intermediate /image in the set_rate service path -->
+      <arg name="set_rate_ign_service" value="$(arg gazebo_topic)/set_rate" />
+    </include>
 
     <!-- 3D cloud -->
     <node pkg="ros_ign_bridge" type="parameter_bridge" respawn="true"


### PR DESCRIPTION
One more fix to models_common.

RGBD camera advertises the `set_rate` service one level higher than RGB camera.

Example RGB camera `set_rate` path:

    /world/example/model/X1/link/sensor_rack/sensor/camera_5/image/set_rate

Example RGBD camera `set_rate` path:

    /world/example/model/X1/link/sensor_rack/sensor/camera_realsense/set_rate