### PR TITLE
Marsupial update  for Marble Husky

### DIFF
--- a/submitted_models/marble_husky_sensor_config_1/model.sdf
+++ b/submitted_models/marble_husky_sensor_config_1/model.sdf
@@ -130,11 +130,11 @@
           </box>
         </geometry>
       </collision>
-      <collision name="base_link_fixed_joint_lump__computer_block_9">
-       <pose frame="">0.050 0 0.185 0 -0 0</pose>
+      <collision name="base_link_fixed_joint_lump__landing_pad_9">
+        <pose>0.0 0 0.155 0 -0 0</pose>
         <geometry>
           <box>
-            <size>0.30 0.355 0.175</size>
+            <size>0.500 0.385 0.155</size>
           </box>
         </geometry>
       </collision>
@@ -256,11 +256,11 @@
           </box>
         </geometry>
       </visual>
-      <visual name="base_link_fixed_joint_lump__computer_block_17">
-       <pose frame="">0.050 0 0.185 0 -0 0</pose>
+      <visual name="base_link_fixed_joint_lump__landing_pad_17">
+       <pose>0.0 0 0.155 0 -0 0</pose>
         <geometry>
           <box>
-            <size>0.30 0.355 0.175</size>
+            <size>0.500 0.385 0.155</size>
           </box>
         </geometry>
       </visual>

--- a/submitted_models/marble_husky_sensor_config_1/specifications.md
+++ b/submitted_models/marble_husky_sensor_config_1/specifications.md
@@ -6,6 +6,9 @@ This specifications.md file is a description and proof of virtual model validati
 ## Description
 This configuration is based on Clearpath Robotics Husky ground robot. The marble sensor suite is located at the front of the husky and includes stationary sensors and some sensors and a light on a pan/tilt mechanism.  
 
+## Marsupial Configuration
+This vehicle has a platform behind it with mechanical grippers (not modeled) that allow for deployment of UAVs. A QAV500 vehicle is the target marsupial vehicle but multiple vehicle platforms are possible and that is represented accordingly here in simulation.
+
 ## Usage Instructions
 The robot can be used in the same manner as the COSTAR Husky robot.  It accepts twist messages on the cmd_vel topic.  The gimbal can be controlled using the test_gimbal.sh script (in this folder).  There are also scripts to print the current angles from the pan and tilt axes of the gimbal (pan_echo.sh and tilt_echo.sh). 
 

--- a/submitted_models/marble_husky_sensor_config_3/model.sdf
+++ b/submitted_models/marble_husky_sensor_config_3/model.sdf
@@ -130,11 +130,11 @@
           </box>
         </geometry>
       </collision>
-      <collision name="base_link_fixed_joint_lump__computer_block_9">
-       <pose frame="">0.050 0 0.185 0 -0 0</pose>
+      <collision name="base_link_fixed_joint_lump__landing_pad_9">
+        <pose>0.0 0 0.155 0 -0 0</pose>
         <geometry>
           <box>
-            <size>0.30 0.355 0.175</size>
+            <size>0.500 0.385 0.155</size>
           </box>
         </geometry>
       </collision>
@@ -256,11 +256,11 @@
           </box>
         </geometry>
       </visual>
-      <visual name="base_link_fixed_joint_lump__computer_block_17">
-       <pose frame="">0.050 0 0.185 0 -0 0</pose>
+      <visual name="base_link_fixed_joint_lump__landing_pad_17">
+       <pose>0.0 0 0.155 0 -0 0</pose>
         <geometry>
           <box>
-            <size>0.30 0.355 0.175</size>
+            <size>0.500 0.385 0.155</size>
           </box>
         </geometry>
       </visual>

--- a/submitted_models/marble_husky_sensor_config_4/model.sdf
+++ b/submitted_models/marble_husky_sensor_config_4/model.sdf
@@ -130,11 +130,11 @@
           </box>
         </geometry>
       </collision>
-      <collision name="base_link_fixed_joint_lump__computer_block_9">
-       <pose frame="">0.050 0 0.185 0 -0 0</pose>
+      <collision name="base_link_fixed_joint_lump__landing_pad_9">
+        <pose>0.0 0 0.155 0 -0 0</pose>
         <geometry>
           <box>
-            <size>0.30 0.355 0.175</size>
+            <size>0.500 0.385 0.155</size>
           </box>
         </geometry>
       </collision>
