### PR TITLE
Absolem: Remove debug visuals

### DIFF
--- a/submitted_models/ctu_cras_norlab_absolem_sensor_config_1/model.sdf
+++ b/submitted_models/ctu_cras_norlab_absolem_sensor_config_1/model.sdf
@@ -234,23 +234,7 @@
           </mesh>
         </geometry>
       </visual>
-      <visual name="base_link_fixed_joint_lump__imu_visual_3">
-        <pose>0 0 0.15 -3.1415926535897931 0 0</pose>
-        <geometry>
-          <box>
-            <size>0.005 0.005 0.005</size>
-          </box>
-        </geometry>
-      </visual>
-      <visual name="base_link_fixed_joint_lump__laser_base_visual_4">
-        <pose>0.2502 0 0.1407 0 -0 0</pose>
-        <geometry>
-          <box>
-            <size>0.005 0.005 0.005</size>
-          </box>
-        </geometry>
-      </visual>
-      <visual name="base_link_fixed_joint_lump__jetson_visual_5">
+      <visual name="base_link_fixed_joint_lump__jetson_visual_3">
         <pose>0.136 0.0435 0.2125 0 -0 0</pose>
         <geometry>
           <box>
@@ -258,7 +242,7 @@
           </box>
         </geometry>
       </visual>
-      <visual name="base_link_fixed_joint_lump__rear_sensor_item_visual_6">
+      <visual name="base_link_fixed_joint_lump__rear_sensor_item_visual_4">
         <pose>-0.295 -0.1065 0.36 0 -0 0</pose>
         <geometry>
           <box>
@@ -266,7 +250,7 @@
           </box>
         </geometry>
       </visual>
-      <visual name="base_link_fixed_joint_lump__mobilicom_visual_7">
+      <visual name="base_link_fixed_joint_lump__mobilicom_visual_5">
         <pose>-0.275459 -0.078002 0.407765 -1.56579 -0.858407 -7.3e-05</pose>
         <geometry>
           <box>
@@ -274,7 +258,7 @@
           </box>
         </geometry>
       </visual>
-      <visual name="base_link_fixed_joint_lump__mobilicom_antenna_l_visual_8">
+      <visual name="base_link_fixed_joint_lump__mobilicom_antenna_l_visual_6">
         <pose>-0.139117 -0.02338 0.465445 -1.29704 -0.418237 -1.17028</pose>
         <geometry>
           <cylinder>
@@ -283,7 +267,7 @@
           </cylinder>
         </geometry>
       </visual>
-      <visual name="base_link_fixed_joint_lump__mobilicom_antenna_r_visual_9">
+      <visual name="base_link_fixed_joint_lump__mobilicom_antenna_r_visual_7">
         <pose>-0.193116 -0.064558 0.541453 -0.7124 0.007057 -1.5707963267948966</pose>
         <geometry>
           <cylinder>
@@ -292,7 +276,7 @@
           </cylinder>
         </geometry>
       </visual>
-      <visual name="base_link_fixed_joint_lump__top_box_visual_10">
+      <visual name="base_link_fixed_joint_lump__top_box_visual_8">
         <pose>0.022 -0.0557 0.185 0 -0 0</pose>
         <geometry>
           <mesh>
@@ -300,7 +284,7 @@
           </mesh>
         </geometry>
       </visual>
-      <visual name="base_link_fixed_joint_lump__omnicam_visual_11">
+      <visual name="base_link_fixed_joint_lump__omnicam_visual_9">
         <pose>0.0243 -0.0574 0.3142 0 0 -0.628319</pose>
         <geometry>
           <mesh>
@@ -308,135 +292,7 @@
           </mesh>
         </geometry>
       </visual>
-      <visual name="base_link_fixed_joint_lump__camera_0_visual_12">
-        <pose>0.057346 -0.083518 0.313841 -1.5707963267948966 -0.000784 -2.19802</pose>
-        <geometry>
-          <box>
-            <size>0.005 0.005 0.005</size>
-          </box>
-        </geometry>
-      </visual>
-      <visual name="base_link_fixed_joint_lump__camera_0_sim_visual_13">
-        <pose>0.057346 -0.083518 0.313841 -0.000948 -0.000784 -2.19802</pose>
-        <geometry>
-          <box>
-            <size>0.005 0.005 0.005</size>
-          </box>
-        </geometry>
-      </visual>
-      <visual name="base_link_fixed_joint_lump__camera_1_visual_14">
-        <pose>0.009992 -0.096606 0.314114 -1.57187 0.000853 2.82791</pose>
-        <geometry>
-          <box>
-            <size>0.005 0.005 0.005</size>
-          </box>
-        </geometry>
-      </visual>
-      <visual name="base_link_fixed_joint_lump__camera_1_sim_visual_15">
-        <pose>0.009992 -0.096606 0.314114 -0.001069 0.000853 2.82791</pose>
-        <geometry>
-          <box>
-            <size>0.005 0.005 0.005</size>
-          </box>
-        </geometry>
-      </visual>
-      <visual name="base_link_fixed_joint_lump__camera_2_visual_16">
-        <pose>-0.01735 -0.055429 0.314721 -1.5725 0.00415 1.56974</pose>
-        <geometry>
-          <box>
-            <size>0.005 0.005 0.005</size>
-          </box>
-        </geometry>
-      </visual>
-      <visual name="base_link_fixed_joint_lump__camera_2_sim_visual_17">
-        <pose>-0.01735 -0.055429 0.314721 -0.001705 0.00415 1.56974</pose>
-        <geometry>
-          <box>
-            <size>0.005 0.005 0.005</size>
-          </box>
-        </geometry>
-      </visual>
-      <visual name="base_link_fixed_joint_lump__camera_3_visual_18">
-        <pose>0.012561 -0.017068 0.314417 -1.5707963267948966 0.005611 0.313689</pose>
-        <geometry>
-          <box>
-            <size>0.005 0.005 0.005</size>
-          </box>
-        </geometry>
-      </visual>
-      <visual name="base_link_fixed_joint_lump__camera_3_sim_visual_19">
-        <pose>0.012561 -0.017068 0.314417 -0.000579 0.005611 0.313689</pose>
-        <geometry>
-          <box>
-            <size>0.005 0.005 0.005</size>
-          </box>
-        </geometry>
-      </visual>
-      <visual name="base_link_fixed_joint_lump__camera_4_visual_20">
-        <pose>0.058951 -0.03438 0.313899 -1.58161 0.001034 -0.943109</pose>
-        <geometry>
-          <box>
-            <size>0.005 0.005 0.005</size>
-          </box>
-        </geometry>
-      </visual>
-      <visual name="base_link_fixed_joint_lump__camera_4_sim_visual_21">
-        <pose>0.058951 -0.03438 0.313899 -0.010815 0.001034 -0.943109</pose>
-        <geometry>
-          <box>
-            <size>0.005 0.005 0.005</size>
-          </box>
-        </geometry>
-      </visual>
-      <visual name="base_link_fixed_joint_lump__camera_5_visual_22">
-        <pose>0.024083 -0.058382 0.376328 0.003778 0.000786 -2.20023</pose>
-        <geometry>
-          <box>
-            <size>0.005 0.005 0.005</size>
-          </box>
-        </geometry>
-      </visual>
-      <visual name="base_link_fixed_joint_lump__camera_5_sim_visual_23">
-        <pose>0.024083 -0.058382 0.376328 -2.19645 -1.5707963267948966 0</pose>
-        <geometry>
-          <box>
-            <size>0.005 0.005 0.005</size>
-          </box>
-        </geometry>
-      </visual>
-      <visual name="base_link_fixed_joint_lump__omnicam_forward_visual_24">
-        <pose>0.0243 -0.0574 0.3142 0 0 -0.000319</pose>
-        <geometry>
-          <box>
-            <size>0.005 0.005 0.005</size>
-          </box>
-        </geometry>
-      </visual>
-      <visual name="base_link_fixed_joint_lump__omnicam_bottom_visual_25">
-        <pose>0.0243 -0.0574 0.2482 0 0 -0.000319</pose>
-        <geometry>
-          <box>
-            <size>0.005 0.005 0.005</size>
-          </box>
-        </geometry>
-      </visual>
-      <visual name="base_link_fixed_joint_lump__omnicam_top_visual_26">
-        <pose>0.0243 -0.0574 0.3882 0 0 -0.000319</pose>
-        <geometry>
-          <box>
-            <size>0.005 0.005 0.005</size>
-          </box>
-        </geometry>
-      </visual>
-      <visual name="base_link_fixed_joint_lump__omnicam_sensor_mount_visual_27">
-        <pose>0.0243 -0.0574 0.3882 0 0 -0.000319</pose>
-        <geometry>
-          <box>
-            <size>0.005 0.005 0.005</size>
-          </box>
-        </geometry>
-      </visual>
-      <visual name="base_link_fixed_joint_lump__realsense_holder_part2_visual_28">
+      <visual name="base_link_fixed_joint_lump__realsense_holder_part2_visual_10">
         <pose>0.088136 -0.07392 0.386942 -5e-06 -0.002418 1.57486</pose>
         <geometry>
           <mesh>
@@ -449,31 +305,7 @@
           <ambient>0.1 0.1 0.1 1</ambient>
         </material>
       </visual>
-      <visual name="base_link_fixed_joint_lump__camera_back_mounting_plane_visual_29">
-        <pose>0.115312 -0.018929 0.4382 0.015 0.499467 -0.000319</pose>
-        <geometry>
-          <box>
-            <size>0.005 0.005 0.005</size>
-          </box>
-        </geometry>
-      </visual>
-      <visual name="base_link_fixed_joint_lump__camera_tripod_screw_link_visual_30">
-        <pose>0.119362 -0.010781 0.424738 0.015 0.499467 -0.000319</pose>
-        <geometry>
-          <box>
-            <size>0.005 0.005 0.005</size>
-          </box>
-        </geometry>
-      </visual>
-      <visual name="base_link_fixed_joint_lump__camera_bottom_screw_frame_visual_31">
-        <pose>0.119362 -0.010781 0.424738 0.015 0.499467 -0.000319</pose>
-        <geometry>
-          <box>
-            <size>0.005 0.005 0.005</size>
-          </box>
-        </geometry>
-      </visual>
-      <visual name="base_link_fixed_joint_lump__camera_link_visual_32">
+      <visual name="base_link_fixed_joint_lump__camera_link_visual_11">
         <pose>0.133719 -0.010853 0.422031 2.07031 -0.013167 1.56329</pose>
         <geometry>
           <mesh>
@@ -484,70 +316,6 @@
           <diffuse>0.5 0.5 0.5 1</diffuse>
           <ambient>0.1 0.1 0.1 1</ambient>
         </material>
-      </visual>
-      <visual name="base_link_fixed_joint_lump__camera_depth_frame_visual_33">
-        <pose>0.125479 0.006527 0.435941 0.015 0.499467 -0.000319</pose>
-        <geometry>
-          <box>
-            <size>0.005 0.005 0.005</size>
-          </box>
-        </geometry>
-      </visual>
-      <visual name="base_link_fixed_joint_lump__camera_color_frame_visual_34">
-        <pose>0.125592 0.021526 0.436138 0.015 0.499467 -0.000319</pose>
-        <geometry>
-          <box>
-            <size>0.005 0.005 0.005</size>
-          </box>
-        </geometry>
-      </visual>
-      <visual name="base_link_fixed_joint_lump__camera_color_optical_frame_visual_35">
-        <pose>0.125592 0.021526 0.436138 -2.07031 0.013167 -1.5783</pose>
-        <geometry>
-          <box>
-            <size>0.005 0.005 0.005</size>
-          </box>
-        </geometry>
-      </visual>
-      <visual name="base_link_fixed_joint_lump__camera_depth_optical_frame_visual_36">
-        <pose>0.125479 0.006527 0.435941 -2.07031 0.013167 -1.5783</pose>
-        <geometry>
-          <box>
-            <size>0.005 0.005 0.005</size>
-          </box>
-        </geometry>
-      </visual>
-      <visual name="base_link_fixed_joint_lump__camera_left_ir_frame_visual_37">
-        <pose>0.125479 0.006527 0.435941 0.015 0.499467 -0.000319</pose>
-        <geometry>
-          <box>
-            <size>0.005 0.005 0.005</size>
-          </box>
-        </geometry>
-      </visual>
-      <visual name="base_link_fixed_joint_lump__camera_left_ir_optical_frame_visual_38">
-        <pose>0.125479 0.006527 0.435941 -2.07031 0.013167 -1.5783</pose>
-        <geometry>
-          <box>
-            <size>0.005 0.005 0.005</size>
-          </box>
-        </geometry>
-      </visual>
-      <visual name="base_link_fixed_joint_lump__camera_right_ir_frame_visual_39">
-        <pose>0.125104 -0.043467 0.435282 0.015 0.499467 -0.000319</pose>
-        <geometry>
-          <box>
-            <size>0.005 0.005 0.005</size>
-          </box>
-        </geometry>
-      </visual>
-      <visual name="base_link_fixed_joint_lump__camera_right_ir_optical_frame_visual_40">
-        <pose>0.125104 -0.043467 0.435282 -2.07031 0.013167 -1.5783</pose>
-        <geometry>
-          <box>
-            <size>0.005 0.005 0.005</size>
-          </box>
-        </geometry>
       </visual>
       <light name="light_left" type="spot">
         <pose>0 0.13 0.2 1.5707963267948966 1.5707963267948966 0</pose>

--- a/submitted_models/ctu_cras_norlab_absolem_sensor_config_1/model.sdf
+++ b/submitted_models/ctu_cras_norlab_absolem_sensor_config_1/model.sdf
@@ -2501,6 +2501,22 @@
         </surface>
       </collision>
     </link>
+    <joint name="front_right_flipper_wheel2_j" type="revolute">
+      <pose relative_to="front_right_flipper">-0.0825 0 0 0 -0 0</pose>
+      <parent>front_right_flipper</parent>
+      <child>front_right_flipper_wheel2</child>
+      <axis>
+        <xyz>0 1 0</xyz>
+        <limit>
+          <lower>-1e+16</lower>
+          <upper>1e+16</upper>
+        </limit>
+        <dynamics>
+          <spring_reference>0</spring_reference>
+          <spring_stiffness>0</spring_stiffness>
+        </dynamics>
+      </axis>
+    </joint>
     <link name="front_right_flipper_wheel2">
       <pose relative_to="front_right_flipper_wheel2_j">0 0 0 0 -0 0</pose>
       <inertial>
@@ -2542,22 +2558,6 @@
         </surface>
       </collision>
     </link>
-    <joint name="front_right_flipper_wheel2_j" type="revolute">
-      <pose relative_to="front_right_flipper">-0.0825 0 0 0 -0 0</pose>
-      <parent>front_right_flipper</parent>
-      <child>front_right_flipper_wheel2</child>
-      <axis>
-        <xyz>0 1 0</xyz>
-        <limit>
-          <lower>-1e+16</lower>
-          <upper>1e+16</upper>
-        </limit>
-        <dynamics>
-          <spring_reference>0</spring_reference>
-          <spring_stiffness>0</spring_stiffness>
-        </dynamics>
-      </axis>
-    </joint>
     <link name="front_right_flipper_wheel3">
       <pose relative_to="front_right_flipper_wheel3_j">0 0 0 0 -0 0</pose>
       <inertial>

--- a/submitted_models/ctu_cras_norlab_absolem_sensor_config_1/model.sdf
+++ b/submitted_models/ctu_cras_norlab_absolem_sensor_config_1/model.sdf
@@ -1329,6 +1329,22 @@
         </surface>
       </collision>
     </link>
+    <joint name="front_left_flipper_wheel3_j" type="revolute">
+      <pose relative_to="front_left_flipper">0.165 0 0 0 -0 0</pose>
+      <parent>front_left_flipper</parent>
+      <child>front_left_flipper_wheel3</child>
+      <axis>
+        <xyz>0 1 0</xyz>
+        <limit>
+          <lower>-1e+16</lower>
+          <upper>1e+16</upper>
+        </limit>
+        <dynamics>
+          <spring_reference>0</spring_reference>
+          <spring_stiffness>0</spring_stiffness>
+        </dynamics>
+      </axis>
+    </joint>
     <link name="front_left_flipper_wheel3">
       <pose relative_to="front_left_flipper_wheel3_j">0 0 0 0 -0 0</pose>
       <inertial>
@@ -1370,22 +1386,6 @@
         </surface>
       </collision>
     </link>
-    <joint name="front_left_flipper_wheel3_j" type="revolute">
-      <pose relative_to="front_left_flipper">0.165 0 0 0 -0 0</pose>
-      <parent>front_left_flipper</parent>
-      <child>front_left_flipper_wheel3</child>
-      <axis>
-        <xyz>0 1 0</xyz>
-        <limit>
-          <lower>-1e+16</lower>
-          <upper>1e+16</upper>
-        </limit>
-        <dynamics>
-          <spring_reference>0</spring_reference>
-          <spring_stiffness>0</spring_stiffness>
-        </dynamics>
-      </axis>
-    </joint>
     <link name="front_left_flipper_wheel4">
       <pose relative_to="front_left_flipper_wheel4_j">0 0 0 0 -0 0</pose>
       <inertial>

--- a/submitted_models/ctu_cras_norlab_absolem_sensor_config_1/model.sdf
+++ b/submitted_models/ctu_cras_norlab_absolem_sensor_config_1/model.sdf
@@ -2852,6 +2852,22 @@
         </surface>
       </collision>
     </link>
+    <joint name="rear_right_flipper_wheel2_j" type="revolute">
+      <pose relative_to="rear_right_flipper">-0.0825 0 0 0 -0 0</pose>
+      <parent>rear_right_flipper</parent>
+      <child>rear_right_flipper_wheel2</child>
+      <axis>
+        <xyz>0 1 0</xyz>
+        <limit>
+          <lower>-1e+16</lower>
+          <upper>1e+16</upper>
+        </limit>
+        <dynamics>
+          <spring_reference>0</spring_reference>
+          <spring_stiffness>0</spring_stiffness>
+        </dynamics>
+      </axis>
+    </joint>
     <link name="rear_right_flipper_wheel2">
       <pose relative_to="rear_right_flipper_wheel2_j">0 0 0 0 -0 0</pose>
       <inertial>
@@ -2893,22 +2909,6 @@
         </surface>
       </collision>
     </link>
-    <joint name="rear_right_flipper_wheel2_j" type="revolute">
-      <pose relative_to="rear_right_flipper">-0.0825 0 0 0 -0 0</pose>
-      <parent>rear_right_flipper</parent>
-      <child>rear_right_flipper_wheel2</child>
-      <axis>
-        <xyz>0 1 0</xyz>
-        <limit>
-          <lower>-1e+16</lower>
-          <upper>1e+16</upper>
-        </limit>
-        <dynamics>
-          <spring_reference>0</spring_reference>
-          <spring_stiffness>0</spring_stiffness>
-        </dynamics>
-      </axis>
-    </joint>
     <link name="rear_right_flipper_wheel3">
       <pose relative_to="rear_right_flipper_wheel3_j">0 0 0 0 -0 0</pose>
       <inertial>

--- a/submitted_models/ctu_cras_norlab_absolem_sensor_config_1/model.sdf
+++ b/submitted_models/ctu_cras_norlab_absolem_sensor_config_1/model.sdf
@@ -944,7 +944,7 @@
             <scale_to_hfov>1</scale_to_hfov>
           </lens>
         </camera>
-        <pose>0.024083 -0.058382 0.376328 3.1415926535897931 -1.5707963267948966 0.945143</pose>
+        <pose>0.024083 -0.058382 0.376328 -2.19645 -1.5707963267948966 0</pose>
       </sensor>
       <sensor name="camera" type="rgbd_camera">
         <camera name="camera_camera">

--- a/submitted_models/ctu_cras_norlab_absolem_sensor_config_1/model.sdf
+++ b/submitted_models/ctu_cras_norlab_absolem_sensor_config_1/model.sdf
@@ -1215,6 +1215,22 @@
         </geometry>
       </visual>
     </link>
+    <joint name="front_left_flipper_wheel1_j" type="revolute">
+      <pose relative_to="front_left_flipper">0 0 0 0 -0 0</pose>
+      <parent>front_left_flipper</parent>
+      <child>front_left_flipper_wheel1</child>
+      <axis>
+        <xyz>0 1 0</xyz>
+        <limit>
+          <lower>-1e+16</lower>
+          <upper>1e+16</upper>
+        </limit>
+        <dynamics>
+          <spring_reference>0</spring_reference>
+          <spring_stiffness>0</spring_stiffness>
+        </dynamics>
+      </axis>
+    </joint>
     <link name="front_left_flipper_wheel1">
       <pose relative_to="front_left_flipper_wheel1_j">0 0 0 0 -0 0</pose>
       <inertial>
@@ -1256,22 +1272,6 @@
         </surface>
       </collision>
     </link>
-    <joint name="front_left_flipper_wheel1_j" type="revolute">
-      <pose relative_to="front_left_flipper">0 0 0 0 -0 0</pose>
-      <parent>front_left_flipper</parent>
-      <child>front_left_flipper_wheel1</child>
-      <axis>
-        <xyz>0 1 0</xyz>
-        <limit>
-          <lower>-1e+16</lower>
-          <upper>1e+16</upper>
-        </limit>
-        <dynamics>
-          <spring_reference>0</spring_reference>
-          <spring_stiffness>0</spring_stiffness>
-        </dynamics>
-      </axis>
-    </joint>
     <link name="front_left_flipper_wheel2">
       <pose relative_to="front_left_flipper_wheel2_j">0 0 0 0 -0 0</pose>
       <inertial>

--- a/submitted_models/ctu_cras_norlab_absolem_sensor_config_1/model.sdf
+++ b/submitted_models/ctu_cras_norlab_absolem_sensor_config_1/model.sdf
@@ -3194,6 +3194,22 @@
         </surface>
       </collision>
     </link>
+    <joint name="right_track_wheel3_j" type="revolute">
+      <pose relative_to="right_track">0.107143 0 0.01855 0 -0 0</pose>
+      <parent>right_track</parent>
+      <child>right_track_wheel3</child>
+      <axis>
+        <xyz>0 1 0</xyz>
+        <limit>
+          <lower>-1e+16</lower>
+          <upper>1e+16</upper>
+        </limit>
+        <dynamics>
+          <spring_reference>0</spring_reference>
+          <spring_stiffness>0</spring_stiffness>
+        </dynamics>
+      </axis>
+    </joint>
     <link name="right_track_wheel3">
       <pose relative_to="right_track_wheel3_j">0 0 0 0 -0 0</pose>
       <inertial>
