### PR TITLE
Absolem: syncronize Xacro with manual edits of model.sdf

### DIFF
--- a/submitted_models/ctu_cras_norlab_absolem_sensor_config_1/model.sdf
+++ b/submitted_models/ctu_cras_norlab_absolem_sensor_config_1/model.sdf
@@ -79,7 +79,7 @@
         </geometry>
       </collision>
       <collision name="base_link_fixed_joint_lump__antenna_collision_8">
-        <pose>-0.39064 0.0789 0.1551 3.1415926535897931 1.5707963267948966 3.1415926535897931</pose>
+        <pose>-0.39064 0.0789 0.1551 0 1.5707963267948966 0</pose>
         <geometry>
           <cylinder>
             <length>0.03718</length>
@@ -235,7 +235,7 @@
         </geometry>
       </visual>
       <visual name="base_link_fixed_joint_lump__imu_visual_3">
-        <pose>0 0 0.15 -3.1415926535897931 -0 0</pose>
+        <pose>0 0 0.15 -3.1415926535897931 0 0</pose>
         <geometry>
           <box>
             <size>0.005 0.005 0.005</size>
@@ -341,7 +341,7 @@
         </geometry>
       </visual>
       <visual name="base_link_fixed_joint_lump__camera_2_visual_16">
-        <pose>-0.01735 -0.055429 0.314721 -1.5725 0.00415 1.56975</pose>
+        <pose>-0.01735 -0.055429 0.314721 -1.5725 0.00415 1.56974</pose>
         <geometry>
           <box>
             <size>0.005 0.005 0.005</size>
@@ -349,7 +349,7 @@
         </geometry>
       </visual>
       <visual name="base_link_fixed_joint_lump__camera_2_sim_visual_17">
-        <pose>-0.01735 -0.055429 0.314721 -0.001705 0.00415 1.56975</pose>
+        <pose>-0.01735 -0.055429 0.314721 -0.001705 0.00415 1.56974</pose>
         <geometry>
           <box>
             <size>0.005 0.005 0.005</size>
@@ -397,7 +397,7 @@
         </geometry>
       </visual>
       <visual name="base_link_fixed_joint_lump__camera_5_sim_visual_23">
-        <pose>0.024083 -0.058382 0.376328 3.1415926535897931 -1.5707963267948966 0.945143</pose>
+        <pose>0.024083 -0.058382 0.376328 -2.19645 -1.5707963267948966 0</pose>
         <geometry>
           <box>
             <size>0.005 0.005 0.005</size>
@@ -474,7 +474,7 @@
         </geometry>
       </visual>
       <visual name="base_link_fixed_joint_lump__camera_link_visual_32">
-        <pose>0.133719 -0.010853 0.422031 2.07031 -0.013168 1.56329</pose>
+        <pose>0.133719 -0.010853 0.422031 2.07031 -0.013167 1.56329</pose>
         <geometry>
           <mesh>
             <uri>meshes/realsense_d435.dae</uri>
@@ -639,77 +639,77 @@
         <always_on>1</always_on>
         <update_rate>50</update_rate>
         <imu>
