### PR TITLE
Adjust x500 depth camera positions to match visuals

### DIFF
--- a/submitted_models/ctu_cras_norlab_x500_sensor_config_1/model.sdf
+++ b/submitted_models/ctu_cras_norlab_x500_sensor_config_1/model.sdf
@@ -35,7 +35,7 @@
       </sensor>
 
       <sensor name="rs_up" type="rgbd_camera">
-          <pose>0.082 0 0.034 0 -1.57079632679 0</pose>
+          <pose>0.082 0 0.06 0 -1.57079632679 0</pose>
           <always_on>1</always_on>
           <update_rate>30</update_rate>
           <camera name="rs_up">
@@ -84,7 +84,7 @@
       </sensor>
 
       <sensor name="rs_down" type="rgbd_camera">
-          <pose>0.085 0 -0.20 0 1.57079632679 0</pose>
+          <pose>0.085 0 -0.046 0 1.57079632679 0</pose>
           <always_on>1</always_on>
           <update_rate>30</update_rate>
           <camera name="rs_down">


### PR DESCRIPTION
The ctu_cras_norlab_x500_sensor_config_1 depth camera z positions were off by a bit.  The upper sensor was below the camera visual and the lower sensor was below the floor.   See before.png and after.png

The moves the sensor location to match the visual location and will reduce the intermittent -inf and seeing through the floor issues.
Before:
![before](https://user-images.githubusercontent.com/4065104/122832455-32929680-d2a0-11eb-9025-1b33621469b8.png)
After:
![after](https://user-images.githubusercontent.com/4065104/122832470-39b9a480-d2a0-11eb-9e82-ed5da3f146c1.png)