@@ -3235,22 +3251,6 @@
         </surface>
       </collision>
     </link>
-    <joint name="right_track_wheel3_j" type="revolute">
-      <pose relative_to="right_track">0.107143 0 0.01855 0 -0 0</pose>
-      <parent>right_track</parent>
-      <child>right_track_wheel3</child>
-      <axis>
-        <xyz>0 1 0</xyz>
-        <limit>
-          <lower>-1e+16</lower>
-          <upper>1e+16</upper>
-        </limit>
-        <dynamics>
-          <spring_reference>0</spring_reference>
-          <spring_stiffness>0</spring_stiffness>
-        </dynamics>
-      </axis>
-    </joint>
     <link name="right_track_wheel4">
       <pose relative_to="right_track_wheel4_j">0 0 0 0 -0 0</pose>
       <inertial>

--- a/submitted_models/ctu_cras_norlab_absolem_sensor_config_1/model.sdf
+++ b/submitted_models/ctu_cras_norlab_absolem_sensor_config_1/model.sdf
@@ -1078,6 +1078,39 @@
         </lidar>
       </sensor>
     </link>
+    <joint name="left_track_j" type="revolute">
+      <pose relative_to="base_link">0 0.1985 0 0 -0 0</pose>
+      <parent>base_link</parent>
+      <child>left_track</child>
+      <axis>
+        <xyz>0 1 0</xyz>
+        <limit>
+          <lower>0</lower>
+          <upper>0</upper>
+          <effort>0</effort>
+          <velocity>4</velocity>
+        </limit>
+        <dynamics>
+          <spring_reference>0</spring_reference>
+          <spring_stiffness>0</spring_stiffness>
+        </dynamics>
+      </axis>
+      <physics>
+        <ode>
+          <limit>
+            <cfm>0</cfm>
+            <erp>0.2</erp>
+          </limit>
+        </ode>
+      </physics>
+      <physics>
+        <ode>
+          <implicit_spring_damper>1</implicit_spring_damper>
+          <cfm>0</cfm>
+          <erp>0.95</erp>
+        </ode>
+      </physics>
+    </joint>
     <link name="left_track">
       <pose relative_to="left_track_j">0 0 0 0 -0 0</pose>
       <inertial>
@@ -1116,39 +1149,6 @@
         </geometry>
       </visual>
     </link>
-    <joint name="left_track_j" type="revolute">
-      <pose relative_to="base_link">0 0.1985 0 0 -0 0</pose>
-      <parent>base_link</parent>
-      <child>left_track</child>
-      <axis>
-        <xyz>0 1 0</xyz>
-        <limit>
-          <lower>0</lower>
-          <upper>0</upper>
-          <effort>0</effort>
-          <velocity>4</velocity>
-        </limit>
-        <dynamics>
-          <spring_reference>0</spring_reference>
-          <spring_stiffness>0</spring_stiffness>
-        </dynamics>
-      </axis>
-      <physics>
-        <ode>
-          <limit>
-            <cfm>0</cfm>
-            <erp>0.2</erp>
-          </limit>
-        </ode>
-      </physics>
-      <physics>
-        <ode>
-          <implicit_spring_damper>1</implicit_spring_damper>
-          <cfm>0</cfm>
-          <erp>0.95</erp>
-        </ode>
-      </physics>
-    </joint>
     <link name="front_left_flipper">
       <pose relative_to="front_left_flipper_j">0 0 0 0 -0 0</pose>
       <inertial>

--- a/submitted_models/ctu_cras_norlab_absolem_sensor_config_1/model.sdf
+++ b/submitted_models/ctu_cras_norlab_absolem_sensor_config_1/model.sdf
@@ -2079,6 +2079,22 @@
         </surface>
       </collision>
     </link>
+    <joint name="rear_left_flipper_wheel2_j" type="revolute">
+      <pose relative_to="rear_left_flipper">0.0825 0 0 0 -0 0</pose>
+      <parent>rear_left_flipper</parent>
+      <child>rear_left_flipper_wheel2</child>
+      <axis>
+        <xyz>0 1 0</xyz>
+        <limit>
+          <lower>-1e+16</lower>
+          <upper>1e+16</upper>
+        </limit>
+        <dynamics>
+          <spring_reference>0</spring_reference>
+          <spring_stiffness>0</spring_stiffness>
+        </dynamics>
+      </axis>
+    </joint>
     <link name="rear_left_flipper_wheel2">
       <pose relative_to="rear_left_flipper_wheel2_j">0 0 0 0 -0 0</pose>
       <inertial>
@@ -2120,22 +2136,6 @@
         </surface>
       </collision>
     </link>
-    <joint name="rear_left_flipper_wheel2_j" type="revolute">
-      <pose relative_to="rear_left_flipper">0.0825 0 0 0 -0 0</pose>
-      <parent>rear_left_flipper</parent>
-      <child>rear_left_flipper_wheel2</child>
-      <axis>
-        <xyz>0 1 0</xyz>
-        <limit>
-          <lower>-1e+16</lower>
-          <upper>1e+16</upper>
-        </limit>
-        <dynamics>
-          <spring_reference>0</spring_reference>
-          <spring_stiffness>0</spring_stiffness>
-        </dynamics>
-      </axis>
-    </joint>
     <link name="rear_left_flipper_wheel3">
       <pose relative_to="rear_left_flipper_wheel3_j">0 0 0 0 -0 0</pose>
       <inertial>

--- a/submitted_models/ctu_cras_norlab_absolem_sensor_config_1/model.sdf
+++ b/submitted_models/ctu_cras_norlab_absolem_sensor_config_1/model.sdf
@@ -3479,6 +3479,22 @@
         </surface>
       </collision>
     </link>
+    <joint name="right_track_wheel8_j" type="revolute">
+      <pose relative_to="right_track">-0.25 0 0.01855 0 -0 0</pose>
+      <parent>right_track</parent>
+      <child>right_track_wheel8</child>
+      <axis>
+        <xyz>0 1 0</xyz>
+        <limit>
+          <lower>-1e+16</lower>
+          <upper>1e+16</upper>
+        </limit>
+        <dynamics>
+          <spring_reference>0</spring_reference>
+          <spring_stiffness>0</spring_stiffness>
+        </dynamics>
+      </axis>
+    </joint>
     <link name="right_track_wheel8">
       <pose relative_to="right_track_wheel8_j">0 0 0 0 -0 0</pose>
       <inertial>
@@ -3520,22 +3536,6 @@
         </surface>
       </collision>
     </link>
-    <joint name="right_track_wheel8_j" type="revolute">
-      <pose relative_to="right_track">-0.25 0 0.01855 0 -0 0</pose>
-      <parent>right_track</parent>
-      <child>right_track_wheel8</child>
-      <axis>
-        <xyz>0 1 0</xyz>
-        <limit>
-          <lower>-1e+16</lower>
-          <upper>1e+16</upper>
-        </limit>
-        <dynamics>
-          <spring_reference>0</spring_reference>
-          <spring_stiffness>0</spring_stiffness>
-        </dynamics>
-      </axis>
-    </joint>
     <plugin name="cras::FlipperControlPlugin" filename="libflipper_control_plugin.so">
       <joint_name>front_left_flipper_j</joint_name>
       <max_velocity>0.8</max_velocity>

--- a/submitted_models/ctu_cras_norlab_absolem_sensor_config_1/model.sdf
+++ b/submitted_models/ctu_cras_norlab_absolem_sensor_config_1/model.sdf
@@ -1671,6 +1671,22 @@
         </surface>
       </collision>
     </link>
+    <joint name="left_track_wheel4_j" type="revolute">
+      <pose relative_to="left_track">0.035714 0 0.01855 0 -0 0</pose>
+      <parent>left_track</parent>
+      <child>left_track_wheel4</child>
+      <axis>
+        <xyz>0 1 0</xyz>
+        <limit>
+          <lower>-1e+16</lower>
+          <upper>1e+16</upper>
+        </limit>
+        <dynamics>
+          <spring_reference>0</spring_reference>
+          <spring_stiffness>0</spring_stiffness>
+        </dynamics>
+      </axis>
+    </joint>
     <link name="left_track_wheel4">
       <pose relative_to="left_track_wheel4_j">0 0 0 0 -0 0</pose>
       <inertial>
@@ -1712,22 +1728,6 @@
         </surface>
       </collision>
     </link>
-    <joint name="left_track_wheel4_j" type="revolute">
-      <pose relative_to="left_track">0.035714 0 0.01855 0 -0 0</pose>
-      <parent>left_track</parent>
-      <child>left_track_wheel4</child>
-      <axis>
-        <xyz>0 1 0</xyz>
-        <limit>
-          <lower>-1e+16</lower>
-          <upper>1e+16</upper>
-        </limit>
-        <dynamics>
-          <spring_reference>0</spring_reference>
-          <spring_stiffness>0</spring_stiffness>
-        </dynamics>
-      </axis>
-    </joint>
     <link name="left_track_wheel5">
       <pose relative_to="left_track_wheel5_j">0 0 0 0 -0 0</pose>
       <inertial>

--- a/submitted_models/ctu_cras_norlab_absolem_sensor_config_1/model.sdf
+++ b/submitted_models/ctu_cras_norlab_absolem_sensor_config_1/model.sdf
@@ -2558,6 +2558,22 @@
         </surface>
       </collision>
     </link>
+    <joint name="front_right_flipper_wheel3_j" type="revolute">
+      <pose relative_to="front_right_flipper">-0.165 0 0 0 -0 0</pose>
+      <parent>front_right_flipper</parent>
+      <child>front_right_flipper_wheel3</child>
+      <axis>
+        <xyz>0 1 0</xyz>
+        <limit>
+          <lower>-1e+16</lower>
+          <upper>1e+16</upper>
+        </limit>
+        <dynamics>
+          <spring_reference>0</spring_reference>
+          <spring_stiffness>0</spring_stiffness>
+        </dynamics>
+      </axis>
+    </joint>
     <link name="front_right_flipper_wheel3">
       <pose relative_to="front_right_flipper_wheel3_j">0 0 0 0 -0 0</pose>
       <inertial>
@@ -2599,22 +2615,6 @@
         </surface>
       </collision>
     </link>
-    <joint name="front_right_flipper_wheel3_j" type="revolute">
-      <pose relative_to="front_right_flipper">-0.165 0 0 0 -0 0</pose>
-      <parent>front_right_flipper</parent>
-      <child>front_right_flipper_wheel3</child>
-      <axis>
-        <xyz>0 1 0</xyz>
-        <limit>
-          <lower>-1e+16</lower>
-          <upper>1e+16</upper>
-        </limit>
-        <dynamics>
-          <spring_reference>0</spring_reference>
-          <spring_stiffness>0</spring_stiffness>
-        </dynamics>
-      </axis>
-    </joint>
     <link name="front_right_flipper_wheel4">
       <pose relative_to="front_right_flipper_wheel4_j">0 0 0 0 -0 0</pose>
       <inertial>

--- a/submitted_models/ctu_cras_norlab_absolem_sensor_config_1/model.sdf
+++ b/submitted_models/ctu_cras_norlab_absolem_sensor_config_1/model.sdf
@@ -2193,6 +2193,22 @@
         </surface>
       </collision>
     </link>
+    <joint name="rear_left_flipper_wheel4_j" type="revolute">
+      <pose relative_to="rear_left_flipper">0.2475 0 0 0 -0 0</pose>
+      <parent>rear_left_flipper</parent>
+      <child>rear_left_flipper_wheel4</child>
+      <axis>
+        <xyz>0 1 0</xyz>
+        <limit>
+          <lower>-1e+16</lower>
+          <upper>1e+16</upper>
+        </limit>
+        <dynamics>
+          <spring_reference>0</spring_reference>
+          <spring_stiffness>0</spring_stiffness>
+        </dynamics>
+      </axis>
+    </joint>
     <link name="rear_left_flipper_wheel4">
       <pose relative_to="rear_left_flipper_wheel4_j">0 0 0 0 -0 0</pose>
       <inertial>
@@ -2234,22 +2250,6 @@
         </surface>
       </collision>
     </link>
-    <joint name="rear_left_flipper_wheel4_j" type="revolute">
-      <pose relative_to="rear_left_flipper">0.2475 0 0 0 -0 0</pose>
-      <parent>rear_left_flipper</parent>
-      <child>rear_left_flipper_wheel4</child>
-      <axis>
-        <xyz>0 1 0</xyz>
-        <limit>
-          <lower>-1e+16</lower>
-          <upper>1e+16</upper>
-        </limit>
-        <dynamics>
-          <spring_reference>0</spring_reference>
-          <spring_stiffness>0</spring_stiffness>
-        </dynamics>
-      </axis>
-    </joint>
     <link name="rear_left_flipper_wheel5">
       <pose relative_to="rear_left_flipper_wheel5_j">0 0 0 0 -0 0</pose>
       <inertial>

--- a/submitted_models/ctu_cras_norlab_absolem_sensor_config_1/model.sdf
+++ b/submitted_models/ctu_cras_norlab_absolem_sensor_config_1/model.sdf
@@ -1842,6 +1842,22 @@
         </surface>
       </collision>
     </link>
+    <joint name="left_track_wheel7_j" type="revolute">
+      <pose relative_to="left_track">-0.178571 0 0.01855 0 -0 0</pose>
+      <parent>left_track</parent>
+      <child>left_track_wheel7</child>
+      <axis>
+        <xyz>0 1 0</xyz>
+        <limit>
+          <lower>-1e+16</lower>
+          <upper>1e+16</upper>
+        </limit>
+        <dynamics>
+          <spring_reference>0</spring_reference>
+          <spring_stiffness>0</spring_stiffness>
+        </dynamics>
+      </axis>
+    </joint>
     <link name="left_track_wheel7">
       <pose relative_to="left_track_wheel7_j">0 0 0 0 -0 0</pose>
       <inertial>
@@ -1883,22 +1899,6 @@
         </surface>
       </collision>
     </link>
-    <joint name="left_track_wheel7_j" type="revolute">
-      <pose relative_to="left_track">-0.178571 0 0.01855 0 -0 0</pose>
-      <parent>left_track</parent>
-      <child>left_track_wheel7</child>
-      <axis>
-        <xyz>0 1 0</xyz>
-        <limit>
-          <lower>-1e+16</lower>
-          <upper>1e+16</upper>
-        </limit>
-        <dynamics>
-          <spring_reference>0</spring_reference>
-          <spring_stiffness>0</spring_stiffness>
-        </dynamics>
-      </axis>
-    </joint>
     <link name="left_track_wheel8">
       <pose relative_to="left_track_wheel8_j">0 0 0 0 -0 0</pose>
       <inertial>

--- a/submitted_models/ctu_cras_norlab_absolem_sensor_config_1/model.sdf
+++ b/submitted_models/ctu_cras_norlab_absolem_sensor_config_1/model.sdf
@@ -1614,6 +1614,22 @@
         </surface>
       </collision>
     </link>
+    <joint name="left_track_wheel3_j" type="revolute">
+      <pose relative_to="left_track">0.107143 0 0.01855 0 -0 0</pose>
+      <parent>left_track</parent>
+      <child>left_track_wheel3</child>
+      <axis>
+        <xyz>0 1 0</xyz>
+        <limit>
+          <lower>-1e+16</lower>
+          <upper>1e+16</upper>
+        </limit>
+        <dynamics>
+          <spring_reference>0</spring_reference>
+          <spring_stiffness>0</spring_stiffness>
+        </dynamics>
+      </axis>
+    </joint>
     <link name="left_track_wheel3">
       <pose relative_to="left_track_wheel3_j">0 0 0 0 -0 0</pose>
       <inertial>
@@ -1655,22 +1671,6 @@
         </surface>
       </collision>
     </link>
-    <joint name="left_track_wheel3_j" type="revolute">
-      <pose relative_to="left_track">0.107143 0 0.01855 0 -0 0</pose>
-      <parent>left_track</parent>
-      <child>left_track_wheel3</child>
-      <axis>
-        <xyz>0 1 0</xyz>
-        <limit>
-          <lower>-1e+16</lower>
-          <upper>1e+16</upper>
-        </limit>
-        <dynamics>
-          <spring_reference>0</spring_reference>
-          <spring_stiffness>0</spring_stiffness>
-        </dynamics>
-      </axis>
-    </joint>
     <link name="left_track_wheel4">
       <pose relative_to="left_track_wheel4_j">0 0 0 0 -0 0</pose>
       <inertial>

--- a/submitted_models/ctu_cras_norlab_absolem_sensor_config_1/model.sdf
+++ b/submitted_models/ctu_cras_norlab_absolem_sensor_config_1/model.sdf
@@ -2250,6 +2250,22 @@
         </surface>
       </collision>
     </link>
+    <joint name="rear_left_flipper_wheel5_j" type="revolute">
+      <pose relative_to="rear_left_flipper">0.33 0 0 0 -0 0</pose>
+      <parent>rear_left_flipper</parent>
+      <child>rear_left_flipper_wheel5</child>
+      <axis>
+        <xyz>0 1 0</xyz>
+        <limit>
+          <lower>-1e+16</lower>
+          <upper>1e+16</upper>
+        </limit>
+        <dynamics>
+          <spring_reference>0</spring_reference>
+          <spring_stiffness>0</spring_stiffness>
+        </dynamics>
+      </axis>
+    </joint>
     <link name="rear_left_flipper_wheel5">
       <pose relative_to="rear_left_flipper_wheel5_j">0 0 0 0 -0 0</pose>
       <inertial>
@@ -2291,22 +2307,6 @@
         </surface>
       </collision>
     </link>
-    <joint name="rear_left_flipper_wheel5_j" type="revolute">
-      <pose relative_to="rear_left_flipper">0.33 0 0 0 -0 0</pose>
-      <parent>rear_left_flipper</parent>
-      <child>rear_left_flipper_wheel5</child>
-      <axis>
-        <xyz>0 1 0</xyz>
-        <limit>
-          <lower>-1e+16</lower>
-          <upper>1e+16</upper>
-        </limit>
-        <dynamics>
-          <spring_reference>0</spring_reference>
-          <spring_stiffness>0</spring_stiffness>
-        </dynamics>
-      </axis>
-    </joint>
     <link name="right_track">
       <pose relative_to="right_track_j">0 0 0 0 -0 0</pose>
       <inertial>

--- a/submitted_models/ctu_cras_norlab_absolem_sensor_config_1/model.sdf
+++ b/submitted_models/ctu_cras_norlab_absolem_sensor_config_1/model.sdf
@@ -1443,6 +1443,22 @@
         </surface>
       </collision>
     </link>
+    <joint name="front_left_flipper_wheel5_j" type="revolute">
+      <pose relative_to="front_left_flipper">0.33 0 0 0 -0 0</pose>
+      <parent>front_left_flipper</parent>
+      <child>front_left_flipper_wheel5</child>
+      <axis>
+        <xyz>0 1 0</xyz>
+        <limit>
+          <lower>-1e+16</lower>
+          <upper>1e+16</upper>
+        </limit>
+        <dynamics>
+          <spring_reference>0</spring_reference>
+          <spring_stiffness>0</spring_stiffness>
+        </dynamics>
+      </axis>
+    </joint>
     <link name="front_left_flipper_wheel5">
       <pose relative_to="front_left_flipper_wheel5_j">0 0 0 0 -0 0</pose>
       <inertial>
@@ -1484,22 +1500,6 @@
         </surface>
       </collision>
     </link>
-    <joint name="front_left_flipper_wheel5_j" type="revolute">
-      <pose relative_to="front_left_flipper">0.33 0 0 0 -0 0</pose>
-      <parent>front_left_flipper</parent>
-      <child>front_left_flipper_wheel5</child>
-      <axis>
-        <xyz>0 1 0</xyz>
-        <limit>
-          <lower>-1e+16</lower>
-          <upper>1e+16</upper>
-        </limit>
-        <dynamics>
-          <spring_reference>0</spring_reference>
-          <spring_stiffness>0</spring_stiffness>
-        </dynamics>
-      </axis>
-    </joint>
     <link name="left_track_wheel1">
       <pose relative_to="left_track_wheel1_j">0 0 0 0 -0 0</pose>
       <inertial>

--- a/submitted_models/ctu_cras_norlab_absolem_sensor_config_1/model.sdf
+++ b/submitted_models/ctu_cras_norlab_absolem_sensor_config_1/model.sdf
@@ -2729,6 +2729,34 @@
         </surface>
       </collision>
     </link>
+    <joint name="rear_right_flipper_j" type="revolute">
+      <pose relative_to="right_track">-0.25 -0.0735 0.0195 0 -0.193732 0</pose>
+      <parent>right_track</parent>
+      <child>rear_right_flipper</child>
+      <axis>
+        <xyz>0 1 0</xyz>
+        <limit>
+          <lower>-1e+16</lower>
+          <upper>1e+16</upper>
+          <effort>20</effort>
+          <velocity>0.785398</velocity>
+        </limit>
+        <dynamics>
+          <spring_reference>0</spring_reference>
+          <spring_stiffness>0</spring_stiffness>
+        </dynamics>
+      </axis>
+      <physics>
+        <ode>
+          <implicit_spring_damper>1</implicit_spring_damper>
+          <cfm_damping>1</cfm_damping>
+          <limit>
+            <cfm>0</cfm>
+            <erp>0.2</erp>
+          </limit>
+        </ode>
+      </physics>
+    </joint>
     <link name="rear_right_flipper">
       <pose relative_to="rear_right_flipper_j">0 0 0 0 -0 0</pose>
       <inertial>
@@ -2767,34 +2795,6 @@
         </geometry>
       </visual>
     </link>
-    <joint name="rear_right_flipper_j" type="revolute">
-      <pose relative_to="right_track">-0.25 -0.0735 0.0195 0 -0.193732 0</pose>
-      <parent>right_track</parent>
-      <child>rear_right_flipper</child>
-      <axis>
-        <xyz>0 1 0</xyz>
-        <limit>
-          <lower>-1e+16</lower>
-          <upper>1e+16</upper>
-          <effort>20</effort>
-          <velocity>0.785398</velocity>
-        </limit>
-        <dynamics>
-          <spring_reference>0</spring_reference>
-          <spring_stiffness>0</spring_stiffness>
-        </dynamics>
-      </axis>
-      <physics>
-        <ode>
-          <implicit_spring_damper>1</implicit_spring_damper>
-          <cfm_damping>1</cfm_damping>
-          <limit>
-            <cfm>0</cfm>
-            <erp>0.2</erp>
-          </limit>
-        </ode>
-      </physics>
-    </joint>
     <link name="rear_right_flipper_wheel1">
       <pose relative_to="rear_right_flipper_wheel1_j">0 0 0 0 -0 0</pose>
       <inertial>