-                    <angular_velocity>
-                        <x>
-                            <noise type="gaussian">
-                                <mean>0</mean>
-                                <stddev>0.009</stddev>
-                                <bias_mean>0.00075</bias_mean>
-                                <bias_stddev>0.005</bias_stddev>
-                                <dynamic_bias_stddev>0.00002</dynamic_bias_stddev>
-                                <dynamic_bias_correlation_time>400.0</dynamic_bias_correlation_time>
-                                <precision>0.00025</precision>
-                            </noise>
-                        </x>
-                        <y>
-                            <noise type="gaussian">
-                                <mean>0</mean>
-                                <stddev>0.009</stddev>
-                                <bias_mean>0.00075</bias_mean>
-                                <bias_stddev>0.005</bias_stddev>
-                                <dynamic_bias_stddev>0.00002</dynamic_bias_stddev>
-                                <dynamic_bias_correlation_time>400.0</dynamic_bias_correlation_time>
-                                <precision>0.00025</precision>
-                            </noise>
-                        </y>
-                        <z>
-                            <noise type="gaussian">
-                                <mean>0</mean>
-                                <stddev>0.009</stddev>
-                                <bias_mean>0.00075</bias_mean>
-                                <bias_stddev>0.005</bias_stddev>
-                                <dynamic_bias_stddev>0.00002</dynamic_bias_stddev>
-                                <dynamic_bias_correlation_time>400.0</dynamic_bias_correlation_time>
-                                <precision>0.00025</precision>
-                            </noise>
-                        </z>
-                    </angular_velocity>
-                    <linear_acceleration>
-                        <x>
-                            <noise type="gaussian">
-                                <mean>0</mean>
-                                <stddev>0.021</stddev>
-                                <bias_mean>0.05</bias_mean>
-                                <bias_stddev>0.0075</bias_stddev>
-                                <dynamic_bias_stddev>0.000375</dynamic_bias_stddev>
-                                <dynamic_bias_correlation_time>175.0</dynamic_bias_correlation_time>
-                                <precision>0.005</precision>
-                            </noise>
-                        </x>
-                        <y>
-                            <noise type="gaussian">
-                                <mean>0</mean>
-                                <stddev>0.021</stddev>
-                                <bias_mean>0.05</bias_mean>
-                                <bias_stddev>0.0075</bias_stddev>
-                                <dynamic_bias_stddev>0.000375</dynamic_bias_stddev>
-                                <dynamic_bias_correlation_time>175.0</dynamic_bias_correlation_time>
-                                <precision>0.005</precision>
-                            </noise>
-                        </y>
-                        <z>
-                            <noise type="gaussian">
-                                <mean>0</mean>
-                                <stddev>0.021</stddev>
-                                <bias_mean>0.05</bias_mean>
-                                <bias_stddev>0.0075</bias_stddev>
-                                <dynamic_bias_stddev>0.000375</dynamic_bias_stddev>
-                                <dynamic_bias_correlation_time>175.0</dynamic_bias_correlation_time>
-                                <precision>0.005</precision>
-                            </noise>
-                        </z>
-                    </linear_acceleration>
-                </imu>
+          <angular_velocity>
+            <x>
+              <noise type="gaussian">
+                <mean>0</mean>
+                <stddev>0.009</stddev>
+                <bias_mean>0.00075</bias_mean>
+                <bias_stddev>0.005</bias_stddev>
+                <dynamic_bias_stddev>2e-05</dynamic_bias_stddev>
+                <dynamic_bias_correlation_time>400</dynamic_bias_correlation_time>
+                <precision>0.00025</precision>
+              </noise>
+            </x>
+            <y>
+              <noise type="gaussian">
+                <mean>0</mean>
+                <stddev>0.009</stddev>
+                <bias_mean>0.00075</bias_mean>
+                <bias_stddev>0.005</bias_stddev>
+                <dynamic_bias_stddev>2e-05</dynamic_bias_stddev>
+                <dynamic_bias_correlation_time>400</dynamic_bias_correlation_time>
+                <precision>0.00025</precision>
+              </noise>
+            </y>
+            <z>
+              <noise type="gaussian">
+                <mean>0</mean>
+                <stddev>0.009</stddev>
+                <bias_mean>0.00075</bias_mean>
+                <bias_stddev>0.005</bias_stddev>
+                <dynamic_bias_stddev>2e-05</dynamic_bias_stddev>
+                <dynamic_bias_correlation_time>400</dynamic_bias_correlation_time>
+                <precision>0.00025</precision>
+              </noise>
+            </z>
+          </angular_velocity>
+          <linear_acceleration>
+            <x>
+              <noise type="gaussian">
+                <mean>0</mean>
+                <stddev>0.021</stddev>
+                <bias_mean>0.05</bias_mean>
+                <bias_stddev>0.0075</bias_stddev>
+                <dynamic_bias_stddev>0.000375</dynamic_bias_stddev>
+                <dynamic_bias_correlation_time>175</dynamic_bias_correlation_time>
+                <precision>0.005</precision>
+              </noise>
+            </x>
+            <y>
+              <noise type="gaussian">
+                <mean>0</mean>
+                <stddev>0.021</stddev>
+                <bias_mean>0.05</bias_mean>
+                <bias_stddev>0.0075</bias_stddev>
+                <dynamic_bias_stddev>0.000375</dynamic_bias_stddev>
+                <dynamic_bias_correlation_time>175</dynamic_bias_correlation_time>
+                <precision>0.005</precision>
+              </noise>
+            </y>
+            <z>
+              <noise type="gaussian">
+                <mean>0</mean>
+                <stddev>0.021</stddev>
+                <bias_mean>0.05</bias_mean>
+                <bias_stddev>0.0075</bias_stddev>
+                <dynamic_bias_stddev>0.000375</dynamic_bias_stddev>
+                <dynamic_bias_correlation_time>175</dynamic_bias_correlation_time>
+                <precision>0.005</precision>
+              </noise>
+            </z>
+          </linear_acceleration>
+        </imu>
         <pose>0 0 0.15 -3.1415926535897931 -0 0</pose>
       </sensor>
       <sensor name="omnicam_sensor0" type="camera">
