### PR TITLE
Make gzserver and bridge images log stdout into a log file.

### DIFF
--- a/docker/cloudsim_bridge/run_bridge.bash
+++ b/docker/cloudsim_bridge/run_bridge.bash
@@ -21,4 +21,4 @@ export ROSCONSOLE_STDOUT_LINE_BUFFERED=1
 # atop process monitoring
 atop -R -w /home/developer/.ros/atop_log &
 
-ign launch cloudsim_bridge.ign -v 4 $@
+ign launch cloudsim_bridge.ign -v 4 $@ | tee /home/developer/.ros/bridge.log

--- a/docker/cloudsim_bridge/run_bridge.bash
+++ b/docker/cloudsim_bridge/run_bridge.bash
@@ -21,4 +21,4 @@ export ROSCONSOLE_STDOUT_LINE_BUFFERED=1
 # atop process monitoring
 atop -R -w /home/developer/.ros/atop_log &
 
-ign launch cloudsim_bridge.ign -v 4 "$@" | tee /home/developer/.ros/bridge.log
+ign launch cloudsim_bridge.ign -v 4 "$@" 2>&1 | tee /home/developer/.ros/bridge.log

--- a/docker/cloudsim_bridge/run_bridge.bash
+++ b/docker/cloudsim_bridge/run_bridge.bash
@@ -21,4 +21,4 @@ export ROSCONSOLE_STDOUT_LINE_BUFFERED=1
 # atop process monitoring
 atop -R -w /home/developer/.ros/atop_log &
 
-ign launch cloudsim_bridge.ign -v 4 $@ | tee /home/developer/.ros/bridge.log
+ign launch cloudsim_bridge.ign -v 4 "$@" | tee /home/developer/.ros/bridge.log

--- a/docker/cloudsim_sim/run_sim.bash
+++ b/docker/cloudsim_sim/run_sim.bash
@@ -14,4 +14,4 @@ bwm-ng -o csv -c 0 -t 1000 -T rate -I eth0 >> $FILE &
 atop -R -w /tmp/ign/logs/atop_log &
 
 export ROS_LOG_DIR=/tmp/ign/logs/ros
-ign launch -v 4 "$@" | tee /tmp/ign/logs/gzserver.log
+ign launch -v 4 "$@" 2>&1 | tee /tmp/ign/logs/gzserver.log

--- a/docker/cloudsim_sim/run_sim.bash
+++ b/docker/cloudsim_sim/run_sim.bash
@@ -14,4 +14,4 @@ bwm-ng -o csv -c 0 -t 1000 -T rate -I eth0 >> $FILE &
 atop -R -w /tmp/ign/logs/atop_log &
 
 export ROS_LOG_DIR=/tmp/ign/logs/ros
-ign launch -v 4 $@ | tee /tmp/ign/logs/gzserver.log
+ign launch -v 4 "$@" | tee /tmp/ign/logs/gzserver.log

--- a/docker/cloudsim_sim/run_sim.bash
+++ b/docker/cloudsim_sim/run_sim.bash
@@ -14,4 +14,4 @@ bwm-ng -o csv -c 0 -t 1000 -T rate -I eth0 >> $FILE &
 atop -R -w /tmp/ign/logs/atop_log &
 
 export ROS_LOG_DIR=/tmp/ign/logs/ros
-ign launch -v 4 $@
+ign launch -v 4 $@ | tee /tmp/ign/logs/gzserver.log


### PR DESCRIPTION
### Context
The cloudsim team would like add a new feature to upload logs and enable different teams to download robot log messages from the standard output. This will also help Ignition Gazebo developers use those logs to debug errors.

### Change
This PR appends a `tee` command to the `gzserver` and `bridge` entry-point scripts in order to generate a log file that will be collected by cloudsim and uploaded to a storage for future use.