--- a/submitted_models/ctu_cras_norlab_absolem_sensor_config_1/model.sdf
+++ b/submitted_models/ctu_cras_norlab_absolem_sensor_config_1/model.sdf
@@ -1785,6 +1785,22 @@
         </surface>
       </collision>
     </link>
+    <joint name="left_track_wheel6_j" type="revolute">
+      <pose relative_to="left_track">-0.107143 0 0.01855 0 -0 0</pose>
+      <parent>left_track</parent>
+      <child>left_track_wheel6</child>
+      <axis>
+        <xyz>0 1 0</xyz>
+        <limit>
+          <lower>-1e+16</lower>
+          <upper>1e+16</upper>
+        </limit>
+        <dynamics>
+          <spring_reference>0</spring_reference>
+          <spring_stiffness>0</spring_stiffness>
+        </dynamics>
+      </axis>
+    </joint>
     <link name="left_track_wheel6">
       <pose relative_to="left_track_wheel6_j">0 0 0 0 -0 0</pose>
       <inertial>
@@ -1826,22 +1842,6 @@
         </surface>
       </collision>
     </link>
-    <joint name="left_track_wheel6_j" type="revolute">
-      <pose relative_to="left_track">-0.107143 0 0.01855 0 -0 0</pose>
-      <parent>left_track</parent>
-      <child>left_track_wheel6</child>
-      <axis>
-        <xyz>0 1 0</xyz>
-        <limit>
-          <lower>-1e+16</lower>
-          <upper>1e+16</upper>
-        </limit>
-        <dynamics>
-          <spring_reference>0</spring_reference>
-          <spring_stiffness>0</spring_stiffness>
-        </dynamics>
-      </axis>
-    </joint>
     <link name="left_track_wheel7">
       <pose relative_to="left_track_wheel7_j">0 0 0 0 -0 0</pose>
       <inertial>

--- a/submitted_models/ctu_cras_norlab_absolem_sensor_config_1/model.sdf
+++ b/submitted_models/ctu_cras_norlab_absolem_sensor_config_1/model.sdf
@@ -1500,6 +1500,22 @@
         </surface>
       </collision>
     </link>
+    <joint name="left_track_wheel1_j" type="revolute">
+      <pose relative_to="left_track">0.25 0 0.01855 0 -0 0</pose>
+      <parent>left_track</parent>
+      <child>left_track_wheel1</child>
+      <axis>
+        <xyz>0 1 0</xyz>
+        <limit>
+          <lower>-1e+16</lower>
+          <upper>1e+16</upper>
+        </limit>
+        <dynamics>
+          <spring_reference>0</spring_reference>
+          <spring_stiffness>0</spring_stiffness>
+        </dynamics>
+      </axis>
+    </joint>
     <link name="left_track_wheel1">
       <pose relative_to="left_track_wheel1_j">0 0 0 0 -0 0</pose>
       <inertial>
@@ -1541,22 +1557,6 @@
         </surface>
       </collision>
     </link>
-    <joint name="left_track_wheel1_j" type="revolute">
-      <pose relative_to="left_track">0.25 0 0.01855 0 -0 0</pose>
-      <parent>left_track</parent>
-      <child>left_track_wheel1</child>
-      <axis>
-        <xyz>0 1 0</xyz>
-        <limit>
-          <lower>-1e+16</lower>
-          <upper>1e+16</upper>
-        </limit>
-        <dynamics>
-          <spring_reference>0</spring_reference>
-          <spring_stiffness>0</spring_stiffness>
-        </dynamics>
-      </axis>
-    </joint>
     <link name="left_track_wheel2">
       <pose relative_to="left_track_wheel2_j">0 0 0 0 -0 0</pose>
       <inertial>

--- a/submitted_models/ctu_cras_norlab_absolem_sensor_config_1/model.sdf
+++ b/submitted_models/ctu_cras_norlab_absolem_sensor_config_1/model.sdf
@@ -1386,6 +1386,22 @@
         </surface>
       </collision>
     </link>
+    <joint name="front_left_flipper_wheel4_j" type="revolute">
+      <pose relative_to="front_left_flipper">0.2475 0 0 0 -0 0</pose>
+      <parent>front_left_flipper</parent>
+      <child>front_left_flipper_wheel4</child>
+      <axis>
+        <xyz>0 1 0</xyz>
+        <limit>
+          <lower>-1e+16</lower>
+          <upper>1e+16</upper>
+        </limit>
+        <dynamics>
+          <spring_reference>0</spring_reference>
+          <spring_stiffness>0</spring_stiffness>
+        </dynamics>
+      </axis>
+    </joint>
     <link name="front_left_flipper_wheel4">
       <pose relative_to="front_left_flipper_wheel4_j">0 0 0 0 -0 0</pose>
       <inertial>
@@ -1427,22 +1443,6 @@
         </surface>
       </collision>
     </link>
-    <joint name="front_left_flipper_wheel4_j" type="revolute">
-      <pose relative_to="front_left_flipper">0.2475 0 0 0 -0 0</pose>
-      <parent>front_left_flipper</parent>
-      <child>front_left_flipper_wheel4</child>
-      <axis>
-        <xyz>0 1 0</xyz>
-        <limit>
-          <lower>-1e+16</lower>
-          <upper>1e+16</upper>
-        </limit>
-        <dynamics>
-          <spring_reference>0</spring_reference>
-          <spring_stiffness>0</spring_stiffness>
-        </dynamics>
-      </axis>
-    </joint>
     <link name="front_left_flipper_wheel5">
       <pose relative_to="front_left_flipper_wheel5_j">0 0 0 0 -0 0</pose>
       <inertial>

--- a/submitted_models/ctu_cras_norlab_absolem_sensor_config_1/model.sdf
+++ b/submitted_models/ctu_cras_norlab_absolem_sensor_config_1/model.sdf
@@ -3080,6 +3080,22 @@
         </surface>
       </collision>
     </link>
+    <joint name="right_track_wheel1_j" type="revolute">
+      <pose relative_to="right_track">0.25 0 0.01855 0 -0 0</pose>
+      <parent>right_track</parent>
+      <child>right_track_wheel1</child>
+      <axis>
+        <xyz>0 1 0</xyz>
+        <limit>
+          <lower>-1e+16</lower>
+          <upper>1e+16</upper>
+        </limit>
+        <dynamics>
+          <spring_reference>0</spring_reference>
+          <spring_stiffness>0</spring_stiffness>
+        </dynamics>
+      </axis>
+    </joint>
     <link name="right_track_wheel1">
       <pose relative_to="right_track_wheel1_j">0 0 0 0 -0 0</pose>
       <inertial>
@@ -3121,22 +3137,6 @@
         </surface>
       </collision>
     </link>
-    <joint name="right_track_wheel1_j" type="revolute">
-      <pose relative_to="right_track">0.25 0 0.01855 0 -0 0</pose>
-      <parent>right_track</parent>
-      <child>right_track_wheel1</child>
-      <axis>
-        <xyz>0 1 0</xyz>
-        <limit>
-          <lower>-1e+16</lower>
-          <upper>1e+16</upper>
-        </limit>
-        <dynamics>
-          <spring_reference>0</spring_reference>
-          <spring_stiffness>0</spring_stiffness>
-        </dynamics>
-      </axis>
-    </joint>
     <link name="right_track_wheel2">
       <pose relative_to="right_track_wheel2_j">0 0 0 0 -0 0</pose>
       <inertial>

--- a/submitted_models/ctu_cras_norlab_absolem_sensor_config_1/model.sdf
+++ b/submitted_models/ctu_cras_norlab_absolem_sensor_config_1/model.sdf
@@ -3308,6 +3308,22 @@
         </surface>
       </collision>
     </link>
+    <joint name="right_track_wheel5_j" type="revolute">
+      <pose relative_to="right_track">-0.035714 0 0.01855 0 -0 0</pose>
+      <parent>right_track</parent>
+      <child>right_track_wheel5</child>
+      <axis>
+        <xyz>0 1 0</xyz>
+        <limit>
+          <lower>-1e+16</lower>
+          <upper>1e+16</upper>
+        </limit>
+        <dynamics>
+          <spring_reference>0</spring_reference>
+          <spring_stiffness>0</spring_stiffness>
+        </dynamics>
+      </axis>
+    </joint>
     <link name="right_track_wheel5">
       <pose relative_to="right_track_wheel5_j">0 0 0 0 -0 0</pose>
       <inertial>
@@ -3349,22 +3365,6 @@
         </surface>
       </collision>
     </link>
-    <joint name="right_track_wheel5_j" type="revolute">
-      <pose relative_to="right_track">-0.035714 0 0.01855 0 -0 0</pose>
-      <parent>right_track</parent>
-      <child>right_track_wheel5</child>
-      <axis>
-        <xyz>0 1 0</xyz>
-        <limit>
-          <lower>-1e+16</lower>
-          <upper>1e+16</upper>
-        </limit>
-        <dynamics>
-          <spring_reference>0</spring_reference>
-          <spring_stiffness>0</spring_stiffness>
-        </dynamics>
-      </axis>
-    </joint>
     <link name="right_track_wheel6">
       <pose relative_to="right_track_wheel6_j">0 0 0 0 -0 0</pose>
       <inertial>

--- a/submitted_models/ctu_cras_norlab_absolem_sensor_config_1/model.sdf
+++ b/submitted_models/ctu_cras_norlab_absolem_sensor_config_1/model.sdf
@@ -1557,6 +1557,22 @@
         </surface>
       </collision>
     </link>
+    <joint name="left_track_wheel2_j" type="revolute">
+      <pose relative_to="left_track">0.178571 0 0.01855 0 -0 0</pose>
+      <parent>left_track</parent>
+      <child>left_track_wheel2</child>
+      <axis>
+        <xyz>0 1 0</xyz>
+        <limit>
+          <lower>-1e+16</lower>
+          <upper>1e+16</upper>
+        </limit>
+        <dynamics>
+          <spring_reference>0</spring_reference>
+          <spring_stiffness>0</spring_stiffness>
+        </dynamics>
+      </axis>
+    </joint>
     <link name="left_track_wheel2">
       <pose relative_to="left_track_wheel2_j">0 0 0 0 -0 0</pose>
       <inertial>
@@ -1598,22 +1614,6 @@
         </surface>
       </collision>
     </link>
-    <joint name="left_track_wheel2_j" type="revolute">
-      <pose relative_to="left_track">0.178571 0 0.01855 0 -0 0</pose>
-      <parent>left_track</parent>
-      <child>left_track_wheel2</child>
-      <axis>
-        <xyz>0 1 0</xyz>
-        <limit>
-          <lower>-1e+16</lower>
-          <upper>1e+16</upper>
-        </limit>
-        <dynamics>
-          <spring_reference>0</spring_reference>
-          <spring_stiffness>0</spring_stiffness>
-        </dynamics>
-      </axis>
-    </joint>
     <link name="left_track_wheel3">
       <pose relative_to="left_track_wheel3_j">0 0 0 0 -0 0</pose>
       <inertial>

--- a/submitted_models/ctu_cras_norlab_absolem_sensor_config_1/model.sdf
+++ b/submitted_models/ctu_cras_norlab_absolem_sensor_config_1/model.sdf
@@ -995,6 +995,34 @@
         <pose>0.13592 -0.016338 0.419596 0.015 0.499467 -0.000319</pose>
       </sensor>
     </link>
+    <joint name="laser_j" type="revolute">
+      <pose relative_to="base_link">0.2502 0 0.1407 -3.1415926535897931 0 0</pose>
+      <child>laser</child>
+      <parent>base_link</parent>
+      <axis>
+        <xyz>1 0 0</xyz>
+        <limit>
+          <lower>-2.35619</lower>
+          <upper>2.35619</upper>
+          <effort>10</effort>
+          <velocity>1.2</velocity>
+        </limit>
+        <dynamics>
+          <spring_reference>0</spring_reference>
+          <spring_stiffness>0</spring_stiffness>
+        </dynamics>
+      </axis>
+      <physics>
+        <ode>
+          <implicit_spring_damper>1</implicit_spring_damper>
+          <cfm_damping>1</cfm_damping>
+          <limit>
+            <cfm>0</cfm>
+            <erp>0.2</erp>
+          </limit>
+        </ode>
+      </physics>
+    </joint>
     <link name="laser">
       <pose relative_to="laser_j">0 0 0 0 -0 0</pose>
       <inertial>
@@ -1050,34 +1078,6 @@
         </lidar>
       </sensor>
     </link>
-    <joint name="laser_j" type="revolute">
-      <pose relative_to="base_link">0.2502 0 0.1407 -3.1415926535897931 0 0</pose>
-      <child>laser</child>
-      <parent>base_link</parent>
-      <axis>
-        <xyz>1 0 0</xyz>
-        <limit>
-          <lower>-2.35619</lower>
-          <upper>2.35619</upper>
-          <effort>10</effort>
-          <velocity>1.2</velocity>
-        </limit>
-        <dynamics>
-          <spring_reference>0</spring_reference>
-          <spring_stiffness>0</spring_stiffness>
-        </dynamics>
-      </axis>
-      <physics>
-        <ode>
-          <implicit_spring_damper>1</implicit_spring_damper>
-          <cfm_damping>1</cfm_damping>
-          <limit>
-            <cfm>0</cfm>
-            <erp>0.2</erp>
-          </limit>
-        </ode>
-      </physics>
-    </joint>
     <link name="left_track">
       <pose relative_to="left_track_j">0 0 0 0 -0 0</pose>
       <inertial>

--- a/submitted_models/ctu_cras_norlab_absolem_sensor_config_1/model.sdf
+++ b/submitted_models/ctu_cras_norlab_absolem_sensor_config_1/model.sdf
@@ -1899,6 +1899,22 @@
         </surface>
       </collision>
     </link>
+    <joint name="left_track_wheel8_j" type="revolute">
+      <pose relative_to="left_track">-0.25 0 0.01855 0 -0 0</pose>
+      <parent>left_track</parent>
+      <child>left_track_wheel8</child>
+      <axis>
+        <xyz>0 1 0</xyz>
+        <limit>
+          <lower>-1e+16</lower>
+          <upper>1e+16</upper>
+        </limit>
+        <dynamics>
+          <spring_reference>0</spring_reference>
+          <spring_stiffness>0</spring_stiffness>
+        </dynamics>
+      </axis>
+    </joint>
     <link name="left_track_wheel8">
       <pose relative_to="left_track_wheel8_j">0 0 0 0 -0 0</pose>
       <inertial>
@@ -1940,22 +1956,6 @@
         </surface>
       </collision>
     </link>
-    <joint name="left_track_wheel8_j" type="revolute">
-      <pose relative_to="left_track">-0.25 0 0.01855 0 -0 0</pose>
-      <parent>left_track</parent>
-      <child>left_track_wheel8</child>
-      <axis>
-        <xyz>0 1 0</xyz>
-        <limit>
-          <lower>-1e+16</lower>
-          <upper>1e+16</upper>
-        </limit>
-        <dynamics>
-          <spring_reference>0</spring_reference>
-          <spring_stiffness>0</spring_stiffness>
-        </dynamics>
-      </axis>
-    </joint>
     <link name="rear_left_flipper">
       <pose relative_to="rear_left_flipper_j">0 0 0 0 -0 0</pose>
       <inertial>

--- a/submitted_models/ctu_cras_norlab_absolem_sensor_config_1/model.sdf
+++ b/submitted_models/ctu_cras_norlab_absolem_sensor_config_1/model.sdf
@@ -1728,6 +1728,22 @@
         </surface>
       </collision>
     </link>
+    <joint name="left_track_wheel5_j" type="revolute">
+      <pose relative_to="left_track">-0.035714 0 0.01855 0 -0 0</pose>
+      <parent>left_track</parent>
+      <child>left_track_wheel5</child>
+      <axis>
+        <xyz>0 1 0</xyz>
+        <limit>
+          <lower>-1e+16</lower>
+          <upper>1e+16</upper>
+        </limit>
+        <dynamics>
+          <spring_reference>0</spring_reference>
+          <spring_stiffness>0</spring_stiffness>
+        </dynamics>
+      </axis>
+    </joint>
     <link name="left_track_wheel5">
       <pose relative_to="left_track_wheel5_j">0 0 0 0 -0 0</pose>
       <inertial>
@@ -1769,22 +1785,6 @@
         </surface>
       </collision>
     </link>
-    <joint name="left_track_wheel5_j" type="revolute">
-      <pose relative_to="left_track">-0.035714 0 0.01855 0 -0 0</pose>
-      <parent>left_track</parent>
-      <child>left_track_wheel5</child>
-      <axis>
-        <xyz>0 1 0</xyz>
-        <limit>
-          <lower>-1e+16</lower>
-          <upper>1e+16</upper>
-        </limit>
-        <dynamics>
-          <spring_reference>0</spring_reference>
-          <spring_stiffness>0</spring_stiffness>
-        </dynamics>
-      </axis>
-    </joint>
     <link name="left_track_wheel6">
       <pose relative_to="left_track_wheel6_j">0 0 0 0 -0 0</pose>
       <inertial>

--- a/submitted_models/ctu_cras_norlab_absolem_sensor_config_1/model.sdf
+++ b/submitted_models/ctu_cras_norlab_absolem_sensor_config_1/model.sdf
@@ -2909,6 +2909,22 @@
         </surface>
       </collision>
     </link>
+    <joint name="rear_right_flipper_wheel3_j" type="revolute">
+      <pose relative_to="rear_right_flipper">-0.165 0 0 0 -0 0</pose>
+      <parent>rear_right_flipper</parent>
+      <child>rear_right_flipper_wheel3</child>
+      <axis>
+        <xyz>0 1 0</xyz>
+        <limit>
+          <lower>-1e+16</lower>
+          <upper>1e+16</upper>
+        </limit>
+        <dynamics>
+          <spring_reference>0</spring_reference>
+          <spring_stiffness>0</spring_stiffness>
+        </dynamics>
+      </axis>
+    </joint>
     <link name="rear_right_flipper_wheel3">
       <pose relative_to="rear_right_flipper_wheel3_j">0 0 0 0 -0 0</pose>
       <inertial>
@@ -2950,22 +2966,6 @@
         </surface>
       </collision>
     </link>
-    <joint name="rear_right_flipper_wheel3_j" type="revolute">
-      <pose relative_to="rear_right_flipper">-0.165 0 0 0 -0 0</pose>
-      <parent>rear_right_flipper</parent>
-      <child>rear_right_flipper_wheel3</child>
-      <axis>
-        <xyz>0 1 0</xyz>
-        <limit>
-          <lower>-1e+16</lower>
-          <upper>1e+16</upper>
-        </limit>
-        <dynamics>
-          <spring_reference>0</spring_reference>
-          <spring_stiffness>0</spring_stiffness>
-        </dynamics>
-      </axis>
-    </joint>
     <link name="rear_right_flipper_wheel4">
       <pose relative_to="rear_right_flipper_wheel4_j">0 0 0 0 -0 0</pose>
       <inertial>

--- a/submitted_models/ctu_cras_norlab_absolem_sensor_config_1/model.sdf
+++ b/submitted_models/ctu_cras_norlab_absolem_sensor_config_1/model.sdf
@@ -2378,6 +2378,34 @@
         </geometry>
       </visual>
     </link>
+    <joint name="front_right_flipper_j" type="revolute">
+      <pose relative_to="right_track">0.25 -0.0735 0.0195 3.1415926535897931 -0.193732 3.1415926535897931</pose>
+      <parent>right_track</parent>
+      <child>front_right_flipper</child>
+      <axis>
+        <xyz>0 1 0</xyz>
+        <limit>
+          <lower>-1e+16</lower>
+          <upper>1e+16</upper>
+          <effort>20</effort>
+          <velocity>0.785398</velocity>
+        </limit>
+        <dynamics>
+          <spring_reference>0</spring_reference>
+          <spring_stiffness>0</spring_stiffness>
+        </dynamics>
+      </axis>
+      <physics>
+        <ode>
+          <implicit_spring_damper>1</implicit_spring_damper>
+          <cfm_damping>1</cfm_damping>
+          <limit>
+            <cfm>0</cfm>
+            <erp>0.2</erp>
+          </limit>
+        </ode>
+      </physics>
+    </joint>
     <link name="front_right_flipper">
       <pose relative_to="front_right_flipper_j">0 0 0 0 -0 0</pose>
       <inertial>
@@ -2416,34 +2444,6 @@
         </geometry>
       </visual>
     </link>
-    <joint name="front_right_flipper_j" type="revolute">
-      <pose relative_to="right_track">0.25 -0.0735 0.0195 3.1415926535897931 -0.193732 3.1415926535897931</pose>
-      <parent>right_track</parent>
-      <child>front_right_flipper</child>
-      <axis>
-        <xyz>0 1 0</xyz>
-        <limit>
-          <lower>-1e+16</lower>
-          <upper>1e+16</upper>
-          <effort>20</effort>
-          <velocity>0.785398</velocity>
-        </limit>
-        <dynamics>
-          <spring_reference>0</spring_reference>
-          <spring_stiffness>0</spring_stiffness>
-        </dynamics>
-      </axis>
-      <physics>
-        <ode>
-          <implicit_spring_damper>1</implicit_spring_damper>
-          <cfm_damping>1</cfm_damping>
-          <limit>
-            <cfm>0</cfm>
-            <erp>0.2</erp>
-          </limit>
-        </ode>
-      </physics>
-    </joint>
     <link name="front_right_flipper_wheel1">
       <pose relative_to="front_right_flipper_wheel1_j">0 0 0 0 -0 0</pose>
       <inertial>

--- a/submitted_models/ctu_cras_norlab_absolem_sensor_config_1/model.sdf
+++ b/submitted_models/ctu_cras_norlab_absolem_sensor_config_1/model.sdf
@@ -2966,6 +2966,22 @@
         </surface>
       </collision>
     </link>
+    <joint name="rear_right_flipper_wheel4_j" type="revolute">
+      <pose relative_to="rear_right_flipper">-0.2475 0 0 0 -0 0</pose>
+      <parent>rear_right_flipper</parent>
+      <child>rear_right_flipper_wheel4</child>
+      <axis>
+        <xyz>0 1 0</xyz>
+        <limit>
+          <lower>-1e+16</lower>
+          <upper>1e+16</upper>
+        </limit>
+        <dynamics>
+          <spring_reference>0</spring_reference>
+          <spring_stiffness>0</spring_stiffness>
+        </dynamics>
+      </axis>
+    </joint>
     <link name="rear_right_flipper_wheel4">
       <pose relative_to="rear_right_flipper_wheel4_j">0 0 0 0 -0 0</pose>
       <inertial>
