### PR TITLE
Added dynamic collapse region event, and prevent extra fog

### DIFF
--- a/subt_ign/src/GameLogicPlugin.cc
+++ b/subt_ign/src/GameLogicPlugin.cc
@@ -533,9 +533,9 @@ class subt::GameLogicPluginPrivate
   /// fall model.
   public: std::map<std::string, std::pair<int, int>> rockFallsMax;
 
-  /// \brief Map of model name to {sim_time_sec, deployments_over_max}. This
-  /// map is used to log when no more dynamic collapses are possible.
-  public: std::map<std::string, int> dynamicCollapseMax;
+  /// \brief Map of model name to bool. This map is used to log when no more
+  /// dynamic collapses are possible.
+  public: std::map<std::string, bool> dynamicCollapseMax;
 
   /// \brief Map of model name to deployments_over_max. This map
   /// is used to log when no more breadcrumb deployments are possible.
@@ -1442,7 +1442,7 @@ void GameLogicPlugin::PostUpdate(
 
         // Subscribe to remaining dynamic collapse deploy topics. We are doing a
         // blanket subscribe even though a model in this function may not be
-        // a rock fall.
+        // a dynamic collapse.
         if (this->dataPtr->dynamicCollapseMax.find(_nameComp->Data()) ==
             this->dataPtr->dynamicCollapseMax.end())
         {
@@ -1453,6 +1453,7 @@ void GameLogicPlugin::PostUpdate(
               &GameLogicPluginPrivate::OnDynamicCollapseDeployRemainingEvent,
               this->dataPtr.get());
         }
+
         {
           std::lock_guard<std::mutex> lock(this->dataPtr->posesMutex);
           this->dataPtr->poses[_nameComp->Data()] = _poseComp->Data();

--- a/subt_ign/src/GameLogicPlugin.cc
+++ b/subt_ign/src/GameLogicPlugin.cc
@@ -222,6 +222,13 @@ class subt::GameLogicPluginPrivate
     const ignition::msgs::Int32 &_msg,
     const transport::MessageInfo &_info);
 
+  /// \brief Dynamic collapse remaining subscription callback.
+  /// \param[in] _msg Remaining count.
+  /// \param[in] _info Message information.
+  public: void OnDynamicCollapseDeployRemainingEvent(
+    const ignition::msgs::Int32 &_msg,
+    const transport::MessageInfo &_info);
+
   /// \brief Rock fall remaining subscription callback.
   /// \param[in] _msg Remaining count.
   /// \param[in] _info Message information.
@@ -525,6 +532,10 @@ class subt::GameLogicPluginPrivate
   /// map is used to log when no more rock falls are possible for a rock
   /// fall model.
   public: std::map<std::string, std::pair<int, int>> rockFallsMax;
+
+  /// \brief Map of model name to {sim_time_sec, deployments_over_max}. This
+  /// map is used to log when no more dynamic collapses are possible.
+  public: std::map<std::string, int> dynamicCollapseMax;
 
   /// \brief Map of model name to deployments_over_max. This map
   /// is used to log when no more breadcrumb deployments are possible.
@@ -868,6 +879,39 @@ void GameLogicPluginPrivate::OnBreadcrumbDeployRemainingEvent(
     }
 
     this->breadcrumbsMax[name]++;
+  }
+}
+
+//////////////////////////////////////////////////
+void GameLogicPluginPrivate::OnDynamicCollapseDeployRemainingEvent(
+    const ignition::msgs::Int32 &/*_msg*/,
+    const transport::MessageInfo &_info)
+{
+  ignition::msgs::Time localSimTime(this->simTime);
+  std::vector<std::string> topicParts = common::split(_info.Topic(), "/");
+  std::string name = "_unknown_";
+
+  // Get the name of the model from the topic name, where the topic name
+  // look like '/model/{model_name}/deploy'.
+  if (topicParts.size() > 1)
+    name = topicParts[1];
+
+  if (!this->dynamicCollapseMax[name])
+  {
+    std::lock_guard<std::mutex> lock(this->eventCounterMutex);
+    std::ostringstream stream;
+    stream
+      << "- event:\n"
+      << "  id: " << this->eventCounter << "\n"
+      << "  type: dynamic_collapse\n"
+      << "  time_sec: " << localSimTime.sec() << "\n"
+      << "  model: " << name << std::endl;
+
+    this->LogEvent(stream.str());
+    this->PublishRegionEvent(localSimTime, "dynamic_collapse", "", name,
+        "dynamic_collapse", this->eventCounter);
+    this->eventCounter++;
+    this->dynamicCollapseMax[name] = true;
   }
 }
 
