### PR TITLE
Fix X500 kinetic energy threshold

### DIFF
--- a/subt_ign/include/subt_ign/RobotPlatformTypes.hh
+++ b/subt_ign/include/subt_ign/RobotPlatformTypes.hh
@@ -53,7 +53,7 @@ const std::map<std::string, double> robotPlatformTypes = {
   {"X2", 1},
   {"X3", 8}, // UAV, no prop guards
   {"X4", 8}, // UAV, no prop guards
-  {"X500", 8} // UAV, no prop guards
+  {"X500", 5} // UAV, no prop guards
 };
 
 #endif

--- a/subt_ign/src/GameLogicPlugin.cc
+++ b/subt_ign/src/GameLogicPlugin.cc
@@ -1247,7 +1247,10 @@ void GameLogicPlugin::PreUpdate(const UpdateInfo &_info,
     for (auto &ke : this->dataPtr->keInfo)
     {
       ignition::gazebo::Link link(ke.second.link);
-      if (std::nullopt != link.WorldKineticEnergy(_ecm))
+      if (std::nullopt != link.WorldKineticEnergy(_ecm) &&
+          robotPlatformTypes.find(
+          this->dataPtr->robotFullTypes[ke.second.robotName].first) !=
+          robotPlatformTypes.end())
       {
         double currKineticEnergy = *link.WorldKineticEnergy(_ecm);
 


### PR DESCRIPTION
Resolves issue #954.

I tested each robot type using the steps described in issue #954:
1. Start simulation with a cave world.
2. `rostopic pub -1 X1/cmd_vel geometry_msgs/Twist -- '[0,0,5]' '[0,0,0]'`
3. Wait for the robot to reach the grass area above the cave entrance
4. `rostopic pub -1 X1/cmd_vel geometry_msgs/Twist -- '[0,0,0]' '[0,0,0]'`

I found an issue only with the X500 robot. The minimum factor that would trigger a collision was 5.2. Based on this, I updated the X500 to have a factor of 5.

The update to the `if` statement is just an extra safety check to make sure that the `maps` have been initialized.

Signed-off-by: Nate Koenig <nate@openrobotics.org>