@@ -3007,22 +3023,6 @@
         </surface>
       </collision>
     </link>
-    <joint name="rear_right_flipper_wheel4_j" type="revolute">
-      <pose relative_to="rear_right_flipper">-0.2475 0 0 0 -0 0</pose>
-      <parent>rear_right_flipper</parent>
-      <child>rear_right_flipper_wheel4</child>
-      <axis>
-        <xyz>0 1 0</xyz>
-        <limit>
-          <lower>-1e+16</lower>
-          <upper>1e+16</upper>
-        </limit>
-        <dynamics>
-          <spring_reference>0</spring_reference>
-          <spring_stiffness>0</spring_stiffness>
-        </dynamics>
-      </axis>
-    </joint>
     <link name="rear_right_flipper_wheel5">
       <pose relative_to="rear_right_flipper_wheel5_j">0 0 0 0 -0 0</pose>
       <inertial>

--- a/submitted_models/ctu_cras_norlab_absolem_sensor_config_1/model.sdf
+++ b/submitted_models/ctu_cras_norlab_absolem_sensor_config_1/model.sdf
@@ -996,7 +996,7 @@
       </sensor>
     </link>
     <link name="laser">
-      <pose>0.2502 0 0.1407 -3.1415926535897931 -0 0</pose>
+      <pose relative_to="laser_j">0 0 0 0 -0 0</pose>
       <inertial>
         <pose>0 0 -0.04 0 -0 0</pose>
         <mass>1.1</mass>
@@ -1051,6 +1051,7 @@
       </sensor>
     </link>
     <joint name="laser_j" type="revolute">
+      <pose relative_to="base_link">0.2502 0 0.1407 -3.1415926535897931 0 0</pose>
       <child>laser</child>
       <parent>base_link</parent>
       <axis>
@@ -1065,7 +1066,6 @@
           <spring_reference>0</spring_reference>
           <spring_stiffness>0</spring_stiffness>
         </dynamics>
-        <use_parent_model_frame>0</use_parent_model_frame>
       </axis>
       <physics>
         <ode>
@@ -1079,7 +1079,7 @@
       </physics>
     </joint>
     <link name="left_track">
-      <pose>0 0.1985 0 0 -0 0</pose>
+      <pose relative_to="left_track_j">0 0 0 0 -0 0</pose>
       <inertial>
         <mass>1e-05</mass>
         <inertia>
@@ -1117,6 +1117,7 @@
       </visual>
     </link>
     <joint name="left_track_j" type="revolute">
+      <pose relative_to="base_link">0 0.1985 0 0 -0 0</pose>
       <child>left_track</child>
       <parent>base_link</parent>
       <axis>
@@ -1131,7 +1132,6 @@
           <spring_reference>0</spring_reference>
           <spring_stiffness>0</spring_stiffness>
         </dynamics>
-        <use_parent_model_frame>0</use_parent_model_frame>
       </axis>
       <physics>
         <ode>
@@ -1150,7 +1150,7 @@
       </physics>
     </joint>
     <link name="front_left_flipper">
-      <pose>0.25 0.272 0.0195 0 0.193732 0</pose>
+      <pose relative_to="front_left_flipper_j">0 0 0 0 -0 0</pose>
       <inertial>
         <mass>1e-05</mass>
         <inertia>
@@ -1188,6 +1188,7 @@
       </visual>
     </link>
     <joint name="front_left_flipper_j" type="revolute">
+      <pose relative_to="left_track">0.25 0.0735 0.0195 0 0.193732 0</pose>
       <child>front_left_flipper</child>
       <parent>left_track</parent>
       <axis>
@@ -1202,7 +1203,6 @@
           <spring_reference>0</spring_reference>
           <spring_stiffness>0</spring_stiffness>
         </dynamics>
-        <use_parent_model_frame>0</use_parent_model_frame>
       </axis>
       <physics>
         <ode>
@@ -1216,7 +1216,7 @@
       </physics>
     </joint>
     <link name="front_left_flipper_wheel1">
-      <pose>0.25 0.272 0.0195 0 0.193732 0</pose>
+      <pose relative_to="front_left_flipper_wheel1_j">0 0 0 0 -0 0</pose>
       <inertial>
         <pose>0.08 0 0 0 -0 0</pose>
         <mass>0.15</mass>
@@ -1257,6 +1257,7 @@
       </collision>
     </link>
     <joint name="front_left_flipper_wheel1_j" type="revolute">
+      <pose relative_to="front_left_flipper">0 0 0 0 -0 0</pose>
       <child>front_left_flipper_wheel1</child>
       <parent>front_left_flipper</parent>
       <axis>
@@ -1269,11 +1270,10 @@
           <spring_reference>0</spring_reference>
           <spring_stiffness>0</spring_stiffness>
         </dynamics>
-        <use_parent_model_frame>0</use_parent_model_frame>
       </axis>
     </joint>
     <link name="front_left_flipper_wheel2">
-      <pose>0.330957 0.272 0.003617 0 0.193732 0</pose>
+      <pose relative_to="front_left_flipper_wheel2_j">0 0 0 0 -0 0</pose>
       <inertial>
         <pose>0.08 0 0 0 -0 0</pose>
         <mass>0.15</mass>
@@ -1314,6 +1314,7 @@
       </collision>
     </link>
     <joint name="front_left_flipper_wheel2_j" type="revolute">
+      <pose relative_to="front_left_flipper">0.0825 0 0 0 -0 0</pose>
       <child>front_left_flipper_wheel2</child>
       <parent>front_left_flipper</parent>
       <axis>
@@ -1326,11 +1327,10 @@
           <spring_reference>0</spring_reference>
           <spring_stiffness>0</spring_stiffness>
         </dynamics>
-        <use_parent_model_frame>0</use_parent_model_frame>
       </axis>
     </joint>
     <link name="front_left_flipper_wheel3">
-      <pose>0.411913 0.272 -0.012266 0 0.193732 0</pose>
+      <pose relative_to="front_left_flipper_wheel3_j">0 0 0 0 -0 0</pose>
       <inertial>
         <pose>0.08 0 0 0 -0 0</pose>
         <mass>0.15</mass>
@@ -1371,6 +1371,7 @@
       </collision>
     </link>
     <joint name="front_left_flipper_wheel3_j" type="revolute">
+      <pose relative_to="front_left_flipper">0.165 0 0 0 -0 0</pose>
       <child>front_left_flipper_wheel3</child>
       <parent>front_left_flipper</parent>
       <axis>
@@ -1383,11 +1384,10 @@
           <spring_reference>0</spring_reference>
           <spring_stiffness>0</spring_stiffness>
         </dynamics>
-        <use_parent_model_frame>0</use_parent_model_frame>
       </axis>
     </joint>
     <link name="front_left_flipper_wheel4">
-      <pose>0.49287 0.272 -0.028149 0 0.193732 0</pose>
+      <pose relative_to="front_left_flipper_wheel4_j">0 0 0 0 -0 0</pose>
       <inertial>
         <pose>0.08 0 0 0 -0 0</pose>
         <mass>0.15</mass>
@@ -1428,6 +1428,7 @@
       </collision>
     </link>
     <joint name="front_left_flipper_wheel4_j" type="revolute">
+      <pose relative_to="front_left_flipper">0.2475 0 0 0 -0 0</pose>
       <child>front_left_flipper_wheel4</child>
       <parent>front_left_flipper</parent>
       <axis>
@@ -1440,11 +1441,10 @@
           <spring_reference>0</spring_reference>
           <spring_stiffness>0</spring_stiffness>
         </dynamics>
-        <use_parent_model_frame>0</use_parent_model_frame>
       </axis>
     </joint>
     <link name="front_left_flipper_wheel5">
-      <pose>0.573827 0.272 -0.044032 0 0.193732 0</pose>
+      <pose relative_to="front_left_flipper_wheel5_j">0 0 0 0 -0 0</pose>
       <inertial>
         <pose>0.08 0 0 0 -0 0</pose>
         <mass>0.15</mass>
@@ -1485,6 +1485,7 @@
       </collision>
     </link>
     <joint name="front_left_flipper_wheel5_j" type="revolute">
+      <pose relative_to="front_left_flipper">0.33 0 0 0 -0 0</pose>
       <child>front_left_flipper_wheel5</child>
       <parent>front_left_flipper</parent>
       <axis>
@@ -1497,11 +1498,10 @@
           <spring_reference>0</spring_reference>
           <spring_stiffness>0</spring_stiffness>
         </dynamics>
-        <use_parent_model_frame>0</use_parent_model_frame>
       </axis>
     </joint>
     <link name="left_track_wheel1">
-      <pose>0.25 0.1985 0.01855 0 -0 0</pose>
+      <pose relative_to="left_track_wheel1_j">0 0 0 0 -0 0</pose>
       <inertial>
         <pose>0 0 0.0141 0 -0 0</pose>
         <mass>0.7575</mass>
@@ -1542,6 +1542,7 @@
       </collision>
     </link>
     <joint name="left_track_wheel1_j" type="revolute">
+      <pose relative_to="left_track">0.25 0 0.01855 0 -0 0</pose>
       <child>left_track_wheel1</child>
       <parent>left_track</parent>
       <axis>
@@ -1554,11 +1555,10 @@
           <spring_reference>0</spring_reference>
           <spring_stiffness>0</spring_stiffness>
         </dynamics>
-        <use_parent_model_frame>0</use_parent_model_frame>
       </axis>
     </joint>
     <link name="left_track_wheel2">
-      <pose>0.178571 0.1985 0.01855 0 -0 0</pose>
+      <pose relative_to="left_track_wheel2_j">0 0 0 0 -0 0</pose>
       <inertial>
         <pose>0 0 0.0141 0 -0 0</pose>
         <mass>0.7575</mass>
@@ -1599,6 +1599,7 @@
       </collision>
     </link>
     <joint name="left_track_wheel2_j" type="revolute">
+      <pose relative_to="left_track">0.178571 0 0.01855 0 -0 0</pose>
       <child>left_track_wheel2</child>
       <parent>left_track</parent>
       <axis>
@@ -1611,11 +1612,10 @@
           <spring_reference>0</spring_reference>
           <spring_stiffness>0</spring_stiffness>
         </dynamics>
-        <use_parent_model_frame>0</use_parent_model_frame>
       </axis>
     </joint>
     <link name="left_track_wheel3">
-      <pose>0.107143 0.1985 0.01855 0 -0 0</pose>
+      <pose relative_to="left_track_wheel3_j">0 0 0 0 -0 0</pose>
       <inertial>
         <pose>0 0 0.0141 0 -0 0</pose>
         <mass>0.7575</mass>
@@ -1656,6 +1656,7 @@
       </collision>
     </link>
     <joint name="left_track_wheel3_j" type="revolute">
+      <pose relative_to="left_track">0.107143 0 0.01855 0 -0 0</pose>
       <child>left_track_wheel3</child>
       <parent>left_track</parent>
       <axis>
@@ -1668,11 +1669,10 @@
           <spring_reference>0</spring_reference>
           <spring_stiffness>0</spring_stiffness>
         </dynamics>
-        <use_parent_model_frame>0</use_parent_model_frame>
       </axis>
     </joint>
     <link name="left_track_wheel4">
-      <pose>0.035714 0.1985 0.01855 0 -0 0</pose>
+      <pose relative_to="left_track_wheel4_j">0 0 0 0 -0 0</pose>
       <inertial>
         <pose>0 0 0.0141 0 -0 0</pose>
         <mass>0.7575</mass>
@@ -1713,6 +1713,7 @@
       </collision>
     </link>
     <joint name="left_track_wheel4_j" type="revolute">
+      <pose relative_to="left_track">0.035714 0 0.01855 0 -0 0</pose>
       <child>left_track_wheel4</child>
       <parent>left_track</parent>
       <axis>
@@ -1725,11 +1726,10 @@
           <spring_reference>0</spring_reference>
           <spring_stiffness>0</spring_stiffness>
         </dynamics>
-        <use_parent_model_frame>0</use_parent_model_frame>
       </axis>
     </joint>
     <link name="left_track_wheel5">
-      <pose>-0.035714 0.1985 0.01855 0 -0 0</pose>
+      <pose relative_to="left_track_wheel5_j">0 0 0 0 -0 0</pose>
       <inertial>
         <pose>0 0 0.0141 0 -0 0</pose>
         <mass>0.7575</mass>
@@ -1770,6 +1770,7 @@
       </collision>
     </link>
     <joint name="left_track_wheel5_j" type="revolute">
+      <pose relative_to="left_track">-0.035714 0 0.01855 0 -0 0</pose>
       <child>left_track_wheel5</child>
       <parent>left_track</parent>
       <axis>
@@ -1782,11 +1783,10 @@
           <spring_reference>0</spring_reference>
           <spring_stiffness>0</spring_stiffness>
         </dynamics>
-        <use_parent_model_frame>0</use_parent_model_frame>
       </axis>
     </joint>
     <link name="left_track_wheel6">
-      <pose>-0.107143 0.1985 0.01855 0 -0 0</pose>
+      <pose relative_to="left_track_wheel6_j">0 0 0 0 -0 0</pose>
       <inertial>
         <pose>0 0 0.0141 0 -0 0</pose>
         <mass>0.7575</mass>
@@ -1827,6 +1827,7 @@
       </collision>
     </link>
     <joint name="left_track_wheel6_j" type="revolute">
+      <pose relative_to="left_track">-0.107143 0 0.01855 0 -0 0</pose>
       <child>left_track_wheel6</child>
       <parent>left_track</parent>
       <axis>
@@ -1839,11 +1840,10 @@
           <spring_reference>0</spring_reference>
           <spring_stiffness>0</spring_stiffness>
         </dynamics>
-        <use_parent_model_frame>0</use_parent_model_frame>
       </axis>
     </joint>
     <link name="left_track_wheel7">
-      <pose>-0.178571 0.1985 0.01855 0 -0 0</pose>
+      <pose relative_to="left_track_wheel7_j">0 0 0 0 -0 0</pose>
       <inertial>
         <pose>0 0 0.0141 0 -0 0</pose>
         <mass>0.7575</mass>
@@ -1884,6 +1884,7 @@
       </collision>
     </link>
     <joint name="left_track_wheel7_j" type="revolute">
+      <pose relative_to="left_track">-0.178571 0 0.01855 0 -0 0</pose>
       <child>left_track_wheel7</child>
       <parent>left_track</parent>
       <axis>
@@ -1896,11 +1897,10 @@
           <spring_reference>0</spring_reference>
           <spring_stiffness>0</spring_stiffness>
         </dynamics>
-        <use_parent_model_frame>0</use_parent_model_frame>
       </axis>
     </joint>
     <link name="left_track_wheel8">
-      <pose>-0.25 0.1985 0.01855 0 -0 0</pose>
+      <pose relative_to="left_track_wheel8_j">0 0 0 0 -0 0</pose>
       <inertial>
         <pose>0 0 0.0141 0 -0 0</pose>
         <mass>0.7575</mass>
@@ -1941,6 +1941,7 @@
       </collision>
     </link>
     <joint name="left_track_wheel8_j" type="revolute">
+      <pose relative_to="left_track">-0.25 0 0.01855 0 -0 0</pose>
       <child>left_track_wheel8</child>
       <parent>left_track</parent>
       <axis>
@@ -1953,11 +1954,10 @@
           <spring_reference>0</spring_reference>
           <spring_stiffness>0</spring_stiffness>
         </dynamics>
-        <use_parent_model_frame>0</use_parent_model_frame>
       </axis>
     </joint>
     <link name="rear_left_flipper">
-      <pose>-0.25 0.272 0.0195 3.1415926535897931 0.193732 3.1415926535897931</pose>
+      <pose relative_to="rear_left_flipper_j">0 0 0 0 -0 0</pose>
       <inertial>
         <mass>1e-05</mass>
         <inertia>
@@ -1995,6 +1995,7 @@
       </visual>
     </link>
     <joint name="rear_left_flipper_j" type="revolute">
+      <pose relative_to="left_track">-0.25 0.0735 0.0195 3.1415926535897931 0.193732 3.1415926535897931</pose>
       <child>rear_left_flipper</child>
       <parent>left_track</parent>
       <axis>
@@ -2009,7 +2010,6 @@
           <spring_reference>0</spring_reference>
           <spring_stiffness>0</spring_stiffness>
         </dynamics>
-        <use_parent_model_frame>0</use_parent_model_frame>
       </axis>
       <physics>
         <ode>
@@ -2023,7 +2023,7 @@
       </physics>
     </joint>
     <link name="rear_left_flipper_wheel1">
-      <pose>-0.25 0.272 0.0195 3.1415926535897931 0.193732 3.1415926535897931</pose>
+      <pose relative_to="rear_left_flipper_wheel1_j">0 0 0 0 -0 0</pose>
       <inertial>
         <pose>0.08 0 0 0 -0 0</pose>
         <mass>0.15</mass>
@@ -2064,6 +2064,7 @@
       </collision>
     </link>
     <joint name="rear_left_flipper_wheel1_j" type="revolute">
+      <pose relative_to="rear_left_flipper">0 0 0 0 -0 0</pose>
       <child>rear_left_flipper_wheel1</child>
       <parent>rear_left_flipper</parent>
       <axis>
@@ -2076,11 +2077,10 @@
           <spring_reference>0</spring_reference>
           <spring_stiffness>0</spring_stiffness>
         </dynamics>
-        <use_parent_model_frame>0</use_parent_model_frame>
       </axis>
     </joint>
     <link name="rear_left_flipper_wheel2">
-      <pose>-0.330957 0.272 0.003617 3.1415926535897931 0.193732 3.1415926535897931</pose>
+      <pose relative_to="rear_left_flipper_wheel2_j">0 0 0 0 -0 0</pose>
       <inertial>
         <pose>0.08 0 0 0 -0 0</pose>
         <mass>0.15</mass>
@@ -2121,6 +2121,7 @@
       </collision>
     </link>
     <joint name="rear_left_flipper_wheel2_j" type="revolute">
+      <pose relative_to="rear_left_flipper">0.0825 0 0 0 -0 0</pose>
       <child>rear_left_flipper_wheel2</child>
       <parent>rear_left_flipper</parent>
       <axis>
@@ -2133,11 +2134,10 @@
           <spring_reference>0</spring_reference>
           <spring_stiffness>0</spring_stiffness>
         </dynamics>
-        <use_parent_model_frame>0</use_parent_model_frame>
       </axis>
     </joint>
     <link name="rear_left_flipper_wheel3">
-      <pose>-0.411913 0.272 -0.012266 3.1415926535897931 0.193732 3.1415926535897931</pose>
+      <pose relative_to="rear_left_flipper_wheel3_j">0 0 0 0 -0 0</pose>
       <inertial>
         <pose>0.08 0 0 0 -0 0</pose>
         <mass>0.15</mass>
@@ -2178,6 +2178,7 @@
       </collision>
     </link>
     <joint name="rear_left_flipper_wheel3_j" type="revolute">
+      <pose relative_to="rear_left_flipper">0.165 0 0 0 -0 0</pose>
       <child>rear_left_flipper_wheel3</child>
       <parent>rear_left_flipper</parent>
       <axis>
@@ -2190,11 +2191,10 @@
           <spring_reference>0</spring_reference>
           <spring_stiffness>0</spring_stiffness>
         </dynamics>
-        <use_parent_model_frame>0</use_parent_model_frame>
       </axis>
     </joint>
     <link name="rear_left_flipper_wheel4">
-      <pose>-0.49287 0.272 -0.028149 3.1415926535897931 0.193732 3.1415926535897931</pose>
+      <pose relative_to="rear_left_flipper_wheel4_j">0 0 0 0 -0 0</pose>
       <inertial>
         <pose>0.08 0 0 0 -0 0</pose>
         <mass>0.15</mass>
@@ -2235,6 +2235,7 @@
       </collision>
     </link>
     <joint name="rear_left_flipper_wheel4_j" type="revolute">
+      <pose relative_to="rear_left_flipper">0.2475 0 0 0 -0 0</pose>
       <child>rear_left_flipper_wheel4</child>
       <parent>rear_left_flipper</parent>
       <axis>
@@ -2247,11 +2248,10 @@
           <spring_reference>0</spring_reference>
           <spring_stiffness>0</spring_stiffness>
         </dynamics>
-        <use_parent_model_frame>0</use_parent_model_frame>
       </axis>
     </joint>
     <link name="rear_left_flipper_wheel5">
-      <pose>-0.573827 0.272 -0.044032 3.1415926535897931 0.193732 3.1415926535897931</pose>
+      <pose relative_to="rear_left_flipper_wheel5_j">0 0 0 0 -0 0</pose>
       <inertial>
         <pose>0.08 0 0 0 -0 0</pose>
         <mass>0.15</mass>
@@ -2292,6 +2292,7 @@
       </collision>
     </link>
     <joint name="rear_left_flipper_wheel5_j" type="revolute">
+      <pose relative_to="rear_left_flipper">0.33 0 0 0 -0 0</pose>
       <child>rear_left_flipper_wheel5</child>
       <parent>rear_left_flipper</parent>
       <axis>
@@ -2304,11 +2305,10 @@
           <spring_reference>0</spring_reference>
           <spring_stiffness>0</spring_stiffness>
         </dynamics>
-        <use_parent_model_frame>0</use_parent_model_frame>
       </axis>
     </joint>
     <link name="right_track">
-      <pose>0 -0.1985 0 0 -0 0</pose>
+      <pose relative_to="right_track_j">0 0 0 0 -0 0</pose>
       <inertial>
         <mass>1e-05</mass>
         <inertia>
@@ -2346,6 +2346,7 @@
       </visual>
     </link>
     <joint name="right_track_j" type="revolute">
+      <pose relative_to="base_link">0 -0.1985 0 0 -0 0</pose>
       <child>right_track</child>
       <parent>base_link</parent>
       <axis>
@@ -2360,7 +2361,6 @@
           <spring_reference>0</spring_reference>
           <spring_stiffness>0</spring_stiffness>
         </dynamics>
-        <use_parent_model_frame>0</use_parent_model_frame>
       </axis>
       <physics>
         <ode>
@@ -2379,7 +2379,7 @@
       </physics>
     </joint>
     <link name="front_right_flipper">
-      <pose>0.25 -0.272 0.0195 3.1415926535897931 -0.193732 3.1415926535897931</pose>
+      <pose relative_to="front_right_flipper_j">0 0 0 0 -0 0</pose>
       <inertial>
         <mass>1e-05</mass>
         <inertia>
