### PR TITLE
Spot: Disable nodelets because of spurious broken bonds.

### DIFF
--- a/submitted_models/bosdyn_spot/launch/leg.launch
+++ b/submitted_models/bosdyn_spot/launch/leg.launch
@@ -5,8 +5,13 @@
   <arg name="leg"/>
   <arg name="link_prefix" value="/world/$(arg world_name)/model/$(arg name)/link"/>
 
+  <arg name="contacts_manager_cmd" />
+  <arg name="contacts_manager_name" />
+  <arg name="control_manager_cmd" />
+  <arg name="control_manager_name" />
+
   <!-- Contact relay -->
-  <node name="ros_ign_bridge_$(arg leg)_leg_contact" pkg="nodelet" type="nodelet" args="load bosdyn_spot/FootContactBridge contacts_manager" respawn="true">
+  <node name="ros_ign_bridge_$(arg leg)_leg_contact" pkg="nodelet" type="nodelet" args="$(arg contacts_manager_cmd) bosdyn_spot/FootContactBridge $(arg contacts_manager_name)" respawn="true">
     <param name="ign_topic" value="$(arg link_prefix)/$(arg leg)_lower_leg/sensor/contact/contact" />
     <remap from="contacts" to="leg_contacts/$(arg leg)" />
   </node>

--- a/submitted_models/bosdyn_spot/launch/leg_joint.launch
+++ b/submitted_models/bosdyn_spot/launch/leg_joint.launch
@@ -6,6 +6,11 @@
   <arg name="joint"/>
   <arg name="joint_prefix" value="/model/$(arg name)/joint"/>
 
+  <arg name="contacts_manager_cmd" />
+  <arg name="contacts_manager_name" />
+  <arg name="control_manager_cmd" />
+  <arg name="control_manager_name" />
+
   <!-- Position controller (send NaN to disable it). It tries to keep the initial position by default. -->
   <node pkg="ros_ign_bridge" type="parameter_bridge" name="ros_ign_bridge_$(arg leg)_$(arg joint)_position_controller"
     args="$(arg joint_prefix)/$(arg leg)_$(arg joint)/0/cmd_pos@std_msgs/Float64]ignition.msgs.Double" respawn="true">
@@ -21,7 +26,9 @@
   <!-- Position controller PID parameters configuration -->
   <group ns="joint_group_position_controller">
     <group ns="gains">
-      <node name="$(arg leg)_$(arg joint)" pkg="nodelet" type="nodelet" args="load bosdyn_spot/PidControlBridge /$(arg name)/control_manager" respawn="true">
+      <arg name="control_manager_abs_name" value="/$(arg name)/$(arg control_manager_name)" if="$(eval control_manager_name != '')" />
+      <arg name="control_manager_abs_name" value="" if="$(eval control_manager_name == '')" />
+      <node name="$(arg leg)_$(arg joint)" pkg="nodelet" type="nodelet" args="$(arg control_manager_cmd) bosdyn_spot/PidControlBridge $(arg control_manager_abs_name)" respawn="true">
         <param name="ign_topic" value="$(arg joint_prefix)/$(arg leg)_$(arg joint)/0/set_pos_pid" />
       </node>
     </group>

--- a/submitted_models/bosdyn_spot/launch/vehicle_topics.launch
+++ b/submitted_models/bosdyn_spot/launch/vehicle_topics.launch
@@ -8,6 +8,7 @@
   <arg name="breadcrumbs" default="0"/>
   <arg name="description_print_command" default="" />
   <arg name="relay_points" default="1" />
+  <arg name="nodelets" default="0" doc="Most body-related bridges can run as nodelets, but it can be problematic (spurious broken bonds)." />
 
   <include file="$(dirname)/description.launch" pass_all_args="true">
     <arg name="print_command" value="$(arg description_print_command)" if="$(eval description_print_command != '')" />
@@ -67,22 +68,32 @@
 
     <!-- Control -->
 