@@ -996,7 +996,7 @@
       </sensor>
     </link>
     <link name="laser">
-      <pose>0.2502 0 0.1407 -3.1415926535897931 -0 0</pose>
+      <pose>0.2502 0 0.1407 -3.1415926535897931 0 0</pose>
       <inertial>
         <pose>0 0 -0.04 0 -0 0</pose>
         <mass>1.1</mass>
@@ -1179,7 +1179,7 @@
         </surface>
       </collision>
       <visual name="front_left_flipper_visual">
-        <pose>0 0 0 -2.95744 0 1.5707963267948966</pose>
+        <pose>0 0 0 -2.95743 -0 1.5707963267948966</pose>
         <geometry>
           <mesh>
             <uri>meshes/flipper.dae</uri>
@@ -1986,7 +1986,7 @@
         </surface>
       </collision>
       <visual name="rear_left_flipper_visual">
-        <pose>0 0 0 -2.95744 0 1.5707963267948966</pose>
+        <pose>0 0 0 -2.95743 -0 1.5707963267948966</pose>
         <geometry>
           <mesh>
             <uri>meshes/flipper.dae</uri>
@@ -2408,7 +2408,7 @@
         </surface>
       </collision>
       <visual name="front_right_flipper_visual">
-        <pose>0 0 0 -2.95744 -0 -1.5707963267948966</pose>
+        <pose>0 0 0 -2.95743 -0 -1.5707963267948966</pose>
         <geometry>
           <mesh>
             <uri>meshes/flipper.dae</uri>
@@ -2759,7 +2759,7 @@
         </surface>
       </collision>
       <visual name="rear_right_flipper_visual">
-        <pose>0 0 0 -2.95744 -0 -1.5707963267948966</pose>
+        <pose>0 0 0 -2.95743 -0 -1.5707963267948966</pose>
         <geometry>
           <mesh>
             <uri>meshes/flipper.dae</uri>

--- a/submitted_models/ctu_cras_norlab_absolem_sensor_config_1/scripts/update_robot_sdf
+++ b/submitted_models/ctu_cras_norlab_absolem_sensor_config_1/scripts/update_robot_sdf
@@ -7,8 +7,12 @@ MODEL_DIR="${DIR}/.."
 source "${MODEL_DIR}/config/common.sh"
 source "${MODEL_DIR}/config/sdf.sh"
 
+sdf8_version="$(ign sdf --versions | grep '^8')" || true
+[ -z "$sdf8_version" ] && echo "libsdformat8 not found. It is required to update this robot's SDF. Please install libsdformat8-dev and try again." >&2 && exit 1
+echo "Found libsdformat ${sdf8_version}" >&2
+
 rosrun xacro xacro "${MODEL_DIR}/urdf/nifti_robot.xacro" ${config} > "${MODEL_DIR}/nifti_robot.sdf.urdf"