@@ -2417,6 +2417,7 @@
       </visual>
     </link>
     <joint name="front_right_flipper_j" type="revolute">
+      <pose relative_to="right_track">0.25 -0.0735 0.0195 3.1415926535897931 -0.193732 3.1415926535897931</pose>
       <child>front_right_flipper</child>
       <parent>right_track</parent>
       <axis>
@@ -2431,7 +2432,6 @@
           <spring_reference>0</spring_reference>
           <spring_stiffness>0</spring_stiffness>
         </dynamics>
-        <use_parent_model_frame>0</use_parent_model_frame>
       </axis>
       <physics>
         <ode>
@@ -2445,7 +2445,7 @@
       </physics>
     </joint>
     <link name="front_right_flipper_wheel1">
-      <pose>0.25 -0.272 0.0195 3.1415926535897931 -0.193732 3.1415926535897931</pose>
+      <pose relative_to="front_right_flipper_wheel1_j">0 0 0 0 -0 0</pose>
       <inertial>
         <pose>-0.08 0 0 0 -0 0</pose>
         <mass>0.15</mass>
@@ -2486,6 +2486,7 @@
       </collision>
     </link>
     <joint name="front_right_flipper_wheel1_j" type="revolute">
+      <pose relative_to="front_right_flipper">0 0 0 0 -0 0</pose>
       <child>front_right_flipper_wheel1</child>
       <parent>front_right_flipper</parent>
       <axis>
@@ -2498,11 +2499,10 @@
           <spring_reference>0</spring_reference>
           <spring_stiffness>0</spring_stiffness>
         </dynamics>
-        <use_parent_model_frame>0</use_parent_model_frame>
       </axis>
     </joint>
     <link name="front_right_flipper_wheel2">
-      <pose>0.330957 -0.272 0.003617 3.1415926535897931 -0.193732 3.1415926535897931</pose>
+      <pose relative_to="front_right_flipper_wheel2_j">0 0 0 0 -0 0</pose>
       <inertial>
         <pose>-0.08 0 0 0 -0 0</pose>
         <mass>0.15</mass>
@@ -2543,6 +2543,7 @@
       </collision>
     </link>
     <joint name="front_right_flipper_wheel2_j" type="revolute">
+      <pose relative_to="front_right_flipper">-0.0825 0 0 0 -0 0</pose>
       <child>front_right_flipper_wheel2</child>
       <parent>front_right_flipper</parent>
       <axis>
@@ -2555,11 +2556,10 @@
           <spring_reference>0</spring_reference>
           <spring_stiffness>0</spring_stiffness>
         </dynamics>
-        <use_parent_model_frame>0</use_parent_model_frame>
       </axis>
     </joint>
     <link name="front_right_flipper_wheel3">
-      <pose>0.411913 -0.272 -0.012266 3.1415926535897931 -0.193732 3.1415926535897931</pose>
+      <pose relative_to="front_right_flipper_wheel3_j">0 0 0 0 -0 0</pose>
       <inertial>
         <pose>-0.08 0 0 0 -0 0</pose>
         <mass>0.15</mass>
@@ -2600,6 +2600,7 @@
       </collision>
     </link>
     <joint name="front_right_flipper_wheel3_j" type="revolute">
+      <pose relative_to="front_right_flipper">-0.165 0 0 0 -0 0</pose>
       <child>front_right_flipper_wheel3</child>
       <parent>front_right_flipper</parent>
       <axis>
@@ -2612,11 +2613,10 @@
           <spring_reference>0</spring_reference>
           <spring_stiffness>0</spring_stiffness>
         </dynamics>
-        <use_parent_model_frame>0</use_parent_model_frame>
       </axis>
     </joint>
     <link name="front_right_flipper_wheel4">
-      <pose>0.49287 -0.272 -0.028149 3.1415926535897931 -0.193732 3.1415926535897931</pose>
+      <pose relative_to="front_right_flipper_wheel4_j">0 0 0 0 -0 0</pose>
       <inertial>
         <pose>-0.08 0 0 0 -0 0</pose>
         <mass>0.15</mass>
@@ -2657,6 +2657,7 @@
       </collision>
     </link>
     <joint name="front_right_flipper_wheel4_j" type="revolute">
+      <pose relative_to="front_right_flipper">-0.2475 0 0 0 -0 0</pose>
       <child>front_right_flipper_wheel4</child>
       <parent>front_right_flipper</parent>
       <axis>
@@ -2669,11 +2670,10 @@
           <spring_reference>0</spring_reference>
           <spring_stiffness>0</spring_stiffness>
         </dynamics>
-        <use_parent_model_frame>0</use_parent_model_frame>
       </axis>
     </joint>
     <link name="front_right_flipper_wheel5">
-      <pose>0.573827 -0.272 -0.044032 3.1415926535897931 -0.193732 3.1415926535897931</pose>
+      <pose relative_to="front_right_flipper_wheel5_j">0 0 0 0 -0 0</pose>
       <inertial>
         <pose>-0.08 0 0 0 -0 0</pose>
         <mass>0.15</mass>
@@ -2714,6 +2714,7 @@
       </collision>
     </link>
     <joint name="front_right_flipper_wheel5_j" type="revolute">
+      <pose relative_to="front_right_flipper">-0.33 0 0 0 -0 0</pose>
       <child>front_right_flipper_wheel5</child>
       <parent>front_right_flipper</parent>
       <axis>
@@ -2726,11 +2727,10 @@
           <spring_reference>0</spring_reference>
           <spring_stiffness>0</spring_stiffness>
         </dynamics>
-        <use_parent_model_frame>0</use_parent_model_frame>
       </axis>
     </joint>
     <link name="rear_right_flipper">
-      <pose>-0.25 -0.272 0.0195 0 -0.193732 0</pose>
+      <pose relative_to="rear_right_flipper_j">0 0 0 0 -0 0</pose>
       <inertial>
         <mass>1e-05</mass>
         <inertia>
@@ -2768,6 +2768,7 @@
       </visual>
     </link>
     <joint name="rear_right_flipper_j" type="revolute">
+      <pose relative_to="right_track">-0.25 -0.0735 0.0195 0 -0.193732 0</pose>
       <child>rear_right_flipper</child>
       <parent>right_track</parent>
       <axis>
@@ -2782,7 +2783,6 @@
           <spring_reference>0</spring_reference>
           <spring_stiffness>0</spring_stiffness>
         </dynamics>
-        <use_parent_model_frame>0</use_parent_model_frame>
       </axis>
       <physics>
         <ode>
@@ -2796,7 +2796,7 @@
       </physics>
     </joint>
     <link name="rear_right_flipper_wheel1">
-      <pose>-0.25 -0.272 0.0195 0 -0.193732 0</pose>
+      <pose relative_to="rear_right_flipper_wheel1_j">0 0 0 0 -0 0</pose>
       <inertial>
         <pose>-0.08 0 0 0 -0 0</pose>
         <mass>0.15</mass>
@@ -2837,6 +2837,7 @@
       </collision>
     </link>
     <joint name="rear_right_flipper_wheel1_j" type="revolute">
+      <pose relative_to="rear_right_flipper">0 0 0 0 -0 0</pose>
       <child>rear_right_flipper_wheel1</child>
       <parent>rear_right_flipper</parent>
       <axis>
@@ -2849,11 +2850,10 @@
           <spring_reference>0</spring_reference>
           <spring_stiffness>0</spring_stiffness>
         </dynamics>
-        <use_parent_model_frame>0</use_parent_model_frame>
       </axis>
     </joint>
     <link name="rear_right_flipper_wheel2">
-      <pose>-0.330957 -0.272 0.003617 0 -0.193732 0</pose>
+      <pose relative_to="rear_right_flipper_wheel2_j">0 0 0 0 -0 0</pose>
       <inertial>
         <pose>-0.08 0 0 0 -0 0</pose>
         <mass>0.15</mass>
@@ -2894,6 +2894,7 @@
       </collision>
     </link>
     <joint name="rear_right_flipper_wheel2_j" type="revolute">
+      <pose relative_to="rear_right_flipper">-0.0825 0 0 0 -0 0</pose>
       <child>rear_right_flipper_wheel2</child>
       <parent>rear_right_flipper</parent>
       <axis>
@@ -2906,11 +2907,10 @@
           <spring_reference>0</spring_reference>
           <spring_stiffness>0</spring_stiffness>
         </dynamics>
-        <use_parent_model_frame>0</use_parent_model_frame>
       </axis>
     </joint>
     <link name="rear_right_flipper_wheel3">
-      <pose>-0.411913 -0.272 -0.012266 0 -0.193732 0</pose>
+      <pose relative_to="rear_right_flipper_wheel3_j">0 0 0 0 -0 0</pose>
       <inertial>
         <pose>-0.08 0 0 0 -0 0</pose>
         <mass>0.15</mass>
@@ -2951,6 +2951,7 @@
       </collision>
     </link>
     <joint name="rear_right_flipper_wheel3_j" type="revolute">
+      <pose relative_to="rear_right_flipper">-0.165 0 0 0 -0 0</pose>
       <child>rear_right_flipper_wheel3</child>
       <parent>rear_right_flipper</parent>
       <axis>
@@ -2963,11 +2964,10 @@
           <spring_reference>0</spring_reference>
           <spring_stiffness>0</spring_stiffness>
         </dynamics>
-        <use_parent_model_frame>0</use_parent_model_frame>
       </axis>
     </joint>
     <link name="rear_right_flipper_wheel4">
-      <pose>-0.49287 -0.272 -0.028149 0 -0.193732 0</pose>
+      <pose relative_to="rear_right_flipper_wheel4_j">0 0 0 0 -0 0</pose>
       <inertial>
         <pose>-0.08 0 0 0 -0 0</pose>
         <mass>0.15</mass>
@@ -3008,6 +3008,7 @@
       </collision>
     </link>
     <joint name="rear_right_flipper_wheel4_j" type="revolute">
+      <pose relative_to="rear_right_flipper">-0.2475 0 0 0 -0 0</pose>
       <child>rear_right_flipper_wheel4</child>
       <parent>rear_right_flipper</parent>
       <axis>
@@ -3020,11 +3021,10 @@
           <spring_reference>0</spring_reference>
           <spring_stiffness>0</spring_stiffness>
         </dynamics>
-        <use_parent_model_frame>0</use_parent_model_frame>
       </axis>
     </joint>
     <link name="rear_right_flipper_wheel5">
-      <pose>-0.573827 -0.272 -0.044032 0 -0.193732 0</pose>
+      <pose relative_to="rear_right_flipper_wheel5_j">0 0 0 0 -0 0</pose>
       <inertial>
         <pose>-0.08 0 0 0 -0 0</pose>
         <mass>0.15</mass>
@@ -3065,6 +3065,7 @@
       </collision>
     </link>
     <joint name="rear_right_flipper_wheel5_j" type="revolute">
+      <pose relative_to="rear_right_flipper">-0.33 0 0 0 -0 0</pose>
       <child>rear_right_flipper_wheel5</child>
       <parent>rear_right_flipper</parent>
       <axis>
@@ -3077,11 +3078,10 @@
           <spring_reference>0</spring_reference>
           <spring_stiffness>0</spring_stiffness>
         </dynamics>
-        <use_parent_model_frame>0</use_parent_model_frame>
       </axis>
     </joint>
     <link name="right_track_wheel1">
-      <pose>0.25 -0.1985 0.01855 0 -0 0</pose>
+      <pose relative_to="right_track_wheel1_j">0 0 0 0 -0 0</pose>
       <inertial>
         <pose>0 0 0.0141 0 -0 0</pose>
         <mass>0.7575</mass>
@@ -3122,6 +3122,7 @@
       </collision>
     </link>
     <joint name="right_track_wheel1_j" type="revolute">
+      <pose relative_to="right_track">0.25 0 0.01855 0 -0 0</pose>
       <child>right_track_wheel1</child>
       <parent>right_track</parent>
       <axis>
@@ -3134,11 +3135,10 @@
           <spring_reference>0</spring_reference>
           <spring_stiffness>0</spring_stiffness>
         </dynamics>
-        <use_parent_model_frame>0</use_parent_model_frame>
       </axis>
     </joint>
     <link name="right_track_wheel2">
-      <pose>0.178571 -0.1985 0.01855 0 -0 0</pose>
+      <pose relative_to="right_track_wheel2_j">0 0 0 0 -0 0</pose>
       <inertial>
         <pose>0 0 0.0141 0 -0 0</pose>
         <mass>0.7575</mass>
@@ -3179,6 +3179,7 @@
       </collision>
     </link>
     <joint name="right_track_wheel2_j" type="revolute">
+      <pose relative_to="right_track">0.178571 0 0.01855 0 -0 0</pose>
       <child>right_track_wheel2</child>
       <parent>right_track</parent>
       <axis>
@@ -3191,11 +3192,10 @@
           <spring_reference>0</spring_reference>
           <spring_stiffness>0</spring_stiffness>
         </dynamics>
-        <use_parent_model_frame>0</use_parent_model_frame>
       </axis>
     </joint>
     <link name="right_track_wheel3">
-      <pose>0.107143 -0.1985 0.01855 0 -0 0</pose>
+      <pose relative_to="right_track_wheel3_j">0 0 0 0 -0 0</pose>
       <inertial>
         <pose>0 0 0.0141 0 -0 0</pose>
         <mass>0.7575</mass>
@@ -3236,6 +3236,7 @@
       </collision>
     </link>
     <joint name="right_track_wheel3_j" type="revolute">
+      <pose relative_to="right_track">0.107143 0 0.01855 0 -0 0</pose>
       <child>right_track_wheel3</child>
       <parent>right_track</parent>
       <axis>
@@ -3248,11 +3249,10 @@
           <spring_reference>0</spring_reference>
           <spring_stiffness>0</spring_stiffness>
         </dynamics>
-        <use_parent_model_frame>0</use_parent_model_frame>
       </axis>
     </joint>
     <link name="right_track_wheel4">
-      <pose>0.035714 -0.1985 0.01855 0 -0 0</pose>
+      <pose relative_to="right_track_wheel4_j">0 0 0 0 -0 0</pose>
       <inertial>
         <pose>0 0 0.0141 0 -0 0</pose>
         <mass>0.7575</mass>
@@ -3293,6 +3293,7 @@
       </collision>
     </link>
     <joint name="right_track_wheel4_j" type="revolute">
+      <pose relative_to="right_track">0.035714 0 0.01855 0 -0 0</pose>
       <child>right_track_wheel4</child>
       <parent>right_track</parent>
       <axis>
@@ -3305,11 +3306,10 @@
           <spring_reference>0</spring_reference>
           <spring_stiffness>0</spring_stiffness>
         </dynamics>
-        <use_parent_model_frame>0</use_parent_model_frame>
       </axis>
     </joint>
     <link name="right_track_wheel5">
-      <pose>-0.035714 -0.1985 0.01855 0 -0 0</pose>
+      <pose relative_to="right_track_wheel5_j">0 0 0 0 -0 0</pose>
       <inertial>
         <pose>0 0 0.0141 0 -0 0</pose>
         <mass>0.7575</mass>
@@ -3350,6 +3350,7 @@
       </collision>
     </link>
     <joint name="right_track_wheel5_j" type="revolute">
+      <pose relative_to="right_track">-0.035714 0 0.01855 0 -0 0</pose>
       <child>right_track_wheel5</child>
       <parent>right_track</parent>
       <axis>
@@ -3362,11 +3363,10 @@
           <spring_reference>0</spring_reference>
           <spring_stiffness>0</spring_stiffness>
         </dynamics>
-        <use_parent_model_frame>0</use_parent_model_frame>
       </axis>
     </joint>
     <link name="right_track_wheel6">
-      <pose>-0.107143 -0.1985 0.01855 0 -0 0</pose>
+      <pose relative_to="right_track_wheel6_j">0 0 0 0 -0 0</pose>
       <inertial>
         <pose>0 0 0.0141 0 -0 0</pose>
         <mass>0.7575</mass>
@@ -3407,6 +3407,7 @@
       </collision>
     </link>
     <joint name="right_track_wheel6_j" type="revolute">
+      <pose relative_to="right_track">-0.107143 0 0.01855 0 -0 0</pose>
       <child>right_track_wheel6</child>
       <parent>right_track</parent>
       <axis>
@@ -3419,11 +3420,10 @@
           <spring_reference>0</spring_reference>
           <spring_stiffness>0</spring_stiffness>
         </dynamics>
-        <use_parent_model_frame>0</use_parent_model_frame>
       </axis>
     </joint>
     <link name="right_track_wheel7">
-      <pose>-0.178571 -0.1985 0.01855 0 -0 0</pose>
+      <pose relative_to="right_track_wheel7_j">0 0 0 0 -0 0</pose>
       <inertial>
         <pose>0 0 0.0141 0 -0 0</pose>
         <mass>0.7575</mass>
@@ -3464,6 +3464,7 @@
       </collision>
     </link>
     <joint name="right_track_wheel7_j" type="revolute">
+      <pose relative_to="right_track">-0.178571 0 0.01855 0 -0 0</pose>
       <child>right_track_wheel7</child>
       <parent>right_track</parent>
       <axis>
@@ -3476,11 +3477,10 @@
           <spring_reference>0</spring_reference>
           <spring_stiffness>0</spring_stiffness>
         </dynamics>
-        <use_parent_model_frame>0</use_parent_model_frame>
       </axis>
     </joint>
     <link name="right_track_wheel8">
-      <pose>-0.25 -0.1985 0.01855 0 -0 0</pose>
+      <pose relative_to="right_track_wheel8_j">0 0 0 0 -0 0</pose>
       <inertial>
         <pose>0 0 0.0141 0 -0 0</pose>
         <mass>0.7575</mass>
@@ -3521,6 +3521,7 @@
       </collision>
     </link>
     <joint name="right_track_wheel8_j" type="revolute">
+      <pose relative_to="right_track">-0.25 0 0.01855 0 -0 0</pose>
       <child>right_track_wheel8</child>
       <parent>right_track</parent>
       <axis>
@@ -3533,7 +3534,6 @@
           <spring_reference>0</spring_reference>
           <spring_stiffness>0</spring_stiffness>
         </dynamics>
-        <use_parent_model_frame>0</use_parent_model_frame>
       </axis>
     </joint>
     <plugin name="cras::FlipperControlPlugin" filename="libflipper_control_plugin.so">

--- a/submitted_models/ctu_cras_norlab_absolem_sensor_config_1/model.sdf
+++ b/submitted_models/ctu_cras_norlab_absolem_sensor_config_1/model.sdf
@@ -3137,6 +3137,22 @@
         </surface>
       </collision>
     </link>
+    <joint name="right_track_wheel2_j" type="revolute">
+      <pose relative_to="right_track">0.178571 0 0.01855 0 -0 0</pose>
+      <parent>right_track</parent>
+      <child>right_track_wheel2</child>
+      <axis>
+        <xyz>0 1 0</xyz>
+        <limit>
+          <lower>-1e+16</lower>
+          <upper>1e+16</upper>
+        </limit>
+        <dynamics>
+          <spring_reference>0</spring_reference>
+          <spring_stiffness>0</spring_stiffness>
+        </dynamics>
+      </axis>
+    </joint>
     <link name="right_track_wheel2">
       <pose relative_to="right_track_wheel2_j">0 0 0 0 -0 0</pose>
       <inertial>
@@ -3178,22 +3194,6 @@
         </surface>
       </collision>
     </link>
-    <joint name="right_track_wheel2_j" type="revolute">
-      <pose relative_to="right_track">0.178571 0 0.01855 0 -0 0</pose>
-      <parent>right_track</parent>
-      <child>right_track_wheel2</child>
-      <axis>
-        <xyz>0 1 0</xyz>
-        <limit>
-          <lower>-1e+16</lower>
-          <upper>1e+16</upper>
-        </limit>
-        <dynamics>
-          <spring_reference>0</spring_reference>
-          <spring_stiffness>0</spring_stiffness>
-        </dynamics>
-      </axis>
-    </joint>
     <link name="right_track_wheel3">
       <pose relative_to="right_track_wheel3_j">0 0 0 0 -0 0</pose>
       <inertial>

--- a/submitted_models/ctu_cras_norlab_absolem_sensor_config_1/model.sdf
+++ b/submitted_models/ctu_cras_norlab_absolem_sensor_config_1/model.sdf
@@ -3422,6 +3422,22 @@
         </surface>
       </collision>
     </link>
+    <joint name="right_track_wheel7_j" type="revolute">
+      <pose relative_to="right_track">-0.178571 0 0.01855 0 -0 0</pose>
+      <parent>right_track</parent>
+      <child>right_track_wheel7</child>
+      <axis>
+        <xyz>0 1 0</xyz>
+        <limit>
+          <lower>-1e+16</lower>
+          <upper>1e+16</upper>
+        </limit>
+        <dynamics>
+          <spring_reference>0</spring_reference>
+          <spring_stiffness>0</spring_stiffness>
+        </dynamics>
+      </axis>
+    </joint>
     <link name="right_track_wheel7">
       <pose relative_to="right_track_wheel7_j">0 0 0 0 -0 0</pose>
       <inertial>
@@ -3463,22 +3479,6 @@
         </surface>
       </collision>
     </link>
-    <joint name="right_track_wheel7_j" type="revolute">
-      <pose relative_to="right_track">-0.178571 0 0.01855 0 -0 0</pose>
-      <parent>right_track</parent>
-      <child>right_track_wheel7</child>
-      <axis>
-        <xyz>0 1 0</xyz>
-        <limit>
-          <lower>-1e+16</lower>
-          <upper>1e+16</upper>
-        </limit>
-        <dynamics>
-          <spring_reference>0</spring_reference>
-          <spring_stiffness>0</spring_stiffness>
-        </dynamics>
-      </axis>
-    </joint>
     <link name="right_track_wheel8">
       <pose relative_to="right_track_wheel8_j">0 0 0 0 -0 0</pose>
       <inertial>

--- a/submitted_models/ctu_cras_norlab_absolem_sensor_config_1/model.sdf
+++ b/submitted_models/ctu_cras_norlab_absolem_sensor_config_1/model.sdf
@@ -3365,6 +3365,22 @@
         </surface>
       </collision>
     </link>
+    <joint name="right_track_wheel6_j" type="revolute">
+      <pose relative_to="right_track">-0.107143 0 0.01855 0 -0 0</pose>
+      <parent>right_track</parent>
+      <child>right_track_wheel6</child>
+      <axis>
+        <xyz>0 1 0</xyz>
+        <limit>
+          <lower>-1e+16</lower>
+          <upper>1e+16</upper>
+        </limit>
+        <dynamics>
+          <spring_reference>0</spring_reference>
+          <spring_stiffness>0</spring_stiffness>
+        </dynamics>
+      </axis>
+    </joint>
     <link name="right_track_wheel6">
       <pose relative_to="right_track_wheel6_j">0 0 0 0 -0 0</pose>
       <inertial>
