### PR TITLE
LocalWindPlugin implementation

### DIFF
--- a/subt_ign/CMakeLists.txt
+++ b/subt_ign/CMakeLists.txt
@@ -133,6 +133,7 @@ list(APPEND SUBT_IGN_PLUGINS
   ControllerPlugin
   GameLogicPlugin
   GasEmitterDetectorPlugin
+  LocalWindPlugin
   VisibilityPlugin
 )
 

--- a/subt_ign/include/subt_ign/LocalWindPlugin.hh
+++ b/subt_ign/include/subt_ign/LocalWindPlugin.hh
@@ -1,0 +1,59 @@
+/*
+ * Copyright (C) 2021 Open Source Robotics Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+*/
+#ifndef SUBT_IGN_LOCALWINDPLUGIN_HH_
+#define SUBT_IGN_LOCALWINDPLUGIN_HH_
+
+#include <ignition/gazebo/System.hh>
+
+namespace subt
+{
+  class LocalWindPrivate;
+  /// \class LocalWind
+  /// \brief Iterates over all the models and adds wind accordingly.
+  ///
+  /// The LocalWind plugin loads a pre-computed lookup table to
+  /// determine the tile where a robot is based in its position.
+  /// In each simulation step, checks all the robots tiles
+  /// Then checks if the tile has wind defined, and if that's the case
+  /// Add wind to the links of the robot.
+
+  class LocalWind:
+    public ignition::gazebo::System,
+    public ignition::gazebo::ISystemConfigure,
+    public ignition::gazebo::ISystemPreUpdate
+  {
+    /// \brief Constructor
+    public: LocalWind();
+
+    /// \brief Destructor
+    public: ~LocalWind();
+
+    // Documentation inherited
+    public: void Configure(const ignition::gazebo::Entity &_entity,
+                           const std::shared_ptr<const sdf::Element> &_sdf,
+                           ignition::gazebo::EntityComponentManager &_ecm,
+                           ignition::gazebo::EventManager &_eventMgr) override;
+
+    // Documentation inherited
+    public: void PreUpdate(const ignition::gazebo::UpdateInfo &_info,
+                 ignition::gazebo::EntityComponentManager &_ecm) override;
+
+    /// \brief Private data pointer.
+    private: std::unique_ptr<LocalWindPrivate> dataPtr;
+  };
+}
+#endif

--- a/subt_ign/launch/competition.ign
+++ b/subt_ign/launch/competition.ign
@@ -378,6 +378,21 @@
         <elevation_step_size>5</elevation_step_size>
       </logging>
     </plugin>
+
+    <plugin entity_name="<%= $worldName %>"
+            entity_type="world"
+            filename="libLocalWindPlugin.so"
+            name="subt::LocalWind">
+      <scaling>0.8</scaling>
+      <localWind>
+        <tile> 1 </tile>
+        <magnitude> 1 3 0 </magnitude>
+      </localWind>
+      <localWind>
+        <tile> 4 </tile>
+        <magnitude> 1 5 1 </magnitude>
+      </localWind>
+    </plugin>
   </plugin>
 
   <%if !$headless %>