@@ -1396,6 +1440,19 @@ void GameLogicPlugin::PostUpdate(
               this->dataPtr.get());
         }
 
+        // Subscribe to remaining dynamic collapse deploy topics. We are doing a
+        // blanket subscribe even though a model in this function may not be
+        // a rock fall.
+        if (this->dataPtr->dynamicCollapseMax.find(_nameComp->Data()) ==
+            this->dataPtr->dynamicCollapseMax.end())
+        {
+          std::string deployRemainingTopic = std::string("/model/") +
+                  _nameComp->Data() + "/breadcrumbs/Wall/deploy/remaining";
+          this->dataPtr->dynamicCollapseMax[_nameComp->Data()] = false;
+          this->dataPtr->node.Subscribe(deployRemainingTopic,
+              &GameLogicPluginPrivate::OnDynamicCollapseDeployRemainingEvent,
+              this->dataPtr.get());
+        }
         {
           std::lock_guard<std::mutex> lock(this->dataPtr->posesMutex);
           this->dataPtr->poses[_nameComp->Data()] = _poseComp->Data();

--- a/subt_ign/worlds/finals_practice_01.sdf
+++ b/subt_ign/worlds/finals_practice_01.sdf
@@ -2867,9 +2867,11 @@
         <delay_ms>2500</delay_ms>
         <output type="ignition.msgs.ParticleEmitter" topic="/model/debris_wall_1_fog_emitter_1/link/link/particle_emitter/dust_generator/cmd">
           emitting:{data: 0}
+          rate:{data: 0}
         </output>
         <output type="ignition.msgs.ParticleEmitter" topic="/model/debris_wall_1_fog_emitter_2/link/link/particle_emitter/dust_generator/cmd">
           emitting:{data: 0}
+          rate:{data: 0}
         </output>
       </plugin>
     </model>

--- a/subt_ign/worlds/finals_practice_02.sdf
+++ b/subt_ign/worlds/finals_practice_02.sdf
@@ -686,9 +686,11 @@
         <delay_ms>2500</delay_ms>
         <output type="ignition.msgs.ParticleEmitter" topic="/model/debris_wall_1_fog_emitter_1/link/link/particle_emitter/dust_generator/cmd">
           emitting:{data: 0}
+          rate:{data: 0}
         </output>
         <output type="ignition.msgs.ParticleEmitter" topic="/model/debris_wall_1_fog_emitter_2/link/link/particle_emitter/dust_generator/cmd">
           emitting:{data: 0}
+          rate:{data: 0}
         </output>
       </plugin>
     </model>
@@ -821,9 +823,11 @@
         <delay_ms>2500</delay_ms>
         <output type="ignition.msgs.ParticleEmitter" topic="/model/debris_wall_2_fog_emitter_1/link/link/particle_emitter/dust_generator/cmd">
           emitting:{data: 0}
+          rate:{data: 0}
         </output>
         <output type="ignition.msgs.ParticleEmitter" topic="/model/debris_wall_2_fog_emitter_2/link/link/particle_emitter/dust_generator/cmd">
           emitting:{data: 0}
+          rate:{data: 0}
         </output>
       </plugin>
     </model>


### PR DESCRIPTION
Adds region events to dynamic collapse obstacles.

To test:

1. `ign launch cloudsim_sim.ign worldName:=finals_practice_01 circuit:=finals robotName1:=X1 robotConfig1:=X1_SENSOR_CONFIG_1 ros:=true durationSec:=3600`
2. Follow the robot in the GUI.
3. `rostopic echo /subt/region_event`
4. `tail -f /tmp/ign/logs/gazebo/events.yml`
5. `ign service -s /world/finals_practice_01/set_pose /set_pose --reqtype ignition.msgs.Pose --reptype ignition.msgs.Boolean --timeout 300 --req 'name: "X1", position {x:22 y:22 z:.15}, orientation {z:0.707 w:0.707}'`
6. `ign service -s /world/finals_practice_01/set_pose /set_pose --reqtype ignition.msgs.Pose --reptype ignition.msgs.Boolean --timeout 300 --req 'name: "X1", position {x:22 y:16 z:.15}, orientation {z:0.707 w:0.707}'`

After step 6, you should see:

**From the rostopic echo:**
```
---
timestamp: 
  secs: 389
  nsecs:  92000000
event_type: "dynamic_collapse"
robot_name: ''
detector: "debris_wall_1"
state: "dynamic_collapse"
event_id: 7
```

**In  /tmp/ign/logs/gazebo/events.yml**
```
- event:
  id: 7
  type: dynamic_collapse
  time_sec: 389
  model: debris_wall_1
```

Signed-off-by: Nate Koenig <nate@openrobotics.org>