@@ -3406,22 +3422,6 @@
         </surface>
       </collision>
     </link>
-    <joint name="right_track_wheel6_j" type="revolute">
-      <pose relative_to="right_track">-0.107143 0 0.01855 0 -0 0</pose>
-      <parent>right_track</parent>
-      <child>right_track_wheel6</child>
-      <axis>
-        <xyz>0 1 0</xyz>
-        <limit>
-          <lower>-1e+16</lower>
-          <upper>1e+16</upper>
-        </limit>
-        <dynamics>
-          <spring_reference>0</spring_reference>
-          <spring_stiffness>0</spring_stiffness>
-        </dynamics>
-      </axis>
-    </joint>
     <link name="right_track_wheel7">
       <pose relative_to="right_track_wheel7_j">0 0 0 0 -0 0</pose>
       <inertial>

--- a/submitted_models/ctu_cras_norlab_absolem_sensor_config_1/model.sdf
+++ b/submitted_models/ctu_cras_norlab_absolem_sensor_config_1/model.sdf
@@ -639,77 +639,77 @@
         <always_on>1</always_on>
         <update_rate>50</update_rate>
         <imu>
-                    <angular_velocity>
-                        <x>
-                            <noise type="gaussian">
-                                <mean>0</mean>
-                                <stddev>0.009</stddev>
-                                <bias_mean>0.00075</bias_mean>
-                                <bias_stddev>0.005</bias_stddev>
-                                <dynamic_bias_stddev>2e-05</dynamic_bias_stddev>
-                                <dynamic_bias_correlation_time>400</dynamic_bias_correlation_time>
-                                <precision>0.00025</precision>
-                            </noise>
-                        </x>
-                        <y>
-                            <noise type="gaussian">
-                                <mean>0</mean>
-                                <stddev>0.009</stddev>
-                                <bias_mean>0.00075</bias_mean>
-                                <bias_stddev>0.005</bias_stddev>
-                                <dynamic_bias_stddev>2e-05</dynamic_bias_stddev>
-                                <dynamic_bias_correlation_time>400</dynamic_bias_correlation_time>
-                                <precision>0.00025</precision>
-                            </noise>
-                        </y>
-                        <z>
-                            <noise type="gaussian">
-                                <mean>0</mean>
-                                <stddev>0.009</stddev>
-                                <bias_mean>0.00075</bias_mean>
-                                <bias_stddev>0.005</bias_stddev>
-                                <dynamic_bias_stddev>2e-05</dynamic_bias_stddev>
-                                <dynamic_bias_correlation_time>400</dynamic_bias_correlation_time>
-                                <precision>0.00025</precision>
-                            </noise>
-                        </z>
-                    </angular_velocity>
-                    <linear_acceleration>
-                        <x>
-                            <noise type="gaussian">
-                                <mean>0</mean>
-                                <stddev>0.021</stddev>
-                                <bias_mean>0.05</bias_mean>
-                                <bias_stddev>0.0075</bias_stddev>
-                                <dynamic_bias_stddev>0.000375</dynamic_bias_stddev>
-                                <dynamic_bias_correlation_time>175</dynamic_bias_correlation_time>
-                                <precision>0.005</precision>
-                            </noise>
-                        </x>
-                        <y>
-                            <noise type="gaussian">
-                                <mean>0</mean>
-                                <stddev>0.021</stddev>
-                                <bias_mean>0.05</bias_mean>
-                                <bias_stddev>0.0075</bias_stddev>
-                                <dynamic_bias_stddev>0.000375</dynamic_bias_stddev>
-                                <dynamic_bias_correlation_time>175</dynamic_bias_correlation_time>
-                                <precision>0.005</precision>
-                            </noise>
-                        </y>
-                        <z>
-                            <noise type="gaussian">
-                                <mean>0</mean>
-                                <stddev>0.021</stddev>
-                                <bias_mean>0.05</bias_mean>
-                                <bias_stddev>0.0075</bias_stddev>
-                                <dynamic_bias_stddev>0.000375</dynamic_bias_stddev>
-                                <dynamic_bias_correlation_time>175</dynamic_bias_correlation_time>
-                                <precision>0.005</precision>
-                            </noise>
-                        </z>
-                    </linear_acceleration>
-                </imu>
+          <angular_velocity>
+            <x>
+              <noise type="gaussian">
+                <mean>0</mean>
+                <stddev>0.009</stddev>
+                <bias_mean>0.00075</bias_mean>
+                <bias_stddev>0.005</bias_stddev>
+                <dynamic_bias_stddev>2e-05</dynamic_bias_stddev>
+                <dynamic_bias_correlation_time>400</dynamic_bias_correlation_time>
+                <precision>0.00025</precision>
+              </noise>
+            </x>
+            <y>
+              <noise type="gaussian">
+                <mean>0</mean>
+                <stddev>0.009</stddev>
+                <bias_mean>0.00075</bias_mean>
+                <bias_stddev>0.005</bias_stddev>
+                <dynamic_bias_stddev>2e-05</dynamic_bias_stddev>
+                <dynamic_bias_correlation_time>400</dynamic_bias_correlation_time>
+                <precision>0.00025</precision>
+              </noise>
+            </y>
+            <z>
+              <noise type="gaussian">
+                <mean>0</mean>
+                <stddev>0.009</stddev>
+                <bias_mean>0.00075</bias_mean>
+                <bias_stddev>0.005</bias_stddev>
+                <dynamic_bias_stddev>2e-05</dynamic_bias_stddev>
+                <dynamic_bias_correlation_time>400</dynamic_bias_correlation_time>
+                <precision>0.00025</precision>
+              </noise>
+            </z>
+          </angular_velocity>
+          <linear_acceleration>
+            <x>
+              <noise type="gaussian">
+                <mean>0</mean>
+                <stddev>0.021</stddev>
+                <bias_mean>0.05</bias_mean>
+                <bias_stddev>0.0075</bias_stddev>
+                <dynamic_bias_stddev>0.000375</dynamic_bias_stddev>
+                <dynamic_bias_correlation_time>175</dynamic_bias_correlation_time>
+                <precision>0.005</precision>
+              </noise>
+            </x>
+            <y>
+              <noise type="gaussian">
+                <mean>0</mean>
+                <stddev>0.021</stddev>
+                <bias_mean>0.05</bias_mean>
+                <bias_stddev>0.0075</bias_stddev>
+                <dynamic_bias_stddev>0.000375</dynamic_bias_stddev>
+                <dynamic_bias_correlation_time>175</dynamic_bias_correlation_time>
+                <precision>0.005</precision>
+              </noise>
+            </y>
+            <z>
+              <noise type="gaussian">
+                <mean>0</mean>
+                <stddev>0.021</stddev>
+                <bias_mean>0.05</bias_mean>
+                <bias_stddev>0.0075</bias_stddev>
+                <dynamic_bias_stddev>0.000375</dynamic_bias_stddev>
+                <dynamic_bias_correlation_time>175</dynamic_bias_correlation_time>
+                <precision>0.005</precision>
+              </noise>
+            </z>
+          </linear_acceleration>
+        </imu>
         <pose>0 0 0.15 -3.1415926535897931 -0 0</pose>
       </sensor>
       <sensor name="omnicam_sensor0" type="camera">

--- a/submitted_models/ctu_cras_norlab_absolem_sensor_config_1/model.sdf
+++ b/submitted_models/ctu_cras_norlab_absolem_sensor_config_1/model.sdf
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='utf-8'?>
-<sdf version="1.6">
+<sdf version="1.7">
   <model name="ctu_cras_norlab_absolem_sensor_config_1">
     <link name="base_link">
       <inertial>
@@ -341,7 +341,7 @@
         </geometry>
       </visual>
       <visual name="base_link_fixed_joint_lump__camera_2_visual_16">
-        <pose>-0.01735 -0.055429 0.314721 -1.5725 0.00415 1.56975</pose>
+        <pose>-0.01735 -0.055429 0.314721 -1.5725 0.00415 1.56974</pose>
         <geometry>
           <box>
             <size>0.005 0.005 0.005</size>
@@ -349,7 +349,7 @@
         </geometry>
       </visual>
       <visual name="base_link_fixed_joint_lump__camera_2_sim_visual_17">
-        <pose>-0.01735 -0.055429 0.314721 -0.001705 0.00415 1.56975</pose>
+        <pose>-0.01735 -0.055429 0.314721 -0.001705 0.00415 1.56974</pose>
         <geometry>
           <box>
             <size>0.005 0.005 0.005</size>
@@ -474,7 +474,7 @@
         </geometry>
       </visual>
       <visual name="base_link_fixed_joint_lump__camera_link_visual_32">
-        <pose>0.133719 -0.010853 0.422031 2.07031 -0.013168 1.56329</pose>
+        <pose>0.133719 -0.010853 0.422031 2.07031 -0.013167 1.56329</pose>
         <geometry>
           <mesh>
             <uri>meshes/realsense_d435.dae</uri>
@@ -1179,7 +1179,7 @@
         </surface>
       </collision>
       <visual name="front_left_flipper_visual">
-        <pose>0 0 0 -2.95744 0 1.5707963267948966</pose>
+        <pose>0 0 0 -2.95743 -0 1.5707963267948966</pose>
         <geometry>
           <mesh>
             <uri>meshes/flipper.dae</uri>
@@ -1986,7 +1986,7 @@
         </surface>
       </collision>
       <visual name="rear_left_flipper_visual">
-        <pose>0 0 0 -2.95744 0 1.5707963267948966</pose>
+        <pose>0 0 0 -2.95743 -0 1.5707963267948966</pose>
         <geometry>
           <mesh>
             <uri>meshes/flipper.dae</uri>
@@ -2408,7 +2408,7 @@
         </surface>
       </collision>
       <visual name="front_right_flipper_visual">
-        <pose>0 0 0 -2.95744 -0 -1.5707963267948966</pose>
+        <pose>0 0 0 -2.95743 -0 -1.5707963267948966</pose>
         <geometry>
           <mesh>
             <uri>meshes/flipper.dae</uri>
@@ -2759,7 +2759,7 @@
         </surface>
       </collision>
       <visual name="rear_right_flipper_visual">
-        <pose>0 0 0 -2.95744 -0 -1.5707963267948966</pose>
+        <pose>0 0 0 -2.95743 -0 -1.5707963267948966</pose>
         <geometry>
           <mesh>
             <uri>meshes/flipper.dae</uri>

--- a/submitted_models/ctu_cras_norlab_absolem_sensor_config_1/model.sdf
+++ b/submitted_models/ctu_cras_norlab_absolem_sensor_config_1/model.sdf
@@ -2022,6 +2022,22 @@
         </geometry>
       </visual>
     </link>
+    <joint name="rear_left_flipper_wheel1_j" type="revolute">
+      <pose relative_to="rear_left_flipper">0 0 0 0 -0 0</pose>
+      <parent>rear_left_flipper</parent>
+      <child>rear_left_flipper_wheel1</child>
+      <axis>
+        <xyz>0 1 0</xyz>
+        <limit>
+          <lower>-1e+16</lower>
+          <upper>1e+16</upper>
+        </limit>
+        <dynamics>
+          <spring_reference>0</spring_reference>
+          <spring_stiffness>0</spring_stiffness>
+        </dynamics>
+      </axis>
+    </joint>
     <link name="rear_left_flipper_wheel1">
       <pose relative_to="rear_left_flipper_wheel1_j">0 0 0 0 -0 0</pose>
       <inertial>
@@ -2063,22 +2079,6 @@
         </surface>
       </collision>
     </link>
-    <joint name="rear_left_flipper_wheel1_j" type="revolute">
-      <pose relative_to="rear_left_flipper">0 0 0 0 -0 0</pose>
-      <parent>rear_left_flipper</parent>
-      <child>rear_left_flipper_wheel1</child>
-      <axis>
-        <xyz>0 1 0</xyz>
-        <limit>
-          <lower>-1e+16</lower>
-          <upper>1e+16</upper>
-        </limit>
-        <dynamics>
-          <spring_reference>0</spring_reference>
-          <spring_stiffness>0</spring_stiffness>
-        </dynamics>
-      </axis>
-    </joint>
     <link name="rear_left_flipper_wheel2">
       <pose relative_to="rear_left_flipper_wheel2_j">0 0 0 0 -0 0</pose>
       <inertial>

--- a/submitted_models/ctu_cras_norlab_absolem_sensor_config_1/model.sdf
+++ b/submitted_models/ctu_cras_norlab_absolem_sensor_config_1/model.sdf
@@ -1956,6 +1956,34 @@
         </surface>
       </collision>
     </link>
+    <joint name="rear_left_flipper_j" type="revolute">
+      <pose relative_to="left_track">-0.25 0.0735 0.0195 3.1415926535897931 0.193732 3.1415926535897931</pose>
+      <parent>left_track</parent>
+      <child>rear_left_flipper</child>
+      <axis>
+        <xyz>0 1 0</xyz>
+        <limit>
+          <lower>-1e+16</lower>
+          <upper>1e+16</upper>
+          <effort>20</effort>
+          <velocity>0.785398</velocity>
+        </limit>
+        <dynamics>
+          <spring_reference>0</spring_reference>
+          <spring_stiffness>0</spring_stiffness>
+        </dynamics>
+      </axis>
+      <physics>
+        <ode>
+          <implicit_spring_damper>1</implicit_spring_damper>
+          <cfm_damping>1</cfm_damping>
+          <limit>
+            <cfm>0</cfm>
+            <erp>0.2</erp>
+          </limit>
+        </ode>
+      </physics>
+    </joint>
     <link name="rear_left_flipper">
       <pose relative_to="rear_left_flipper_j">0 0 0 0 -0 0</pose>
       <inertial>
@@ -1994,34 +2022,6 @@
         </geometry>
       </visual>
     </link>
-    <joint name="rear_left_flipper_j" type="revolute">
-      <pose relative_to="left_track">-0.25 0.0735 0.0195 3.1415926535897931 0.193732 3.1415926535897931</pose>
-      <parent>left_track</parent>
-      <child>rear_left_flipper</child>
-      <axis>
-        <xyz>0 1 0</xyz>
-        <limit>
-          <lower>-1e+16</lower>
-          <upper>1e+16</upper>
-          <effort>20</effort>
-          <velocity>0.785398</velocity>
-        </limit>
-        <dynamics>
-          <spring_reference>0</spring_reference>
-          <spring_stiffness>0</spring_stiffness>
-        </dynamics>
-      </axis>
-      <physics>
-        <ode>
-          <implicit_spring_damper>1</implicit_spring_damper>
-          <cfm_damping>1</cfm_damping>
-          <limit>
-            <cfm>0</cfm>
-            <erp>0.2</erp>
-          </limit>
-        </ode>
-      </physics>
-    </joint>
     <link name="rear_left_flipper_wheel1">
       <pose relative_to="rear_left_flipper_wheel1_j">0 0 0 0 -0 0</pose>
       <inertial>

--- a/submitted_models/ctu_cras_norlab_absolem_sensor_config_1/model.sdf
+++ b/submitted_models/ctu_cras_norlab_absolem_sensor_config_1/model.sdf
@@ -79,7 +79,7 @@
         </geometry>
       </collision>
       <collision name="base_link_fixed_joint_lump__antenna_collision_8">
-        <pose>-0.39064 0.0789 0.1551 3.1415926535897931 1.5707963267948966 3.1415926535897931</pose>
+        <pose>-0.39064 0.0789 0.1551 0 1.5707963267948966 0</pose>
         <geometry>
           <cylinder>
             <length>0.03718</length>
@@ -235,7 +235,7 @@
         </geometry>
       </visual>
       <visual name="base_link_fixed_joint_lump__imu_visual_3">
-        <pose>0 0 0.15 -3.1415926535897931 -0 0</pose>
+        <pose>0 0 0.15 -3.1415926535897931 0 0</pose>
         <geometry>
           <box>
             <size>0.005 0.005 0.005</size>
@@ -646,8 +646,8 @@
                                 <stddev>0.009</stddev>
                                 <bias_mean>0.00075</bias_mean>
                                 <bias_stddev>0.005</bias_stddev>
-                                <dynamic_bias_stddev>0.00002</dynamic_bias_stddev>
-                                <dynamic_bias_correlation_time>400.0</dynamic_bias_correlation_time>
+                                <dynamic_bias_stddev>2e-05</dynamic_bias_stddev>
+                                <dynamic_bias_correlation_time>400</dynamic_bias_correlation_time>
                                 <precision>0.00025</precision>
                             </noise>
                         </x>
@@ -657,8 +657,8 @@
                                 <stddev>0.009</stddev>
                                 <bias_mean>0.00075</bias_mean>
                                 <bias_stddev>0.005</bias_stddev>
-                                <dynamic_bias_stddev>0.00002</dynamic_bias_stddev>
-                                <dynamic_bias_correlation_time>400.0</dynamic_bias_correlation_time>
+                                <dynamic_bias_stddev>2e-05</dynamic_bias_stddev>
+                                <dynamic_bias_correlation_time>400</dynamic_bias_correlation_time>
                                 <precision>0.00025</precision>
                             </noise>
                         </y>
@@ -668,8 +668,8 @@
                                 <stddev>0.009</stddev>
                                 <bias_mean>0.00075</bias_mean>
                                 <bias_stddev>0.005</bias_stddev>
-                                <dynamic_bias_stddev>0.00002</dynamic_bias_stddev>
-                                <dynamic_bias_correlation_time>400.0</dynamic_bias_correlation_time>
+                                <dynamic_bias_stddev>2e-05</dynamic_bias_stddev>
+                                <dynamic_bias_correlation_time>400</dynamic_bias_correlation_time>
                                 <precision>0.00025</precision>
                             </noise>
                         </z>
@@ -682,7 +682,7 @@
                                 <bias_mean>0.05</bias_mean>
                                 <bias_stddev>0.0075</bias_stddev>
                                 <dynamic_bias_stddev>0.000375</dynamic_bias_stddev>
-                                <dynamic_bias_correlation_time>175.0</dynamic_bias_correlation_time>
+                                <dynamic_bias_correlation_time>175</dynamic_bias_correlation_time>
                                 <precision>0.005</precision>
                             </noise>
                         </x>
@@ -693,7 +693,7 @@
                                 <bias_mean>0.05</bias_mean>
                                 <bias_stddev>0.0075</bias_stddev>
                                 <dynamic_bias_stddev>0.000375</dynamic_bias_stddev>
-                                <dynamic_bias_correlation_time>175.0</dynamic_bias_correlation_time>
+                                <dynamic_bias_correlation_time>175</dynamic_bias_correlation_time>
                                 <precision>0.005</precision>
                             </noise>
                         </y>
@@ -704,7 +704,7 @@
                                 <bias_mean>0.05</bias_mean>
                                 <bias_stddev>0.0075</bias_stddev>
                                 <dynamic_bias_stddev>0.000375</dynamic_bias_stddev>
-                                <dynamic_bias_correlation_time>175.0</dynamic_bias_correlation_time>
+                                <dynamic_bias_correlation_time>175</dynamic_bias_correlation_time>
                                 <precision>0.005</precision>
                             </noise>
                         </z>

--- a/submitted_models/ctu_cras_norlab_absolem_sensor_config_1/model.sdf
+++ b/submitted_models/ctu_cras_norlab_absolem_sensor_config_1/model.sdf
@@ -2307,6 +2307,39 @@
         </surface>
       </collision>
     </link>
+    <joint name="right_track_j" type="revolute">
+      <pose relative_to="base_link">0 -0.1985 0 0 -0 0</pose>
+      <parent>base_link</parent>
+      <child>right_track</child>
+      <axis>
+        <xyz>0 1 0</xyz>
+        <limit>
+          <lower>0</lower>
+          <upper>0</upper>
+          <effort>0</effort>
+          <velocity>4</velocity>
+        </limit>
+        <dynamics>
+          <spring_reference>0</spring_reference>
+          <spring_stiffness>0</spring_stiffness>
+        </dynamics>
+      </axis>
+      <physics>
+        <ode>
+          <limit>
+            <cfm>0</cfm>
+            <erp>0.2</erp>
+          </limit>
+        </ode>
+      </physics>
+      <physics>
+        <ode>
+          <implicit_spring_damper>1</implicit_spring_damper>
+          <cfm>0</cfm>
+          <erp>0.95</erp>
+        </ode>
+      </physics>
+    </joint>
     <link name="right_track">
       <pose relative_to="right_track_j">0 0 0 0 -0 0</pose>
       <inertial>
@@ -2345,39 +2378,6 @@
         </geometry>
       </visual>
     </link>
-    <joint name="right_track_j" type="revolute">
-      <pose relative_to="base_link">0 -0.1985 0 0 -0 0</pose>
-      <parent>base_link</parent>
-      <child>right_track</child>
-      <axis>
-        <xyz>0 1 0</xyz>
-        <limit>
-          <lower>0</lower>
-          <upper>0</upper>
-          <effort>0</effort>
-          <velocity>4</velocity>
-        </limit>
-        <dynamics>
-          <spring_reference>0</spring_reference>
-          <spring_stiffness>0</spring_stiffness>
-        </dynamics>
-      </axis>
-      <physics>
-        <ode>
-          <limit>
-            <cfm>0</cfm>
-            <erp>0.2</erp>
-          </limit>
-        </ode>
-      </physics>
-      <physics>
-        <ode>
-          <implicit_spring_damper>1</implicit_spring_damper>
-          <cfm>0</cfm>
-          <erp>0.95</erp>
-        </ode>
-      </physics>
-    </joint>
     <link name="front_right_flipper">
       <pose relative_to="front_right_flipper_j">0 0 0 0 -0 0</pose>
       <inertial>

--- a/submitted_models/ctu_cras_norlab_absolem_sensor_config_1/model.sdf
+++ b/submitted_models/ctu_cras_norlab_absolem_sensor_config_1/model.sdf
@@ -2615,6 +2615,22 @@
         </surface>
       </collision>
     </link>
+    <joint name="front_right_flipper_wheel4_j" type="revolute">
+      <pose relative_to="front_right_flipper">-0.2475 0 0 0 -0 0</pose>
+      <parent>front_right_flipper</parent>
+      <child>front_right_flipper_wheel4</child>
+      <axis>
+        <xyz>0 1 0</xyz>
+        <limit>
+          <lower>-1e+16</lower>
+          <upper>1e+16</upper>
+        </limit>
+        <dynamics>
+          <spring_reference>0</spring_reference>
+          <spring_stiffness>0</spring_stiffness>
+        </dynamics>
+      </axis>
+    </joint>
     <link name="front_right_flipper_wheel4">
       <pose relative_to="front_right_flipper_wheel4_j">0 0 0 0 -0 0</pose>
       <inertial>
