### PR TITLE
Fixed invalid syntax in rgb_camera.launch file

### DIFF
--- a/subt_ros/launch/models_common/rgb_camera.launch
+++ b/subt_ros/launch/models_common/rgb_camera.launch
@@ -25,8 +25,7 @@
 
     <!-- RGB optical publisher -->
     <node pkg="subt_ros" type="optical_frame_publisher" respawn="true"
-      name="optical_frame_publisher_$(arg node_name_suffix)">
-      if="$(arg publish_optical_frame)"
+      name="optical_frame_publisher_$(arg node_name_suffix)" if="$(arg publish_optical_frame)">
       <remap from="input/image" to="$(arg ros_topic)/image_raw" />
       <remap from="output/image" to="$(arg ros_topic)/optical/image_raw" />
       <remap from="input/camera_info" to="$(arg ros_topic)/camera_info" />


### PR DESCRIPTION
Another little fix for the models_common bridge library. I haven't known roslaunch can process invalid XML and wouldn't tell a thing.