### PR TITLE
Disable IMU orientation output

### DIFF
--- a/subt_ign/launch/cloudsim_sim.ign
+++ b/subt_ign/launch/cloudsim_sim.ign
@@ -419,6 +419,7 @@
             entity_type="world"
             filename="libignition-gazebo-imu-system.so"
             name="ignition::gazebo::systems::Imu">
+      <output_orientation>false<output_orientation>
     </plugin>
 
     <plugin entity_name="<%= $worldName %>"

--- a/subt_ign/launch/competition.ign
+++ b/subt_ign/launch/competition.ign
@@ -333,6 +333,7 @@
             entity_type="world"
             filename="libignition-gazebo-imu-system.so"
             name="ignition::gazebo::systems::Imu">
+      <output_orientation>false</output_orientation>
     </plugin>
 
     <plugin entity_name="<%= $worldName %>"


### PR DESCRIPTION
Signed-off-by: Ian Chen <ichen@osrfoundation.org>

Depends on:
* https://github.com/ignitionrobotics/ign-sensors/pull/142
* https://github.com/ignitionrobotics/ign-gazebo/pull/899
* https://github.com/ignitionrobotics/ros_ign/pull/168

Updates the imu system to disable publishing orientation data. With this change, the orientation values in the ROS imu msg should now be zeros, and the first element of the `orientation_covariance` field is set to -1 as per [ROS imu msg documentation](http://docs.ros.org/en/melodic/api/sensor_msgs/html/msg/Imu.html).

To test, launch any world with a UAV robot, e.g.:

```
ign launch -v 4 competition.ign worldName:=simple_cave_01 circuit:=cave robotName1:=X4 robotConfig1:=X4_SENSOR_CONFIG_1
```

and echo the imu msg to see that the orientation is now zeros:

```
rostopic echo /X4/imu/data
```

Example output:

```
header: 
  seq: 12506
  stamp: 
    secs: 50
    nsecs:  32000000
  frame_id: "X1/base_link/imu_sensor"
orientation: 
  x: 0.0
  y: 0.0
  z: 0.0
  w: 0.0
orientation_covariance: [-1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0]
angular_velocity: 
  x: 0.000139300054549
  y: 5.63009660877e-05
  z: -0.000108313959937
angular_velocity_covariance: [0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0]
linear_acceleration: 
  x: -0.0891951904981
  y: -0.0936655693381
  z: 9.87060748913
linear_acceleration_covariance: [0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0]
```
