### PR TITLE
Limit websocket publish rate and message queue size

### DIFF
--- a/subt_ign/launch/cloudsim_sim.ign
+++ b/subt_ign/launch/cloudsim_sim.ign
@@ -344,6 +344,13 @@
     <authorization_key><%= $websocketAuthKey %></authorization_key>
     <admin_authorization_key><%= $websocketAdminAuthKey %></admin_authorization_key>
     <max_connections><%= $websocketMaxConnections  %></max_connections>
+    <queue_size_per_connection>10</queue_size_per_connection>
+    <subscription_limit_per_connection>
+      <subscription>
+        <msg_type>ignition.msgs.PointCloudPacked</msg_type>
+        <limit>1</limit>
+      </subscription>
+    </subscription_limit_per_connection>
     <ssl>
       <cert_file><%= $websocketSSLCertFile %></cert_file>
       <private_key_file><%= $websocketSSLKeyFile %></private_key_file>

--- a/subt_ign/launch/cloudsim_sim.ign
+++ b/subt_ign/launch/cloudsim_sim.ign
@@ -350,6 +350,10 @@
         <msg_type>ignition.msgs.PointCloudPacked</msg_type>
         <limit>1</limit>
       </subscription>
+      <subscription>
+        <msg_type>ignition.msgs.Image</msg_type>
+        <limit>6</limit>
+      </subscription>
     </subscription_limit_per_connection>
     <ssl>
       <cert_file><%= $websocketSSLCertFile %></cert_file>


### PR DESCRIPTION
depends on https://github.com/ignitionrobotics/ign-launch/pull/116

This PR sets 2 new websocket server params.

1. sets a limit for websocket server's message queue size per connection to prevent the queue from growing infinitely which could lead to out of memory issue. It's current set to 10 but can be changed.

2. sets the limit for number of point cloud subscriptions per connection to 1 per connection, i.e. each client can only subscribe to 1 point cloud topic (to avoid using up all the available bandwidth)



Signed-off-by: Ian Chen <ichen@osrfoundation.org>