--- a/subt_ign/src/LocalWindPlugin.cc
+++ b/subt_ign/src/LocalWindPlugin.cc
@@ -227,7 +227,7 @@ void LocalWind::PreUpdate(
       const auto &tilesMap = this->dataPtr->visibilityTable.Vertices();
       const auto linkTile = tilesMap.at(roundedPos);
       
-      ignerr << "Position: " << std::get<0>(roundedPos) << " "
+      igndbg << "Position: " << std::get<0>(roundedPos) << " "
              << std::get<1>(roundedPos) << " "
              << std::get<2>(roundedPos) << " "
              << " current tile: " << linkTile << "\n";

--- a/subt_ign/src/LocalWindPlugin.cc
+++ b/subt_ign/src/LocalWindPlugin.cc
@@ -1,0 +1,239 @@
+/*
+ * Copyright (C) 2021 Open Source Robotics Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+#include <ignition/common/Console.hh>
+#include <ignition/plugin/Register.hh>
+
+
+#include "ignition/gazebo/components/Inertial.hh"
+#include <ignition/gazebo/components/Name.hh>
+#include "ignition/gazebo/components/LinearVelocity.hh"
+#include "ignition/gazebo/components/Link.hh"
+#include "ignition/gazebo/components/WindMode.hh"
+
+#include <ignition/gazebo/Conversions.hh>
+#include <ignition/gazebo/EntityComponentManager.hh>
+#include <ignition/gazebo/Util.hh>
+
+#include "ignition/gazebo/Link.hh"
+
+#include "subt_ign/LocalWindPlugin.hh"
+#include "subt_ign/VisibilityTable.hh"
+
+IGNITION_ADD_PLUGIN(
+    subt::LocalWind,
+    ignition::gazebo::System,
+    subt::LocalWind::ISystemConfigure,
+    subt::LocalWind::ISystemPreUpdate)
+
+using namespace ignition;
+using namespace subt;
+
+//////////////////////////////////////////////////
+class subt::LocalWindPrivate
+{
+  /// \brief Initialize the system.
+  /// \param[in] _ecm Mutable reference to the EntityComponentManager.
+  /// \param[in] _sdf Pointer to sdf::Element that contains configuration
+  /// parameters for the system.
+  public: void Load(gazebo::EntityComponentManager &_ecm,
+                    const std::shared_ptr<const sdf::Element> &_sdf);
+
+  /// \brief World entity to which this system is attached.
+  public: gazebo::Entity worldEntity;
+
+  /// \brief A map that stores the tiles that have wind defined
+  public: std::map<uint64_t, ignition::math::Vector3d> windTiles;
+
+  /// \brief Table to store the map xyz position -> tile
+  public: subt::VisibilityTable visibilityTable;
+
+  /// \brief boolean to confirm if the plugin is properly configured
+  public: bool initialized{false};
+
+  /// \brief constant factor to determine wind strength
+  public: double forceApproximationScalingFactor{1.0};
+};
+
+//////////////////////////////////////////////////
+LocalWind::LocalWind() :
+  dataPtr(std::make_unique<LocalWindPrivate>())
+{
+}
+
+//////////////////////////////////////////////////
+LocalWind::~LocalWind() = default;
+
+//////////////////////////////////////////////////
+void LocalWindPrivate::Load(
+    gazebo::EntityComponentManager &_ecm,
+    const std::shared_ptr<const sdf::Element> &_sdf
+    )
+{
+  this->forceApproximationScalingFactor =
+    _sdf->Get<double>("scaling", this->forceApproximationScalingFactor).first;
+  // <localWind>
+  //     <tile> 1 </tile>
+  //     <magnitude> 1 3 0 </magnitude>
+  // </localWind>
+  // <localWind>
+  //     <tile> 1 </tile>
+  //     <magnitude> 1 3 0 </magnitude>
+  // </localWind>
+
+  // Iterate over all the localWind instances defined
+  // inside the plugin
+  auto sdfClone = _sdf->Clone();
+  sdf::ElementPtr localWindElement = sdfClone->GetElement("localWind");
+  while (localWindElement)
+  {
+    // Check if valid
+    if (localWindElement->HasElement("tile") &&
+	localWindElement->HasElement("magnitude"))
+    {
+      auto tile = _sdf->Get<uint64_t>(
+          "tile",std::numeric_limits<uint64_t>::max()).first;
+      auto magnitude = _sdf->Get<ignition::math::Vector3d>(
+          "magnitude", math::Vector3d::Zero).first;
+
+      // Avoid duplicates in the plugin definition
+      if ( this->windTiles.find(tile) == this->windTiles.end() ) {
+	this->windTiles[tile] = magnitude;
+      }
+      else
+      {
+	ignerr << "Tile #" << tile << " was already added. Remove duplicated"
+	       << " tiles\n";
+	return;
+      }
+    }
+    else
+    {
+      ignerr << "Parsing problem. Each localWind element requires a tile"
+             << "and a magnitude\n";
+      return;
+    }
+
+    // parse next localWind element
+    localWindElement = localWindElement->GetNextElement("localWind");
+  }
+
+  if(this->windTiles.size() == 0)
+  {
+    ignwarn << "Empty LocalWindPlugin, not using LocalWindPlugin\n";
+    return;
+  }
+
+  auto worldName =
+        _ecm.Component<gazebo::components::Name>(this->worldEntity);
+  if (!worldName){
+    ignerr << "Unable to read world name associated with entity"
+	   << this->worldEntity << "\n";
+  }
+  
+  if (!this->visibilityTable.Load(worldName->Data()))
+  {
+    ignerr << "Unable to load visibility table data files\n";
+    return;
+  }
+
+  this->initialized = true;
+}
+
+//////////////////////////////////////////////////
+void LocalWind::Configure(
+    const gazebo::Entity &_entity,
+    const std::shared_ptr<const sdf::Element> &_sdf,
+    gazebo::EntityComponentManager &_ecm,
+    gazebo::EventManager & /*_eventMgr*/)
+{
+  this->dataPtr->worldEntity = _entity;
+  this->dataPtr->Load(_ecm, _sdf);
+}
+
+//////////////////////////////////////////////////
+void LocalWind::PreUpdate(
+    const gazebo::UpdateInfo &_info,
+    gazebo::EntityComponentManager &_ecm)  
+{
+  if (!this->dataPtr->initialized)
+    return;
+
+  if (_info.paused)
+    return;
+
+  // \TODO(anyone) Support rewind
+  if (_info.dt < std::chrono::steady_clock::duration::zero())
+  {
+    ignwarn << "Detected jump back in time ["
+        << std::chrono::duration_cast<std::chrono::seconds>(_info.dt).count()
+        << "s]. System may not work properly." << std::endl;
+  }
+
+  gazebo::Link link;
+
+  _ecm.Each<gazebo::components::Link, gazebo::components::Inertial,
+            gazebo::components::WindMode,
+            gazebo::components::WorldLinearVelocity>(
+    [&](const gazebo::Entity &_entity, const gazebo::components::Link *,
+        const gazebo::components::Inertial *_inertial,
+	const gazebo::components::WindMode *_windMode,
+	const gazebo::components::WorldLinearVelocity *_linkVel
+	) -> bool
+    {
+
+      // Skip links for which the wind is disabled
+      // This assumption also implies links with windMode enabled
+      // were populated with 
+      if (!_windMode->Data())
+      {
+	return true;
+      }
+
+      // Get XYZ of each link
+      math::Pose3d linkWorldPose = worldPose(_entity, _ecm);
+      math::Vector3d linkPosition = linkWorldPose.Pos();
+
+      int32_t x = std::round(linkPosition.X());
+      int32_t y = std::round(linkPosition.Y());
+      int32_t z = std::round(linkPosition.Z());
+      auto roundedPos = std::make_tuple(x, y, z);
+      
+      // Get Tile defined for that XYZ
+      //auto linkTile = this->dataPtr->visibilityTable.getTile(linkPosition);
+      auto tilesMap = this->dataPtr->visibilityTable.Vertices();
+      auto linkTile = tilesMap[roundedPos];
+      //auto linkTile = this->dataPtr->visibilityTable.Vertices[linkPosition];
+
+      // If Tile is in the tiles defined by the plugin, apply force
+      auto tileLocalWind = this->dataPtr->windTiles.find(linkTile);
+      if(tileLocalWind != this->dataPtr->windTiles.end())
+      {
+	link.ResetEntity(_entity);
+	
+	math::Vector3d windForce =
+          _inertial->Data().MassMatrix().Mass() *
+	  this->dataPtr->forceApproximationScalingFactor *
+	  (tileLocalWind->second - _linkVel->Data());
+	
+	// Apply force at center of mass
+	link.AddWorldForce(_ecm, windForce);
+      }
+      return true;
+    });
+
+}

