### PR TITLE
X500 feedforward added to bridge, cleanup in MRSMultirotorController

### DIFF
--- a/submitted_models/ctu_cras_norlab_x500_sensor_config_1/launch/vehicle_topics.launch
+++ b/submitted_models/ctu_cras_norlab_x500_sensor_config_1/launch/vehicle_topics.launch
@@ -53,6 +53,13 @@
     <node
       pkg="ros_ign_bridge"
       type="parameter_bridge"
+      name="ros_ign_bridge_feedforward"
+      args="/model/$(arg name)/feedforward@geometry_msgs/Twist]ignition.msgs.Twist">
+      <remap from="/model/$(arg name)/feedforward" to="feedforward"/>
+    </node>
+    <node
+      pkg="ros_ign_bridge"
+      type="parameter_bridge"
       name="ros_ign_bridge_velocity_control_enable"
       args="/model/$(arg name)/velocity_controller/enable@std_msgs/Bool]ignition.msgs.Boolean">
       <remap from="/model/$(arg name)/velocity_controller/enable" to="velocity_controller/enable"/>


### PR DESCRIPTION
- Added the feedforward topic to `ros_ign_bridge`. The topic was missing after migrating the controller from ROS to IGN.
- The feedforward subscriber was changed to match the style of `cmd_vel` subscriber.
- The `ignmsg` prints were changed to be called only once instead of every time in callbacks.