@@ -2656,22 +2672,6 @@
         </surface>
       </collision>
     </link>
-    <joint name="front_right_flipper_wheel4_j" type="revolute">
-      <pose relative_to="front_right_flipper">-0.2475 0 0 0 -0 0</pose>
-      <parent>front_right_flipper</parent>
-      <child>front_right_flipper_wheel4</child>
-      <axis>
-        <xyz>0 1 0</xyz>
-        <limit>
-          <lower>-1e+16</lower>
-          <upper>1e+16</upper>
-        </limit>
-        <dynamics>
-          <spring_reference>0</spring_reference>
-          <spring_stiffness>0</spring_stiffness>
-        </dynamics>
-      </axis>
-    </joint>
     <link name="front_right_flipper_wheel5">
       <pose relative_to="front_right_flipper_wheel5_j">0 0 0 0 -0 0</pose>
       <inertial>

--- a/submitted_models/ctu_cras_norlab_absolem_sensor_config_1/model.sdf
+++ b/submitted_models/ctu_cras_norlab_absolem_sensor_config_1/model.sdf
@@ -1149,6 +1149,34 @@
         </geometry>
       </visual>
     </link>
+    <joint name="front_left_flipper_j" type="revolute">
+      <pose relative_to="left_track">0.25 0.0735 0.0195 0 0.193732 0</pose>
+      <parent>left_track</parent>
+      <child>front_left_flipper</child>
+      <axis>
+        <xyz>0 1 0</xyz>
+        <limit>
+          <lower>-1e+16</lower>
+          <upper>1e+16</upper>
+          <effort>20</effort>
+          <velocity>0.785398</velocity>
+        </limit>
+        <dynamics>
+          <spring_reference>0</spring_reference>
+          <spring_stiffness>0</spring_stiffness>
+        </dynamics>
+      </axis>
+      <physics>
+        <ode>
+          <implicit_spring_damper>1</implicit_spring_damper>
+          <cfm_damping>1</cfm_damping>
+          <limit>
+            <cfm>0</cfm>
+            <erp>0.2</erp>
+          </limit>
+        </ode>
+      </physics>
+    </joint>
     <link name="front_left_flipper">
       <pose relative_to="front_left_flipper_j">0 0 0 0 -0 0</pose>
       <inertial>
@@ -1187,34 +1215,6 @@
         </geometry>
       </visual>
     </link>
-    <joint name="front_left_flipper_j" type="revolute">
-      <pose relative_to="left_track">0.25 0.0735 0.0195 0 0.193732 0</pose>
-      <parent>left_track</parent>
-      <child>front_left_flipper</child>
-      <axis>
-        <xyz>0 1 0</xyz>
-        <limit>
-          <lower>-1e+16</lower>
-          <upper>1e+16</upper>
-          <effort>20</effort>
-          <velocity>0.785398</velocity>
-        </limit>
-        <dynamics>
-          <spring_reference>0</spring_reference>
-          <spring_stiffness>0</spring_stiffness>
-        </dynamics>
-      </axis>
-      <physics>
-        <ode>
-          <implicit_spring_damper>1</implicit_spring_damper>
-          <cfm_damping>1</cfm_damping>
-          <limit>
-            <cfm>0</cfm>
-            <erp>0.2</erp>
-          </limit>
-        </ode>
-      </physics>
-    </joint>
     <link name="front_left_flipper_wheel1">
       <pose relative_to="front_left_flipper_wheel1_j">0 0 0 0 -0 0</pose>
       <inertial>

--- a/submitted_models/ctu_cras_norlab_absolem_sensor_config_1/model.sdf
+++ b/submitted_models/ctu_cras_norlab_absolem_sensor_config_1/model.sdf
@@ -2444,6 +2444,22 @@
         </geometry>
       </visual>
     </link>
+    <joint name="front_right_flipper_wheel1_j" type="revolute">
+      <pose relative_to="front_right_flipper">0 0 0 0 -0 0</pose>
+      <parent>front_right_flipper</parent>
+      <child>front_right_flipper_wheel1</child>
+      <axis>
+        <xyz>0 1 0</xyz>
+        <limit>
+          <lower>-1e+16</lower>
+          <upper>1e+16</upper>
+        </limit>
+        <dynamics>
+          <spring_reference>0</spring_reference>
+          <spring_stiffness>0</spring_stiffness>
+        </dynamics>
+      </axis>
+    </joint>
     <link name="front_right_flipper_wheel1">
       <pose relative_to="front_right_flipper_wheel1_j">0 0 0 0 -0 0</pose>
       <inertial>
@@ -2485,22 +2501,6 @@
         </surface>
       </collision>
     </link>
-    <joint name="front_right_flipper_wheel1_j" type="revolute">
-      <pose relative_to="front_right_flipper">0 0 0 0 -0 0</pose>
-      <parent>front_right_flipper</parent>
-      <child>front_right_flipper_wheel1</child>
-      <axis>
-        <xyz>0 1 0</xyz>
-        <limit>
-          <lower>-1e+16</lower>
-          <upper>1e+16</upper>
-        </limit>
-        <dynamics>
-          <spring_reference>0</spring_reference>
-          <spring_stiffness>0</spring_stiffness>
-        </dynamics>
-      </axis>
-    </joint>
     <link name="front_right_flipper_wheel2">
       <pose relative_to="front_right_flipper_wheel2_j">0 0 0 0 -0 0</pose>
       <inertial>

--- a/submitted_models/ctu_cras_norlab_absolem_sensor_config_1/model.sdf
+++ b/submitted_models/ctu_cras_norlab_absolem_sensor_config_1/model.sdf
@@ -397,7 +397,7 @@
         </geometry>
       </visual>
       <visual name="base_link_fixed_joint_lump__camera_5_sim_visual_23">
-        <pose>0.024083 -0.058382 0.376328 3.1415926535897931 -1.5707963267948966 0.945143</pose>
+        <pose>0.024083 -0.058382 0.376328 -2.19645 -1.5707963267948966 0</pose>
         <geometry>
           <box>
             <size>0.005 0.005 0.005</size>

--- a/submitted_models/ctu_cras_norlab_absolem_sensor_config_1/model.sdf
+++ b/submitted_models/ctu_cras_norlab_absolem_sensor_config_1/model.sdf
@@ -2795,6 +2795,22 @@
         </geometry>
       </visual>
     </link>
+    <joint name="rear_right_flipper_wheel1_j" type="revolute">
+      <pose relative_to="rear_right_flipper">0 0 0 0 -0 0</pose>
+      <parent>rear_right_flipper</parent>
+      <child>rear_right_flipper_wheel1</child>
+      <axis>
+        <xyz>0 1 0</xyz>
+        <limit>
+          <lower>-1e+16</lower>
+          <upper>1e+16</upper>
+        </limit>
+        <dynamics>
+          <spring_reference>0</spring_reference>
+          <spring_stiffness>0</spring_stiffness>
+        </dynamics>
+      </axis>
+    </joint>
     <link name="rear_right_flipper_wheel1">
       <pose relative_to="rear_right_flipper_wheel1_j">0 0 0 0 -0 0</pose>
       <inertial>
@@ -2836,22 +2852,6 @@
         </surface>
       </collision>
     </link>
-    <joint name="rear_right_flipper_wheel1_j" type="revolute">
-      <pose relative_to="rear_right_flipper">0 0 0 0 -0 0</pose>
-      <parent>rear_right_flipper</parent>
-      <child>rear_right_flipper_wheel1</child>
-      <axis>
-        <xyz>0 1 0</xyz>
-        <limit>
-          <lower>-1e+16</lower>
-          <upper>1e+16</upper>
-        </limit>
-        <dynamics>
-          <spring_reference>0</spring_reference>
-          <spring_stiffness>0</spring_stiffness>
-        </dynamics>
-      </axis>
-    </joint>
     <link name="rear_right_flipper_wheel2">
       <pose relative_to="rear_right_flipper_wheel2_j">0 0 0 0 -0 0</pose>
       <inertial>

--- a/submitted_models/ctu_cras_norlab_absolem_sensor_config_1/model.sdf
+++ b/submitted_models/ctu_cras_norlab_absolem_sensor_config_1/model.sdf
@@ -997,8 +997,8 @@
     </link>
     <joint name="laser_j" type="revolute">
       <pose relative_to="base_link">0.2502 0 0.1407 -3.1415926535897931 0 0</pose>
-      <child>laser</child>
       <parent>base_link</parent>
+      <child>laser</child>
       <axis>
         <xyz>1 0 0</xyz>
         <limit>
@@ -1118,8 +1118,8 @@
     </link>
     <joint name="left_track_j" type="revolute">
       <pose relative_to="base_link">0 0.1985 0 0 -0 0</pose>
-      <child>left_track</child>
       <parent>base_link</parent>
+      <child>left_track</child>
       <axis>
         <xyz>0 1 0</xyz>
         <limit>
@@ -1189,8 +1189,8 @@
     </link>
     <joint name="front_left_flipper_j" type="revolute">
       <pose relative_to="left_track">0.25 0.0735 0.0195 0 0.193732 0</pose>
-      <child>front_left_flipper</child>
       <parent>left_track</parent>
+      <child>front_left_flipper</child>
       <axis>
         <xyz>0 1 0</xyz>
         <limit>
@@ -1258,8 +1258,8 @@
     </link>
     <joint name="front_left_flipper_wheel1_j" type="revolute">
       <pose relative_to="front_left_flipper">0 0 0 0 -0 0</pose>
-      <child>front_left_flipper_wheel1</child>
       <parent>front_left_flipper</parent>
+      <child>front_left_flipper_wheel1</child>
       <axis>
         <xyz>0 1 0</xyz>
         <limit>
@@ -1315,8 +1315,8 @@
     </link>
     <joint name="front_left_flipper_wheel2_j" type="revolute">
       <pose relative_to="front_left_flipper">0.0825 0 0 0 -0 0</pose>
-      <child>front_left_flipper_wheel2</child>
       <parent>front_left_flipper</parent>
+      <child>front_left_flipper_wheel2</child>
       <axis>
         <xyz>0 1 0</xyz>
         <limit>
@@ -1372,8 +1372,8 @@
     </link>
     <joint name="front_left_flipper_wheel3_j" type="revolute">
       <pose relative_to="front_left_flipper">0.165 0 0 0 -0 0</pose>
-      <child>front_left_flipper_wheel3</child>
       <parent>front_left_flipper</parent>
+      <child>front_left_flipper_wheel3</child>
       <axis>
         <xyz>0 1 0</xyz>
         <limit>
@@ -1429,8 +1429,8 @@
     </link>
     <joint name="front_left_flipper_wheel4_j" type="revolute">
       <pose relative_to="front_left_flipper">0.2475 0 0 0 -0 0</pose>
-      <child>front_left_flipper_wheel4</child>
       <parent>front_left_flipper</parent>
+      <child>front_left_flipper_wheel4</child>
       <axis>
         <xyz>0 1 0</xyz>
         <limit>
@@ -1486,8 +1486,8 @@
     </link>
     <joint name="front_left_flipper_wheel5_j" type="revolute">
       <pose relative_to="front_left_flipper">0.33 0 0 0 -0 0</pose>
-      <child>front_left_flipper_wheel5</child>
       <parent>front_left_flipper</parent>
+      <child>front_left_flipper_wheel5</child>
       <axis>
         <xyz>0 1 0</xyz>
         <limit>
@@ -1543,8 +1543,8 @@
     </link>
     <joint name="left_track_wheel1_j" type="revolute">
       <pose relative_to="left_track">0.25 0 0.01855 0 -0 0</pose>
-      <child>left_track_wheel1</child>
       <parent>left_track</parent>
+      <child>left_track_wheel1</child>
       <axis>
         <xyz>0 1 0</xyz>
         <limit>
@@ -1600,8 +1600,8 @@
     </link>
     <joint name="left_track_wheel2_j" type="revolute">
       <pose relative_to="left_track">0.178571 0 0.01855 0 -0 0</pose>
-      <child>left_track_wheel2</child>
       <parent>left_track</parent>
+      <child>left_track_wheel2</child>
       <axis>
         <xyz>0 1 0</xyz>
         <limit>
@@ -1657,8 +1657,8 @@
     </link>
     <joint name="left_track_wheel3_j" type="revolute">
       <pose relative_to="left_track">0.107143 0 0.01855 0 -0 0</pose>
-      <child>left_track_wheel3</child>
       <parent>left_track</parent>
+      <child>left_track_wheel3</child>
       <axis>
         <xyz>0 1 0</xyz>
         <limit>
@@ -1714,8 +1714,8 @@
     </link>
     <joint name="left_track_wheel4_j" type="revolute">
       <pose relative_to="left_track">0.035714 0 0.01855 0 -0 0</pose>
-      <child>left_track_wheel4</child>
       <parent>left_track</parent>
+      <child>left_track_wheel4</child>
       <axis>
         <xyz>0 1 0</xyz>
         <limit>
@@ -1771,8 +1771,8 @@
     </link>
     <joint name="left_track_wheel5_j" type="revolute">
       <pose relative_to="left_track">-0.035714 0 0.01855 0 -0 0</pose>
-      <child>left_track_wheel5</child>
       <parent>left_track</parent>
+      <child>left_track_wheel5</child>
       <axis>
         <xyz>0 1 0</xyz>
         <limit>
@@ -1828,8 +1828,8 @@
     </link>
     <joint name="left_track_wheel6_j" type="revolute">
       <pose relative_to="left_track">-0.107143 0 0.01855 0 -0 0</pose>
-      <child>left_track_wheel6</child>
       <parent>left_track</parent>
+      <child>left_track_wheel6</child>
       <axis>
         <xyz>0 1 0</xyz>
         <limit>
@@ -1885,8 +1885,8 @@
     </link>
     <joint name="left_track_wheel7_j" type="revolute">
       <pose relative_to="left_track">-0.178571 0 0.01855 0 -0 0</pose>
-      <child>left_track_wheel7</child>
       <parent>left_track</parent>
+      <child>left_track_wheel7</child>
       <axis>
         <xyz>0 1 0</xyz>
         <limit>
@@ -1942,8 +1942,8 @@
     </link>
     <joint name="left_track_wheel8_j" type="revolute">
       <pose relative_to="left_track">-0.25 0 0.01855 0 -0 0</pose>
-      <child>left_track_wheel8</child>
       <parent>left_track</parent>
+      <child>left_track_wheel8</child>
       <axis>
         <xyz>0 1 0</xyz>
         <limit>
@@ -1996,8 +1996,8 @@
     </link>
     <joint name="rear_left_flipper_j" type="revolute">
       <pose relative_to="left_track">-0.25 0.0735 0.0195 3.1415926535897931 0.193732 3.1415926535897931</pose>
-      <child>rear_left_flipper</child>
       <parent>left_track</parent>
+      <child>rear_left_flipper</child>
       <axis>
         <xyz>0 1 0</xyz>
         <limit>
@@ -2065,8 +2065,8 @@
     </link>
     <joint name="rear_left_flipper_wheel1_j" type="revolute">
       <pose relative_to="rear_left_flipper">0 0 0 0 -0 0</pose>
-      <child>rear_left_flipper_wheel1</child>
       <parent>rear_left_flipper</parent>
+      <child>rear_left_flipper_wheel1</child>
       <axis>
         <xyz>0 1 0</xyz>
         <limit>
@@ -2122,8 +2122,8 @@
     </link>
     <joint name="rear_left_flipper_wheel2_j" type="revolute">
       <pose relative_to="rear_left_flipper">0.0825 0 0 0 -0 0</pose>
-      <child>rear_left_flipper_wheel2</child>
       <parent>rear_left_flipper</parent>
+      <child>rear_left_flipper_wheel2</child>
       <axis>
         <xyz>0 1 0</xyz>
         <limit>
@@ -2179,8 +2179,8 @@
     </link>
     <joint name="rear_left_flipper_wheel3_j" type="revolute">
       <pose relative_to="rear_left_flipper">0.165 0 0 0 -0 0</pose>
-      <child>rear_left_flipper_wheel3</child>
       <parent>rear_left_flipper</parent>
+      <child>rear_left_flipper_wheel3</child>
       <axis>
         <xyz>0 1 0</xyz>
         <limit>
@@ -2236,8 +2236,8 @@
     </link>
     <joint name="rear_left_flipper_wheel4_j" type="revolute">
       <pose relative_to="rear_left_flipper">0.2475 0 0 0 -0 0</pose>
-      <child>rear_left_flipper_wheel4</child>
       <parent>rear_left_flipper</parent>
+      <child>rear_left_flipper_wheel4</child>
       <axis>
         <xyz>0 1 0</xyz>
         <limit>
@@ -2293,8 +2293,8 @@
     </link>
     <joint name="rear_left_flipper_wheel5_j" type="revolute">
       <pose relative_to="rear_left_flipper">0.33 0 0 0 -0 0</pose>
-      <child>rear_left_flipper_wheel5</child>
       <parent>rear_left_flipper</parent>
+      <child>rear_left_flipper_wheel5</child>
       <axis>
         <xyz>0 1 0</xyz>
         <limit>
@@ -2347,8 +2347,8 @@
     </link>
     <joint name="right_track_j" type="revolute">
       <pose relative_to="base_link">0 -0.1985 0 0 -0 0</pose>
-      <child>right_track</child>
       <parent>base_link</parent>
+      <child>right_track</child>
       <axis>
         <xyz>0 1 0</xyz>
         <limit>
@@ -2418,8 +2418,8 @@
     </link>
     <joint name="front_right_flipper_j" type="revolute">
       <pose relative_to="right_track">0.25 -0.0735 0.0195 3.1415926535897931 -0.193732 3.1415926535897931</pose>
-      <child>front_right_flipper</child>
       <parent>right_track</parent>
+      <child>front_right_flipper</child>
       <axis>
         <xyz>0 1 0</xyz>
         <limit>
@@ -2487,8 +2487,8 @@
     </link>
     <joint name="front_right_flipper_wheel1_j" type="revolute">
       <pose relative_to="front_right_flipper">0 0 0 0 -0 0</pose>
-      <child>front_right_flipper_wheel1</child>
       <parent>front_right_flipper</parent>
+      <child>front_right_flipper_wheel1</child>
       <axis>
         <xyz>0 1 0</xyz>
         <limit>
@@ -2544,8 +2544,8 @@
     </link>
     <joint name="front_right_flipper_wheel2_j" type="revolute">
       <pose relative_to="front_right_flipper">-0.0825 0 0 0 -0 0</pose>
-      <child>front_right_flipper_wheel2</child>
       <parent>front_right_flipper</parent>
+      <child>front_right_flipper_wheel2</child>
       <axis>
         <xyz>0 1 0</xyz>
         <limit>
@@ -2601,8 +2601,8 @@
     </link>
     <joint name="front_right_flipper_wheel3_j" type="revolute">
       <pose relative_to="front_right_flipper">-0.165 0 0 0 -0 0</pose>
-      <child>front_right_flipper_wheel3</child>
       <parent>front_right_flipper</parent>
+      <child>front_right_flipper_wheel3</child>
       <axis>
         <xyz>0 1 0</xyz>
         <limit>
@@ -2658,8 +2658,8 @@
     </link>
     <joint name="front_right_flipper_wheel4_j" type="revolute">
       <pose relative_to="front_right_flipper">-0.2475 0 0 0 -0 0</pose>
-      <child>front_right_flipper_wheel4</child>
       <parent>front_right_flipper</parent>
+      <child>front_right_flipper_wheel4</child>
       <axis>
         <xyz>0 1 0</xyz>
         <limit>
@@ -2715,8 +2715,8 @@
     </link>
     <joint name="front_right_flipper_wheel5_j" type="revolute">
       <pose relative_to="front_right_flipper">-0.33 0 0 0 -0 0</pose>
-      <child>front_right_flipper_wheel5</child>
       <parent>front_right_flipper</parent>
+      <child>front_right_flipper_wheel5</child>
       <axis>
         <xyz>0 1 0</xyz>
         <limit>
@@ -2769,8 +2769,8 @@
     </link>
     <joint name="rear_right_flipper_j" type="revolute">
       <pose relative_to="right_track">-0.25 -0.0735 0.0195 0 -0.193732 0</pose>
-      <child>rear_right_flipper</child>
       <parent>right_track</parent>
+      <child>rear_right_flipper</child>
       <axis>
         <xyz>0 1 0</xyz>
         <limit>
@@ -2838,8 +2838,8 @@
     </link>
     <joint name="rear_right_flipper_wheel1_j" type="revolute">
       <pose relative_to="rear_right_flipper">0 0 0 0 -0 0</pose>
-      <child>rear_right_flipper_wheel1</child>
       <parent>rear_right_flipper</parent>
+      <child>rear_right_flipper_wheel1</child>
       <axis>
         <xyz>0 1 0</xyz>
         <limit>
@@ -2895,8 +2895,8 @@
     </link>
     <joint name="rear_right_flipper_wheel2_j" type="revolute">
       <pose relative_to="rear_right_flipper">-0.0825 0 0 0 -0 0</pose>
-      <child>rear_right_flipper_wheel2</child>
       <parent>rear_right_flipper</parent>
+      <child>rear_right_flipper_wheel2</child>
       <axis>
         <xyz>0 1 0</xyz>
         <limit>
@@ -2952,8 +2952,8 @@
     </link>
     <joint name="rear_right_flipper_wheel3_j" type="revolute">
       <pose relative_to="rear_right_flipper">-0.165 0 0 0 -0 0</pose>
-      <child>rear_right_flipper_wheel3</child>
       <parent>rear_right_flipper</parent>
+      <child>rear_right_flipper_wheel3</child>
       <axis>
         <xyz>0 1 0</xyz>
         <limit>
@@ -3009,8 +3009,8 @@
     </link>
     <joint name="rear_right_flipper_wheel4_j" type="revolute">
       <pose relative_to="rear_right_flipper">-0.2475 0 0 0 -0 0</pose>
-      <child>rear_right_flipper_wheel4</child>
       <parent>rear_right_flipper</parent>
+      <child>rear_right_flipper_wheel4</child>
       <axis>
         <xyz>0 1 0</xyz>
         <limit>
@@ -3066,8 +3066,8 @@
     </link>
     <joint name="rear_right_flipper_wheel5_j" type="revolute">
       <pose relative_to="rear_right_flipper">-0.33 0 0 0 -0 0</pose>