@@ -256,11 +256,11 @@
           </box>
         </geometry>
       </visual>
-      <visual name="base_link_fixed_joint_lump__computer_block_17">
-       <pose frame="">0.050 0 0.185 0 -0 0</pose>
+      <visual name="base_link_fixed_joint_lump__landing_pad_17">
+       <pose>0.0 0 0.155 0 -0 0</pose>
         <geometry>
           <box>
-            <size>0.30 0.355 0.175</size>
+            <size>0.500 0.385 0.155</size>
           </box>
         </geometry>
       </visual>

--- a/submitted_models/marble_husky_sensor_config_5/model.sdf
+++ b/submitted_models/marble_husky_sensor_config_5/model.sdf
@@ -99,11 +99,11 @@
           </box>
         </geometry>
       </collision>
-      <collision name="base_link_fixed_joint_lump__computer_block_9">
-       <pose>0.050 0 0.185 0 -0 0</pose>
+      <collision name="base_link_fixed_joint_lump__landing_pad_9">
+        <pose>0.0 0 0.155 0 -0 0</pose>
         <geometry>
           <box>
-            <size>0.30 0.355 0.175</size>
+            <size>0.500 0.385 0.155</size>
           </box>
         </geometry>
       </collision>
@@ -170,11 +170,11 @@
           </box>
         </geometry>
       </visual>
-      <visual name="base_link_fixed_joint_lump__computer_block_17">
-       <pose>0.050 0 0.185 0 -0 0</pose>
+      <visual name="base_link_fixed_joint_lump__landing_pad_17">
+       <pose>0.0 0 0.155 0 -0 0</pose>
         <geometry>
           <box>
-            <size>0.30 0.355 0.175</size>
+            <size>0.500 0.385 0.155</size>
           </box>
         </geometry>
       </visual>

--- a/submitted_models/marble_husky_sensor_config_5/specifications.md
+++ b/submitted_models/marble_husky_sensor_config_5/specifications.md
@@ -7,7 +7,10 @@ This specifications.md file is a description and proof of virtual model validati
 This configuration is based on Clearpath Robotics Husky ground robot. The marble sensor suite is located at the front of the husky and includes 2 3D LIDARs, 1 Planar LIDAR, 4 RGB Cameras, and 2 Picco Flexx TOF cameras  
 
 ## Usage Instructions
-The robot can be used in the same manner as the COSTAR Husky robot.  It accepts twist messages on the cmd_vel topic.  
+The robot can be used in the same manner as the COSTAR Husky robot.  It accepts twist messages on the cmd_vel topic. 
+
+## Marsupial Configuration
+This vehicle has a platform behind it with mechanical grippers (not modeled) that allow for deployment of UAVs. A QAV500 vehicle is the target marsupial vehicle but multiple vehicle platforms are possible and that is represented accordingly here in simulation.
 
 ## Usage Rights
 The same Rights are granted for the configuration as for the COSTAR Husky. No additional restrictions have to be taken into account for this configuration.