-ign sdf -p "${MODEL_DIR}/nifti_robot.sdf.urdf" | "${DIR}/high_precision_constants.py" - > "${MODEL_DIR}/model.sdf"
+ign sdf --force-version "$sdf8_version" -p "${MODEL_DIR}/nifti_robot.sdf.urdf" | "${DIR}/high_precision_constants.py" - > "${MODEL_DIR}/model.sdf"
 sed -i -e 's#model://ctu_cras_norlab_absolem_sensor_config_1/##g' \
   -e '/<surface>/{:a;N;/<\/surface>/!ba};/<surface>\n\s*<contact>\n\s*<ode\/>\n\s*<\/contact>\n\s*<friction>\n\s*<ode\/>\n\s*<\/friction>\n\s*<\/surface>/d' \
   -e '/<pose>\(-\?0 \?\)\{6\}<\/pose>/d' \

--- a/submitted_models/ctu_cras_norlab_absolem_sensor_config_1/urdf/nifti_robot.xacro
+++ b/submitted_models/ctu_cras_norlab_absolem_sensor_config_1/urdf/nifti_robot.xacro
@@ -1185,9 +1185,9 @@
 			</contact>
 			<friction>
 				<ode>
-					<mu>1</mu>
+					<mu>0.5</mu>
 					<mu2>1</mu2>
-					<slip1>0.035</slip1>
+					<slip1>0.00092</slip1>
 					<slip2>0</slip2>
 					<fdir1>0 0 1</fdir1>
 				</ode>
@@ -1205,9 +1205,9 @@
 			</contact>
 			<friction>
 				<ode>
-					<mu>1</mu>
+					<mu>0.5</mu>
 					<mu2>1</mu2>
-					<slip1>0.035</slip1>
+					<slip1>0.00092</slip1>
 					<slip2>0</slip2>
 					<fdir1>0 0 1</fdir1>
 				</ode>
@@ -1572,31 +1572,34 @@
 						<x>
 							<noise type="gaussian">
 								<mean>0</mean>
-								<stddev>2e-4</stddev>
-								<bias_mean>0.0000075</bias_mean>
-								<bias_stddev>0.0000008</bias_stddev>
-								<dynamic_bias_stddev>0.0000004</dynamic_bias_stddev>
-								<dynamic_bias_correlation_time>1000.0</dynamic_bias_correlation_time>
+								<stddev>0.009</stddev>
+								<bias_mean>0.00075</bias_mean>
+								<bias_stddev>0.005</bias_stddev>
+								<dynamic_bias_stddev>0.00002</dynamic_bias_stddev>
+								<dynamic_bias_correlation_time>400.0</dynamic_bias_correlation_time>
+								<precision>0.00025</precision>
 							</noise>
 						</x>
 						<y>
 							<noise type="gaussian">
 								<mean>0</mean>
-								<stddev>2e-4</stddev>
-								<bias_mean>0.0000075</bias_mean>
-								<bias_stddev>0.0000008</bias_stddev>
-								<dynamic_bias_stddev>0.0000004</dynamic_bias_stddev>
-								<dynamic_bias_correlation_time>1000.0</dynamic_bias_correlation_time>
+								<stddev>0.009</stddev>
+								<bias_mean>0.00075</bias_mean>
+								<bias_stddev>0.005</bias_stddev>
+								<dynamic_bias_stddev>0.00002</dynamic_bias_stddev>
+								<dynamic_bias_correlation_time>400.0</dynamic_bias_correlation_time>
+								<precision>0.00025</precision>
 							</noise>
 						</y>
 						<z>
 							<noise type="gaussian">
 								<mean>0</mean>