-      <child>rear_right_flipper_wheel5</child>
       <parent>rear_right_flipper</parent>
+      <child>rear_right_flipper_wheel5</child>
       <axis>
         <xyz>0 1 0</xyz>
         <limit>
@@ -3123,8 +3123,8 @@
     </link>
     <joint name="right_track_wheel1_j" type="revolute">
       <pose relative_to="right_track">0.25 0 0.01855 0 -0 0</pose>
-      <child>right_track_wheel1</child>
       <parent>right_track</parent>
+      <child>right_track_wheel1</child>
       <axis>
         <xyz>0 1 0</xyz>
         <limit>
@@ -3180,8 +3180,8 @@
     </link>
     <joint name="right_track_wheel2_j" type="revolute">
       <pose relative_to="right_track">0.178571 0 0.01855 0 -0 0</pose>
-      <child>right_track_wheel2</child>
       <parent>right_track</parent>
+      <child>right_track_wheel2</child>
       <axis>
         <xyz>0 1 0</xyz>
         <limit>
@@ -3237,8 +3237,8 @@
     </link>
     <joint name="right_track_wheel3_j" type="revolute">
       <pose relative_to="right_track">0.107143 0 0.01855 0 -0 0</pose>
-      <child>right_track_wheel3</child>
       <parent>right_track</parent>
+      <child>right_track_wheel3</child>
       <axis>
         <xyz>0 1 0</xyz>
         <limit>
@@ -3294,8 +3294,8 @@
     </link>
     <joint name="right_track_wheel4_j" type="revolute">
       <pose relative_to="right_track">0.035714 0 0.01855 0 -0 0</pose>
-      <child>right_track_wheel4</child>
       <parent>right_track</parent>
+      <child>right_track_wheel4</child>
       <axis>
         <xyz>0 1 0</xyz>
         <limit>
@@ -3351,8 +3351,8 @@
     </link>
     <joint name="right_track_wheel5_j" type="revolute">
       <pose relative_to="right_track">-0.035714 0 0.01855 0 -0 0</pose>
-      <child>right_track_wheel5</child>
       <parent>right_track</parent>
+      <child>right_track_wheel5</child>
       <axis>
         <xyz>0 1 0</xyz>
         <limit>
@@ -3408,8 +3408,8 @@
     </link>
     <joint name="right_track_wheel6_j" type="revolute">
       <pose relative_to="right_track">-0.107143 0 0.01855 0 -0 0</pose>
-      <child>right_track_wheel6</child>
       <parent>right_track</parent>
+      <child>right_track_wheel6</child>
       <axis>
         <xyz>0 1 0</xyz>
         <limit>
@@ -3465,8 +3465,8 @@
     </link>
     <joint name="right_track_wheel7_j" type="revolute">
       <pose relative_to="right_track">-0.178571 0 0.01855 0 -0 0</pose>
-      <child>right_track_wheel7</child>
       <parent>right_track</parent>
+      <child>right_track_wheel7</child>
       <axis>
         <xyz>0 1 0</xyz>
         <limit>
@@ -3522,8 +3522,8 @@
     </link>
     <joint name="right_track_wheel8_j" type="revolute">
       <pose relative_to="right_track">-0.25 0 0.01855 0 -0 0</pose>
-      <child>right_track_wheel8</child>
       <parent>right_track</parent>
+      <child>right_track_wheel8</child>
       <axis>
         <xyz>0 1 0</xyz>
         <limit>

--- a/submitted_models/ctu_cras_norlab_absolem_sensor_config_1/model.sdf
+++ b/submitted_models/ctu_cras_norlab_absolem_sensor_config_1/model.sdf
@@ -2136,6 +2136,22 @@
         </surface>
       </collision>
     </link>
+    <joint name="rear_left_flipper_wheel3_j" type="revolute">
+      <pose relative_to="rear_left_flipper">0.165 0 0 0 -0 0</pose>
+      <parent>rear_left_flipper</parent>
+      <child>rear_left_flipper_wheel3</child>
+      <axis>
+        <xyz>0 1 0</xyz>
+        <limit>
+          <lower>-1e+16</lower>
+          <upper>1e+16</upper>
+        </limit>
+        <dynamics>
+          <spring_reference>0</spring_reference>
+          <spring_stiffness>0</spring_stiffness>
+        </dynamics>
+      </axis>
+    </joint>
     <link name="rear_left_flipper_wheel3">
       <pose relative_to="rear_left_flipper_wheel3_j">0 0 0 0 -0 0</pose>
       <inertial>
@@ -2177,22 +2193,6 @@
         </surface>
       </collision>
     </link>
-    <joint name="rear_left_flipper_wheel3_j" type="revolute">
-      <pose relative_to="rear_left_flipper">0.165 0 0 0 -0 0</pose>
-      <parent>rear_left_flipper</parent>
-      <child>rear_left_flipper_wheel3</child>
-      <axis>
-        <xyz>0 1 0</xyz>
-        <limit>
-          <lower>-1e+16</lower>
-          <upper>1e+16</upper>
-        </limit>
-        <dynamics>
-          <spring_reference>0</spring_reference>
-          <spring_stiffness>0</spring_stiffness>
-        </dynamics>
-      </axis>
-    </joint>
     <link name="rear_left_flipper_wheel4">
       <pose relative_to="rear_left_flipper_wheel4_j">0 0 0 0 -0 0</pose>
       <inertial>

--- a/submitted_models/ctu_cras_norlab_absolem_sensor_config_1/model.sdf
+++ b/submitted_models/ctu_cras_norlab_absolem_sensor_config_1/model.sdf
@@ -3023,6 +3023,22 @@
         </surface>
       </collision>
     </link>
+    <joint name="rear_right_flipper_wheel5_j" type="revolute">
+      <pose relative_to="rear_right_flipper">-0.33 0 0 0 -0 0</pose>
+      <parent>rear_right_flipper</parent>
+      <child>rear_right_flipper_wheel5</child>
+      <axis>
+        <xyz>0 1 0</xyz>
+        <limit>
+          <lower>-1e+16</lower>
+          <upper>1e+16</upper>
+        </limit>
+        <dynamics>
+          <spring_reference>0</spring_reference>
+          <spring_stiffness>0</spring_stiffness>
+        </dynamics>
+      </axis>
+    </joint>
     <link name="rear_right_flipper_wheel5">
       <pose relative_to="rear_right_flipper_wheel5_j">0 0 0 0 -0 0</pose>
       <inertial>
@@ -3064,22 +3080,6 @@
         </surface>
       </collision>
     </link>
-    <joint name="rear_right_flipper_wheel5_j" type="revolute">
-      <pose relative_to="rear_right_flipper">-0.33 0 0 0 -0 0</pose>
-      <parent>rear_right_flipper</parent>
-      <child>rear_right_flipper_wheel5</child>
-      <axis>
-        <xyz>0 1 0</xyz>
-        <limit>
-          <lower>-1e+16</lower>
-          <upper>1e+16</upper>
-        </limit>
-        <dynamics>
-          <spring_reference>0</spring_reference>
-          <spring_stiffness>0</spring_stiffness>
-        </dynamics>
-      </axis>
-    </joint>
     <link name="right_track_wheel1">
       <pose relative_to="right_track_wheel1_j">0 0 0 0 -0 0</pose>
       <inertial>

--- a/submitted_models/ctu_cras_norlab_absolem_sensor_config_1/model.sdf
+++ b/submitted_models/ctu_cras_norlab_absolem_sensor_config_1/model.sdf
@@ -2672,6 +2672,22 @@
         </surface>
       </collision>
     </link>
+    <joint name="front_right_flipper_wheel5_j" type="revolute">
+      <pose relative_to="front_right_flipper">-0.33 0 0 0 -0 0</pose>
+      <parent>front_right_flipper</parent>
+      <child>front_right_flipper_wheel5</child>
+      <axis>
+        <xyz>0 1 0</xyz>
+        <limit>
+          <lower>-1e+16</lower>
+          <upper>1e+16</upper>
+        </limit>
+        <dynamics>
+          <spring_reference>0</spring_reference>
+          <spring_stiffness>0</spring_stiffness>
+        </dynamics>
+      </axis>
+    </joint>
     <link name="front_right_flipper_wheel5">
       <pose relative_to="front_right_flipper_wheel5_j">0 0 0 0 -0 0</pose>
       <inertial>
@@ -2713,22 +2729,6 @@
         </surface>
       </collision>
     </link>
-    <joint name="front_right_flipper_wheel5_j" type="revolute">
-      <pose relative_to="front_right_flipper">-0.33 0 0 0 -0 0</pose>
-      <parent>front_right_flipper</parent>
-      <child>front_right_flipper_wheel5</child>
-      <axis>
-        <xyz>0 1 0</xyz>
-        <limit>
-          <lower>-1e+16</lower>
-          <upper>1e+16</upper>
-        </limit>
-        <dynamics>
-          <spring_reference>0</spring_reference>
-          <spring_stiffness>0</spring_stiffness>
-        </dynamics>
-      </axis>
-    </joint>
     <link name="rear_right_flipper">
       <pose relative_to="rear_right_flipper_j">0 0 0 0 -0 0</pose>
       <inertial>

--- a/submitted_models/ctu_cras_norlab_absolem_sensor_config_1/model.sdf
+++ b/submitted_models/ctu_cras_norlab_absolem_sensor_config_1/model.sdf
@@ -3251,6 +3251,22 @@
         </surface>
       </collision>
     </link>
+    <joint name="right_track_wheel4_j" type="revolute">
+      <pose relative_to="right_track">0.035714 0 0.01855 0 -0 0</pose>
+      <parent>right_track</parent>
+      <child>right_track_wheel4</child>
+      <axis>
+        <xyz>0 1 0</xyz>
+        <limit>
+          <lower>-1e+16</lower>
+          <upper>1e+16</upper>
+        </limit>
+        <dynamics>
+          <spring_reference>0</spring_reference>
+          <spring_stiffness>0</spring_stiffness>
+        </dynamics>
+      </axis>
+    </joint>
     <link name="right_track_wheel4">
       <pose relative_to="right_track_wheel4_j">0 0 0 0 -0 0</pose>
       <inertial>
@@ -3292,22 +3308,6 @@
         </surface>
       </collision>
     </link>
-    <joint name="right_track_wheel4_j" type="revolute">
-      <pose relative_to="right_track">0.035714 0 0.01855 0 -0 0</pose>
-      <parent>right_track</parent>
-      <child>right_track_wheel4</child>
-      <axis>
-        <xyz>0 1 0</xyz>
-        <limit>
-          <lower>-1e+16</lower>
-          <upper>1e+16</upper>
-        </limit>
-        <dynamics>
-          <spring_reference>0</spring_reference>
-          <spring_stiffness>0</spring_stiffness>
-        </dynamics>
-      </axis>
-    </joint>
     <link name="right_track_wheel5">
       <pose relative_to="right_track_wheel5_j">0 0 0 0 -0 0</pose>
       <inertial>

--- a/submitted_models/ctu_cras_norlab_absolem_sensor_config_1/model.sdf
+++ b/submitted_models/ctu_cras_norlab_absolem_sensor_config_1/model.sdf
@@ -1272,6 +1272,22 @@
         </surface>
       </collision>
     </link>
+    <joint name="front_left_flipper_wheel2_j" type="revolute">
+      <pose relative_to="front_left_flipper">0.0825 0 0 0 -0 0</pose>
+      <parent>front_left_flipper</parent>
+      <child>front_left_flipper_wheel2</child>
+      <axis>
+        <xyz>0 1 0</xyz>
+        <limit>
+          <lower>-1e+16</lower>
+          <upper>1e+16</upper>
+        </limit>
+        <dynamics>
+          <spring_reference>0</spring_reference>
+          <spring_stiffness>0</spring_stiffness>
+        </dynamics>
+      </axis>
+    </joint>
     <link name="front_left_flipper_wheel2">
       <pose relative_to="front_left_flipper_wheel2_j">0 0 0 0 -0 0</pose>
       <inertial>
@@ -1313,22 +1329,6 @@
         </surface>
       </collision>
     </link>
-    <joint name="front_left_flipper_wheel2_j" type="revolute">
-      <pose relative_to="front_left_flipper">0.0825 0 0 0 -0 0</pose>
-      <parent>front_left_flipper</parent>
-      <child>front_left_flipper_wheel2</child>
-      <axis>
-        <xyz>0 1 0</xyz>
-        <limit>
-          <lower>-1e+16</lower>
-          <upper>1e+16</upper>
-        </limit>
-        <dynamics>
-          <spring_reference>0</spring_reference>
-          <spring_stiffness>0</spring_stiffness>
-        </dynamics>
-      </axis>
-    </joint>
     <link name="front_left_flipper_wheel3">
       <pose relative_to="front_left_flipper_wheel3_j">0 0 0 0 -0 0</pose>
       <inertial>

--- a/submitted_models/ctu_cras_norlab_absolem_sensor_config_1/urdf/nifti_robot.xacro
+++ b/submitted_models/ctu_cras_norlab_absolem_sensor_config_1/urdf/nifti_robot.xacro
@@ -1386,6 +1386,13 @@
 										</intrinsics>
 								</lens>
 						</camera>
+						<!-- Until https://github.com/osrf/sdformat/pull/525 gets merged, we work around the camera positions like this -->
+						<xacro:if value="${num == 0}"><pose>0.057346 -0.083518 0.313841 -0.000948 -0.000784 -2.19802</pose></xacro:if>
+						<xacro:if value="${num == 1}"><pose>0.009992 -0.096606 0.314114 -0.001069 0.000853 2.82791</pose></xacro:if>
+						<xacro:if value="${num == 2}"><pose>-0.01735 -0.055429 0.314721 -0.001705 0.00415 1.56975</pose></xacro:if>
+						<xacro:if value="${num == 3}"><pose>0.012561 -0.017068 0.314417 -0.000579 0.005611 0.313689</pose></xacro:if>
+						<xacro:if value="${num == 4}"><pose>0.058951 -0.03438 0.313899 -0.010815 0.001034 -0.943109</pose></xacro:if>
+						<xacro:if value="${num == 5}"><pose>0.024083 -0.058382 0.376328 3.1415926535897931 -1.5707963267948966 0.945143</pose></xacro:if>
 					</sensor>
 				</gazebo>
     </xacro:macro>
@@ -1639,6 +1646,8 @@
 						</z>
 					</linear_acceleration>
 				</imu>
+				<!-- Until https://github.com/osrf/sdformat/pull/525 gets merged, we work around the IMU position like this -->
+				<pose>0 0 0.15 -3.1415926535897931 -0 0</pose>
             </sensor>
         </xacro:if>
 	</gazebo>

--- a/submitted_models/ctu_cras_norlab_absolem_sensor_config_1/urdf/nifti_robot.xacro
+++ b/submitted_models/ctu_cras_norlab_absolem_sensor_config_1/urdf/nifti_robot.xacro
@@ -1185,9 +1185,9 @@
 			</contact>
 			<friction>
 				<ode>
-					<mu>1</mu>
+					<mu>0.5</mu>
 					<mu2>1</mu2>
-					<slip1>0.035</slip1>
+					<slip1>0.00092</slip1>
 					<slip2>0</slip2>
 					<fdir1>0 0 1</fdir1>
 				</ode>
@@ -1205,9 +1205,9 @@
 			</contact>
 			<friction>
 				<ode>
-					<mu>1</mu>
+					<mu>0.5</mu>
 					<mu2>1</mu2>
-					<slip1>0.035</slip1>
+					<slip1>0.00092</slip1>
 					<slip2>0</slip2>
 					<fdir1>0 0 1</fdir1>
 				</ode>
@@ -1572,31 +1572,34 @@
 						<x>
 							<noise type="gaussian">
 								<mean>0</mean>
-								<stddev>2e-4</stddev>
-								<bias_mean>0.0000075</bias_mean>
-								<bias_stddev>0.0000008</bias_stddev>
-								<dynamic_bias_stddev>0.0000004</dynamic_bias_stddev>
-								<dynamic_bias_correlation_time>1000.0</dynamic_bias_correlation_time>
+								<stddev>0.009</stddev>
+								<bias_mean>0.00075</bias_mean>
+								<bias_stddev>0.005</bias_stddev>
+								<dynamic_bias_stddev>0.00002</dynamic_bias_stddev>
+								<dynamic_bias_correlation_time>400.0</dynamic_bias_correlation_time>
+								<precision>0.00025</precision>
 							</noise>
 						</x>
 						<y>
 							<noise type="gaussian">
 								<mean>0</mean>
-								<stddev>2e-4</stddev>
-								<bias_mean>0.0000075</bias_mean>
-								<bias_stddev>0.0000008</bias_stddev>
-								<dynamic_bias_stddev>0.0000004</dynamic_bias_stddev>
-								<dynamic_bias_correlation_time>1000.0</dynamic_bias_correlation_time>
+								<stddev>0.009</stddev>
+								<bias_mean>0.00075</bias_mean>
+								<bias_stddev>0.005</bias_stddev>
+								<dynamic_bias_stddev>0.00002</dynamic_bias_stddev>
+								<dynamic_bias_correlation_time>400.0</dynamic_bias_correlation_time>
+								<precision>0.00025</precision>
 							</noise>
 						</y>
 						<z>
 							<noise type="gaussian">
 								<mean>0</mean>
-								<stddev>2e-4</stddev>
-								<bias_mean>0.0000075</bias_mean>
-								<bias_stddev>0.0000008</bias_stddev>
-								<dynamic_bias_stddev>0.0000004</dynamic_bias_stddev>
-								<dynamic_bias_correlation_time>1000.0</dynamic_bias_correlation_time>
+								<stddev>0.009</stddev>
+								<bias_mean>0.00075</bias_mean>
+								<bias_stddev>0.005</bias_stddev>
+								<dynamic_bias_stddev>0.00002</dynamic_bias_stddev>
+								<dynamic_bias_correlation_time>400.0</dynamic_bias_correlation_time>
+								<precision>0.00025</precision>
 							</noise>
 						</z>
 					</angular_velocity>
@@ -1604,31 +1607,34 @@
 						<x>
 							<noise type="gaussian">
 								<mean>0</mean>
-								<stddev>1e-2</stddev>
-								<bias_mean>0.1</bias_mean>
-								<bias_stddev>0.001</bias_stddev>
-								<dynamic_bias_stddev>0.002</dynamic_bias_stddev>
-								<dynamic_bias_correlation_time>300.0</dynamic_bias_correlation_time>
+								<stddev>0.021</stddev>
+								<bias_mean>0.05</bias_mean>
+								<bias_stddev>0.0075</bias_stddev>
+								<dynamic_bias_stddev>0.000375</dynamic_bias_stddev>
+								<dynamic_bias_correlation_time>175.0</dynamic_bias_correlation_time>
+								<precision>0.005</precision>
 							</noise>
 						</x>
 						<y>
 							<noise type="gaussian">
 								<mean>0</mean>
-								<stddev>1e-2</stddev>
-								<bias_mean>0.1</bias_mean>
-								<bias_stddev>0.001</bias_stddev>
-								<dynamic_bias_stddev>0.002</dynamic_bias_stddev>
-								<dynamic_bias_correlation_time>300.0</dynamic_bias_correlation_time>
+								<stddev>0.021</stddev>
+								<bias_mean>0.05</bias_mean>
+								<bias_stddev>0.0075</bias_stddev>
+								<dynamic_bias_stddev>0.000375</dynamic_bias_stddev>
+								<dynamic_bias_correlation_time>175.0</dynamic_bias_correlation_time>
+								<precision>0.005</precision>
 							</noise>
 						</y>
 						<z>
 							<noise type="gaussian">
 								<mean>0</mean>
-								<stddev>1e-2</stddev>
-								<bias_mean>0.1</bias_mean>
-								<bias_stddev>0.001</bias_stddev>
-								<dynamic_bias_stddev>0.002</dynamic_bias_stddev>
-								<dynamic_bias_correlation_time>300.0</dynamic_bias_correlation_time>
+								<stddev>0.021</stddev>
+								<bias_mean>0.05</bias_mean>
+								<bias_stddev>0.0075</bias_stddev>
+								<dynamic_bias_stddev>0.000375</dynamic_bias_stddev>
+								<dynamic_bias_correlation_time>175.0</dynamic_bias_correlation_time>
+								<precision>0.005</precision>
 							</noise>
 						</z>
 					</linear_acceleration>

--- a/submitted_models/ctu_cras_norlab_absolem_sensor_config_1/urdf/realsense.gazebo.xacro
+++ b/submitted_models/ctu_cras_norlab_absolem_sensor_config_1/urdf/realsense.gazebo.xacro
@@ -65,7 +65,8 @@ This is the Gazebo URDF model for the Intel RealSense D435 camera
           </camera>
           <always_on>1</always_on>
           <update_rate>$(arg realsense_fps)</update_rate>
-          <pose frame="">0.0 0 0.0 0 0.0 0</pose>
+          <!-- Until https://github.com/osrf/sdformat/pull/525 gets merged, we work around the camera position like this -->
+          <pose>0.13592 -0.016338 0.419596 0.015 0.499467 -0.000319</pose>
         </sensor>
     </gazebo>
 

--- a/submitted_models/ctu_cras_norlab_absolem_sensor_config_1/urdf/utils.xacro
+++ b/submitted_models/ctu_cras_norlab_absolem_sensor_config_1/urdf/utils.xacro
@@ -49,15 +49,6 @@
 
     <xacro:macro name="empty_link" params="name">
         <link name="${name}">
-            <visual>
-                <origin xyz="0 0 0" rpy="0 0 0" />
-                <geometry>
-                    <box size="0.005 0.005 0.005"/>
-                </geometry>
-                <material name="invisible_color">
-                    <color rgba="1 0 0 0.5"/>
-                </material>
-            </visual>
             <xacro:default_inertial />
         </link>
     </xacro:macro>


### PR DESCRIPTION
There are some visuals we forgotten to remove on Absolem. They create annoying artifacts in the omnicamera. This PR removes the visuals (all of them were black cubes 0.5x0.5x0.5 cm I used to debug placement of the camera sensors).

Cameras without this PR:
![absolem_unfixed](https://user-images.githubusercontent.com/182533/112982949-5f318900-915d-11eb-97b8-b00ab3363ce0.png)

Cameras with this PR:
![absolem_fixed](https://user-images.githubusercontent.com/182533/112982940-5b9e0200-915d-11eb-9304-05b1b2c270fe.png)

I based this PR on top of #851 . After merging #851, this will be just a single commit. Look at the last commit in this PR during review only.