--- a/subt_ign/launch/competition.ign
+++ b/subt_ign/launch/competition.ign
@@ -116,6 +116,7 @@
 
   MARSUPIAL_PARENT_LINK_NAMES = {
      "X1" => "base_link",
+     "MARBLE_HUSKY" => "base_link",
      "EXPLORER_X1" => "base_link",
      "EXPLORER_R2" => "Rear_Rocker_Link",
      "CSIRO_DATA61_OZBOT_ATR" => "base_link",
@@ -127,6 +128,7 @@
 
   MARSUPIAL_VALID_ROBOT_PAIRS = {
     "X1" => ["X3", "MARBLE_QAV500", "CERBERUS_GAGARIN", "CERBERUS_RMF", "COSTAR_SHAFTER", "CORO_PAM", "CTU_CRAS_NORLAB_X500", "CORO_CRYSTAL"],
+    "MARBLE_HUSKY" =>["X3", "MARBLE_QAV500", "CERBERUS_GAGARIN", "CERBERUS_RMF", "COSTAR_SHAFTER", "CORO_PAM", "CTU_CRAS_NORLAB_X500", "CORO_CRYSTAL"],
     "CORO_ALLIE" => ["CERBERUS_RMF", "CORO_PAM", "CORO_CRYSTAL"],
     "CORO_JEANINE" => ["CERBERUS_RMF", "CORO_PAM", "CORO_CRYSTAL"],
     "CORO_KAREN" => ["CERBERUS_RMF", "CORO_PAM", "CORO_CRYSTAL"],
@@ -138,6 +140,7 @@
 
   MARSUPIAL_PARENT_ROBOT_POSITION_OFFSETS = {
     "X1" => Vector3d.new(0, 0, 0.717),
+    "MARBLE_HUSKY" => Vector3d.new(-0.06, 0, 0.392),
     "EXPLORER_X1" => Vector3d.new(0, 0, 0.717),
     "EXPLORER_R2" => Vector3d.new(-0.402375, 0, 0.6874),
     "CSIRO_DATA61_OZBOT_ATR" => Vector3d.new(-0.15, 0, 0.528),
@@ -149,6 +152,7 @@
 
   MARSUPIAL_PARENT_ROBOT_ROTATION_OFFSETS = {
     "X1" => AngularVector3d.new(0, 0, 0),
+    "MARBLE_HUSKY" => AngularVector3d.new(0, 0, 0),
     "EXPLORER_X1" => AngularVector3d.new(0, 0, 0),
     "EXPLORER_R2" => AngularVector3d.new(0, 0, -3.1416),
     "CSIRO_DATA61_OZBOT_ATR" => AngularVector3d.new(0, 0, -3.1416),
@@ -300,7 +304,7 @@
     <record>
       <enabled>true</enabled>
       <!-- This path is used by cloudsim, please do not change -->
-      <path>/tmp/ign/logs/gazebo</path>
+      <path>/tmp/ign/logs</path>
       <overwrite>true</overwrite>
     </record>
     <%if defined?(seed) && seed != nil && !seed.empty?%>
@@ -367,7 +371,6 @@
       <!-- The collection of artifacts to locate -->
       <world_name><%= $worldName %></world_name>
       <ros>false</ros>
-      <ke_height>0.078</ke_height>
 
       <duration_seconds><%= $durationSec %></duration_seconds>
 
@@ -562,7 +565,7 @@
             <publish_nested_model_pose>#{$enableGroundTruth}</publish_nested_model_pose>
             <use_pose_vector_msg>true</use_pose_vector_msg>
             <static_publisher>true</static_publisher>
-            <static_update_frequency>1</static_update_frequency>
+            <static_update_frequency>50</static_update_frequency>
           </plugin>
           <!-- Battery plugin -->
           <plugin filename="libignition-gazebo-linearbatteryplugin-system.so"
@@ -705,7 +708,7 @@
             <publish_nested_model_pose>#{$enableGroundTruth}</publish_nested_model_pose>
             <use_pose_vector_msg>true</use_pose_vector_msg>
             <static_publisher>true</static_publisher>
-            <static_update_frequency>1</static_update_frequency>
+            <static_update_frequency>50</static_update_frequency>
           </plugin>
           <!-- Battery plugin -->
           <plugin filename="libignition-gazebo-linearbatteryplugin-system.so"
@@ -825,7 +828,7 @@
           <publish_nested_model_pose>#{$enableGroundTruth}</publish_nested_model_pose>
           <use_pose_vector_msg>true</use_pose_vector_msg>
           <static_publisher>true</static_publisher>
-          <static_update_frequency>1</static_update_frequency>
+          <static_update_frequency>50</static_update_frequency>
         </plugin>
         <plugin filename="libignition-gazebo-multicopter-motor-model-system.so"
           name="ignition::gazebo::systems::MulticopterMotorModel">
@@ -1030,7 +1033,7 @@
           <publish_nested_model_pose>#{$enableGroundTruth}</publish_nested_model_pose>
           <use_pose_vector_msg>true</use_pose_vector_msg>
           <static_publisher>true</static_publisher>
-          <static_update_frequency>1</static_update_frequency>
+          <static_update_frequency>50</static_update_frequency>
         </plugin>
         <plugin filename="libignition-gazebo-multicopter-motor-model-system.so"
           name="ignition::gazebo::systems::MulticopterMotorModel">


### PR DESCRIPTION
As requested [here](https://github.com/osrf/subt/pull/920#issuecomment-848776550****), the Marble Husky Vehicles have been updated for marsupial ability. Earlier sensor configurations were also marsupial compatible (in hardware) but the capability did not exist yet in simulation at the time of their making. Let me know if we need any other data or changes for this PR. Thanks guys!