-								<stddev>2e-4</stddev>
-								<bias_mean>0.0000075</bias_mean>
-								<bias_stddev>0.0000008</bias_stddev>
-								<dynamic_bias_stddev>0.0000004</dynamic_bias_stddev>
-								<dynamic_bias_correlation_time>1000.0</dynamic_bias_correlation_time>
+								<stddev>0.009</stddev>
+								<bias_mean>0.00075</bias_mean>
+								<bias_stddev>0.005</bias_stddev>
+								<dynamic_bias_stddev>0.00002</dynamic_bias_stddev>
+								<dynamic_bias_correlation_time>400.0</dynamic_bias_correlation_time>
+								<precision>0.00025</precision>
 							</noise>
 						</z>
 					</angular_velocity>
@@ -1604,31 +1607,34 @@
 						<x>
 							<noise type="gaussian">
 								<mean>0</mean>
-								<stddev>1e-2</stddev>
-								<bias_mean>0.1</bias_mean>
-								<bias_stddev>0.001</bias_stddev>
-								<dynamic_bias_stddev>0.002</dynamic_bias_stddev>
-								<dynamic_bias_correlation_time>300.0</dynamic_bias_correlation_time>
+								<stddev>0.021</stddev>
+								<bias_mean>0.05</bias_mean>
+								<bias_stddev>0.0075</bias_stddev>
+								<dynamic_bias_stddev>0.000375</dynamic_bias_stddev>
+								<dynamic_bias_correlation_time>175.0</dynamic_bias_correlation_time>
+								<precision>0.005</precision>
 							</noise>
 						</x>
 						<y>
 							<noise type="gaussian">
 								<mean>0</mean>
-								<stddev>1e-2</stddev>
-								<bias_mean>0.1</bias_mean>
-								<bias_stddev>0.001</bias_stddev>
-								<dynamic_bias_stddev>0.002</dynamic_bias_stddev>
-								<dynamic_bias_correlation_time>300.0</dynamic_bias_correlation_time>
+								<stddev>0.021</stddev>
+								<bias_mean>0.05</bias_mean>
+								<bias_stddev>0.0075</bias_stddev>
+								<dynamic_bias_stddev>0.000375</dynamic_bias_stddev>
+								<dynamic_bias_correlation_time>175.0</dynamic_bias_correlation_time>
+								<precision>0.005</precision>
 							</noise>
 						</y>
 						<z>
 							<noise type="gaussian">
 								<mean>0</mean>
-								<stddev>1e-2</stddev>
-								<bias_mean>0.1</bias_mean>
-								<bias_stddev>0.001</bias_stddev>
-								<dynamic_bias_stddev>0.002</dynamic_bias_stddev>
-								<dynamic_bias_correlation_time>300.0</dynamic_bias_correlation_time>
+								<stddev>0.021</stddev>
+								<bias_mean>0.05</bias_mean>
+								<bias_stddev>0.0075</bias_stddev>
+								<dynamic_bias_stddev>0.000375</dynamic_bias_stddev>
+								<dynamic_bias_correlation_time>175.0</dynamic_bias_correlation_time>
+								<precision>0.005</precision>
 							</noise>
 						</z>
 					</linear_acceleration>


### PR DESCRIPTION
This PR replaces #851 until gzweb can support SDF 1.7 relative poses.

It updates the Xacro source files to correspond to the manual changes done to model.sdf . With this PR, running `scripts/update_robot_sdf` results again in the exact same SDF as the one commited to the repo.

There are a few changes to the model.sdf brought in by this PR, but that's probably just a difference between SDF rendering by libsdformat 8.9.0 and 8.9.1, and some whitespace changes. The "semantics" of the model is exactly the same. It can be easily seen by reviewing the changes, and I have also tested the update model in the simulator and it produces exactly the same data.

The requirement to keep SDF version 1.6 is satisfied by using `ign sdf -p` from libsdformat 8, which is the version used earlier in Blueprint, which does not know SDF 1.7. All developers who want to update the robot's model.sdf will need to install `libsdformat8-dev` manually. "Normal users" of the robot model are not affected and do not have to install anything.