--- a/subt_ign/src/LocalWindPlugin.cc
+++ b/subt_ign/src/LocalWindPlugin.cc
@@ -227,13 +227,11 @@ void LocalWind::PreUpdate(
       // Skip links for which the wind is disabled
       // This assumption also implies links with windMode enabled
       // were populated with
+      if (!_windMode->Data())
+      {
+        return true;
+      }
 
-      // if (!_windMode->Data())
-      // {
-      // 	return true;
-      // }
-
-      // ignerr << "HERE4 " << " \n";
       auto linkName  = _ecm.Component<gazebo::components::Name>(_entity);
       if (linkName){
 	ignerr << linkName->Data() << "\n";
@@ -250,8 +248,8 @@ void LocalWind::PreUpdate(
 
       // Get Tile defined for that XYZ
       //auto linkTile = this->dataPtr->visibilityTable.getTile(linkPosition);
-      auto tilesMap = this->dataPtr->visibilityTable.Vertices();
-      auto linkTile = tilesMap[roundedPos];
+      const auto &tilesMap = this->dataPtr->visibilityTable.Vertices();
+      const auto linkTile = tilesMap.at(roundedPos);
       //auto linkTile = this->dataPtr->visibilityTable.Vertices[linkPosition];
       
       // ignerr << "Position: " << std::get<0>(roundedPos) << " "

--- a/subt_ign/worlds/cave_circuit_practice_01.sdf
+++ b/subt_ign/worlds/cave_circuit_practice_01.sdf
@@ -21,16 +21,17 @@
 
     <!-- Probably it's better to add this plugin in the launch files -->
     <!-- Adding it here for testing -->
-    <!-- <plugin filename="libLocalWindPlugin.so" name="subt::LocalWindPlugin"> -->
-    <!--   <localWind> -->
-    <!--     <tile> 1 </tile> -->
-    <!--     <magnitude> 1 3 0 </magnitude> -->
-    <!--   </localWind> -->
-    <!--   <localWind> -->
-    <!--     <tile> 1 </tile> -->
-    <!--     <magnitude> 1 3 0 </magnitude> -->
-    <!--   </localWind> -->
-    <!-- </plugin> -->
+    <plugin filename="libLocalWindPlugin.so" name="subt::LocalWindPlugin">
+      <scaling>0.8</scaling>
+      <localWind>
+        <tile> 1 </tile>
+        <magnitude> 1 3 0 </magnitude>
+      </localWind>
+      <localWind>
+        <tile> 1 </tile>
+        <magnitude> 1 3 0 </magnitude>
+      </localWind>
+    </plugin>
 
     <!-- The staging area -->
     <include>

--- a/subt_ign/worlds/cave_circuit_practice_01.sdf
+++ b/subt_ign/worlds/cave_circuit_practice_01.sdf
@@ -19,6 +19,19 @@
        <temperature_gradient>0.2</temperature_gradient>
     </atmosphere>
 
+    <!-- Probably it's better to add this plugin in the launch files -->
+    <!-- Adding it here for testing -->
+    <!-- <plugin filename="libLocalWindPlugin.so" name="subt::LocalWindPlugin"> -->
+    <!--   <localWind> -->
+    <!--     <tile> 1 </tile> -->
+    <!--     <magnitude> 1 3 0 </magnitude> -->
+    <!--   </localWind> -->
+    <!--   <localWind> -->
+    <!--     <tile> 1 </tile> -->
+    <!--     <magnitude> 1 3 0 </magnitude> -->
+    <!--   </localWind> -->
+    <!-- </plugin> -->
+
     <!-- The staging area -->
     <include>
       <static>true</static>

--- a/subt_ign/worlds/cave_circuit_practice_01.sdf
+++ b/subt_ign/worlds/cave_circuit_practice_01.sdf
@@ -19,7 +19,7 @@
        <temperature_gradient>0.2</temperature_gradient>
     </atmosphere>
 
-   <!-- The staging area -->
+    <!-- The staging area -->
     <include>
       <static>true</static>
       <name>staging_area</name>

--- a/subt_ign/worlds/cave_circuit_practice_01.sdf
+++ b/subt_ign/worlds/cave_circuit_practice_01.sdf
@@ -18,22 +18,22 @@
        <temperature>288</temperature>
        <temperature_gradient>0.2</temperature_gradient>
     </atmosphere>
-
+ 
     <!-- Probably it's better to add this plugin in the launch files -->
     <!-- Adding it here for testing -->
-    <plugin filename="libLocalWindPlugin.so" name="subt::LocalWindPlugin">
-      <scaling>0.8</scaling>
-      <localWind>
-        <tile> 1 </tile>
-        <magnitude> 1 3 0 </magnitude>
-      </localWind>
-      <localWind>
-        <tile> 1 </tile>
-        <magnitude> 1 3 0 </magnitude>
-      </localWind>
-    </plugin>
+    <!-- <plugin filename="libLocalWindPlugin.so" name="subt::LocalWind"> -->
+    <!--   <scaling>0.8</scaling> -->
+    <!--   <localWind> -->
+    <!--     <tile> 1 </tile> -->
+    <!--     <magnitude> 1 3 0 </magnitude> -->
+    <!--   </localWind> -->
+    <!--   <localWind> -->
+    <!--     <tile> 4 </tile> -->
+    <!--     <magnitude> 1 5 1 </magnitude> -->
+    <!--   </localWind> -->
+    <!-- </plugin> -->
 
-    <!-- The staging area -->
+   <!-- The staging area -->
     <include>
       <static>true</static>
       <name>staging_area</name>

--- a/subt_ign/worlds/cave_circuit_practice_01.sdf
+++ b/subt_ign/worlds/cave_circuit_practice_01.sdf
@@ -18,20 +18,6 @@
        <temperature>288</temperature>
        <temperature_gradient>0.2</temperature_gradient>
     </atmosphere>
- 
-    <!-- Probably it's better to add this plugin in the launch files -->
-    <!-- Adding it here for testing -->
-    <!-- <plugin filename="libLocalWindPlugin.so" name="subt::LocalWind"> -->
-    <!--   <scaling>0.8</scaling> -->
-    <!--   <localWind> -->
-    <!--     <tile> 1 </tile> -->
-    <!--     <magnitude> 1 3 0 </magnitude> -->
-    <!--   </localWind> -->
-    <!--   <localWind> -->
-    <!--     <tile> 4 </tile> -->
-    <!--     <magnitude> 1 5 1 </magnitude> -->
-    <!--   </localWind> -->
-    <!-- </plugin> -->
 
    <!-- The staging area -->
     <include>


### PR DESCRIPTION
Haven't test it yet. Works as a plugin attached to a world, iterates over all the links with wind_enabled, and based on their XYZ, if those are in a tile with wind defined, then the wind force is added. Re-uses VisibilityTable functionality to map XYZ points of the map to tiles.

Expected usage of the plugin would be something like:

    <plugin filename="libLocalWindPlugin.so" name="subt::LocalWindPlugin">                                                                                                                                 
      <scaling>0.8</scaling>
      <localWind>
        <tile> 1 </tile>
        <magnitude> 1 3 0 </magnitude>
      </localWind>
      <localWind>
        <tile> 1 </tile>
        <magnitude> 1 3 0 </magnitude>
      </localWind>
    </plugin>

The added force follows the equation: f = mass * scaling factor * (tile_wind - current_link_velocity )

Signed-off-by: Jorge Perez <jjperez@ekumenlabs.com>