### PR TITLE
Set the state properly when recording is complete

### DIFF
--- a/subt_ign/src/GameLogicPlugin.cc
+++ b/subt_ign/src/GameLogicPlugin.cc
@@ -2206,6 +2206,7 @@ void GameLogicPluginPrivate::Finish(const ignition::msgs::Time &_simTime)
       completeMsg.mutable_header()->mutable_stamp()->CopyFrom(
           this->simTime);
       completeMsg.set_data("recording_complete");
+      this->state = "recording_complete";
       this->startPub.Publish(completeMsg);
 
       std::lock_guard<std::mutex> lock(this->eventCounterMutex);


### PR DESCRIPTION
Forgot to set the `state` when recording is complete. Without this state set it's possible for cloudsim to miss the `recording_complete` message.

Signed-off-by: Nate Koenig <nate@openrobotics.org>