### PR TITLE
fix finding niosh and satsop resources

### DIFF
--- a/subt_ign/src/Common.cc
+++ b/subt_ign/src/Common.cc
@@ -139,6 +139,8 @@ bool FullWorldPath(const std::string &_worldName,
   else if (_worldName.find("simple") == std::string::npos &&
            _worldName.find("_qual") == std::string::npos &&
            _worldName.find("_stix") == std::string::npos &&
+           _worldName.find("niosh_") == std::string::npos &&
+           _worldName.find("satsop_") == std::string::npos &&
            _worldName.find("finals_") == std::string::npos)
   {
     return false;


### PR DESCRIPTION
You'll see an error about the visibility table when running:

```
ign launch -v 4 cloudsim_sim.ign circuit:=tunnel worldName:=niosh_sr_config_a
```

Signed-off-by: Nate Koenig <nate@openrobotics.org>