+    <arg name="control_manager_cmd" value="load" if="$(arg nodelets)" />
+    <arg name="control_manager_name" value="control_manager" if="$(arg nodelets)" />
+    <arg name="contacts_manager_cmd" value="load" if="$(arg nodelets)" />
+    <arg name="contacts_manager_name" value="contacts_manager" if="$(arg nodelets)" />
+
+    <arg name="control_manager_cmd" value="standalone" unless="$(arg nodelets)" />
+    <arg name="control_manager_name" value="" unless="$(arg nodelets)" />
+    <arg name="contacts_manager_cmd" value="standalone" unless="$(arg nodelets)" />
+    <arg name="contacts_manager_name" value="" unless="$(arg nodelets)" />
+
     <include file="$(dirname)/leg.launch" pass_all_args="true"><arg name="leg" value="front_left" /></include>
     <include file="$(dirname)/leg.launch" pass_all_args="true"><arg name="leg" value="front_right" /></include>
     <include file="$(dirname)/leg.launch" pass_all_args="true"><arg name="leg" value="rear_left" /></include>
     <include file="$(dirname)/leg.launch" pass_all_args="true"><arg name="leg" value="rear_right" /></include>
 
     <!-- Contact relay -->
-    <node name="contacts_manager" pkg="nodelet" type="nodelet" args="manager" respawn="true" />
-    <node name="ros_ign_bridge_leg_contact" pkg="nodelet" type="nodelet" args="load bosdyn_spot/LogicalContactBridge contacts_manager" respawn="true">
+    <node name="contacts_manager" pkg="nodelet" type="nodelet" args="manager" respawn="true" if="$(arg nodelets)" />
+    <node name="ros_ign_bridge_leg_contact" pkg="nodelet" type="nodelet" args="$(arg contacts_manager_cmd) bosdyn_spot/LogicalContactBridge $(arg contacts_manager_name)" respawn="true">
       <remap from="logical_contacts" to="leg_contacts" />
       <param name="ign_topic" value="/model/$(arg name)/leg_collisions" />
     </node>
 
     <rosparam command="load" file="$(find bosdyn_spot)/config/ros_control/ros_control.yaml" subst_value="true" />
-    <node name="control_manager" pkg="nodelet" type="nodelet" args="manager" respawn="true" />
+    <node name="control_manager" pkg="nodelet" type="nodelet" args="manager" respawn="true" if="$(arg nodelets)"/>
 
-    <node pkg="nodelet" type="nodelet" name="ros_ign_bridge_joint_trajectory_command" args="load bosdyn_spot/JointTrajectoryBridge control_manager" respawn="true">
+    <node pkg="nodelet" type="nodelet" name="ros_ign_bridge_joint_trajectory_command" args="$(arg control_manager_cmd) bosdyn_spot/JointTrajectoryBridge $(arg control_manager_name)" respawn="true">
       <remap from="~trajectory" to="joint_group_position_controller/command"/>
       <param name="ign_topic" value="/model/$(arg name)/joint_trajectory" />
     </node>


### PR DESCRIPTION
When playing around with Spot, I observed several times that the nodelets in control_manager get spuriously restarted because of a broken bond. No error is ever written to the log (only "node exited cleanly" for all loaded nodelets). Neither the manager nor the nodelet launchers have a reason to quit. However, after the spurious respawn (all of them are `respawn="true"`), the functionality is broken (i.e. the joint controller no longer controls joints).

I suspect this might be the consequence of having too much nodelets in one manager, and the fact that the nodelets interact with the simulator which is slow (I didn't expect that as they only read topics from Ignition Transport...). However, the bond breaking timeout runs in walltime, so if enough nodelets are just executing their callbacks, it might happen that the bond sending queue in manager is stuck for long enough to break all bonds. Unfortunately, the manager does not die in such case.

This PR makes all nodelets run standalone. But I've retained the possibility to manually run vehicle_topics.launch with the nodelets, just in case someone wants to try and debug this issue.

Maybe increasing the number of threads in the nodelet managers would also help, but getting rid of nodelets completely is a sure solution. I've tested it and the performance is not visibly worse.