### PR TITLE
CTU-CRAS-Norlab Husky and Marmotte: Fix installation of example world

### DIFF
--- a/submitted_models/ctu_cras_norlab_husky_sensor_config_1/CMakeLists.txt
+++ b/submitted_models/ctu_cras_norlab_husky_sensor_config_1/CMakeLists.txt
@@ -5,7 +5,7 @@ find_package(catkin REQUIRED)
 
 catkin_package()
 
-install(DIRECTORY launch meshes materials urdf
+install(DIRECTORY launch meshes materials urdf worlds
   DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION})
 
 install(FILES model.sdf model.config

--- a/submitted_models/ctu_cras_norlab_marmotte_sensor_config_1/CMakeLists.txt
+++ b/submitted_models/ctu_cras_norlab_marmotte_sensor_config_1/CMakeLists.txt
@@ -5,7 +5,7 @@ find_package(catkin REQUIRED)
 
 catkin_package()
 
-install(DIRECTORY launch meshes materials urdf
+install(DIRECTORY launch meshes materials urdf worlds
   DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION})
 
 install(FILES model.sdf model.config


### PR DESCRIPTION
The world is used by `launch/example.ign`.