### PR TITLE
Fix issue #643

### DIFF
--- a/subt-communication/subt_communication_broker/src/subt_communication_broker.cpp
+++ b/subt-communication/subt_communication_broker/src/subt_communication_broker.cpp
@@ -216,7 +216,8 @@ void Broker::DispatchMessages()
 
         bool sendPacket;
         double rssi;
-        std::tie(sendPacket, rssi) =
+        bool usingBreadcrumbs;
+        std::tie(sendPacket, rssi, usingBreadcrumbs) =
           communication_function(txNode->second->radio,
                                  txNode->second->rf_state,
                                  rxNode->second->rf_state,
@@ -224,6 +225,9 @@ void Broker::DispatchMessages()
 
         if (sendPacket)
         {
+          // When using a breadcrumb we don't include the rssi
+          if (usingBreadcrumbs)
+            rssi = std::numeric_limits<double>::lowest();
           msg.set_rssi(rssi);
 
           if (!this->node.Request(client.address, msg))

--- a/subt-communication/subt_communication_broker/src/subt_communication_client.cpp
+++ b/subt-communication/subt_communication_broker/src/subt_communication_client.cpp
@@ -452,8 +452,11 @@ bool CommsClient::OnMessageRos(subt_msgs::DatagramRos::Request &_req,
 
   std::lock_guard<std::mutex> lock(this->mutex);
 
-  this->neighbors[_req.src_address] =
-      std::make_pair(ros::Time::now().toSec(), _req.rssi);
+  if (_req.rssi > std::numeric_limits<double>::lowest())
+  {
+    this->neighbors[_req.src_address] =
+        std::make_pair(ros::Time::now().toSec(), _req.rssi);
+  }
 
   for (auto cb : this->callbacks)
   {

--- a/subt-communication/subt_communication_model/include/subt_communication_model/subt_communication_model.h
+++ b/subt-communication/subt_communication_model/include/subt_communication_model/subt_communication_model.h
@@ -75,9 +75,10 @@ inline std::ostream& operator<<(std::ostream& oss,
 /// @param tx_state Current state of the transmitter (pose)
 /// @param rx_state Current state of the receiver (pose)
 /// @param num_bytes Size of the packet
-/// @return std::tuple<bool, double> reporting if the packet should be
-/// delivered and the received signal strength (in dBm)
-std::tuple<bool, double>
+/// @return std::tuple<bool, double, bool> reporting if the packet should be
+/// delivered, the received signal strength (in dBm) and if breadcrumbs were
+/// used.
+std::tuple<bool, double, bool>
 attempt_send(const radio_configuration& radio,
              rf_interface::radio_state& tx_state,
              rf_interface::radio_state& rx_state,
@@ -85,7 +86,7 @@ attempt_send(const radio_configuration& radio,
              );
 
 /// Function signature for the communication model.
-typedef std::function<std::tuple<bool, double>(const radio_configuration&,
+typedef std::function<std::tuple<bool, double, bool>(const radio_configuration&,
                            rf_interface::radio_state&,
                            rf_interface::radio_state&,
                            const uint64_t&)> communication_function;

--- a/subt-communication/subt_communication_model/tests/unit_test.cpp
+++ b/subt-communication/subt_communication_model/tests/unit_test.cpp
@@ -51,10 +51,11 @@ TEST(range_based, co_located)
 
   bool send_packet;
   double rssi;
-  std::tie(send_packet, rssi) = attempt_send(radio,
-                                             tx,  // TX state
-                                             rx,  // RX state
-                                             1000);    // 1Kb packet
+  bool usingBreadcrumbs;
+  std::tie(send_packet, rssi, usingBreadcrumbs) = attempt_send(radio,
+                                                    tx,  // TX state
+                                                    rx,  // RX state
+                                                    1000);    // 1Kb packet
 
   ASSERT_TRUE(send_packet);
 }

--- a/subt-communication/subt_rf_interface/include/subt_rf_interface/subt_rf_interface.h
+++ b/subt-communication/subt_rf_interface/include/subt_rf_interface/subt_rf_interface.h
@@ -65,7 +65,8 @@ struct rf_power
 /// Function signature for computing pathloss.
 typedef std::function<rf_power(const double&, // tx_power
                                radio_state&, // tx_state
-                               radio_state&  //rx_state
+                               radio_state&,  //rx_state
+                               bool& // using breadcumbs?
                                )> pathloss_function;
 
 

--- a/subt_ign/include/subt_ign/VisibilityRfModel.hh
+++ b/subt_ign/include/subt_ign/VisibilityRfModel.hh
@@ -80,12 +80,14 @@ namespace subt
         /// Compute received power function that will be given to
         /// communcation model.
         ///
-        /// @param tx_power Transmit power (dBm)
-        /// @param tx_state Transmitter state
-        /// @param rx_state Receiver state
+        /// @param _txPower Transmit power (dBm)
+        /// @param _txState Transmitter state
+        /// @param _rxState Receiver state
+        /// @param _usingBreadCrumbs True if one or more breadcrumbs were used
         public: rf_power ComputeReceivedPower(const double &_txPower,
                                               radio_state &_txState,
-                                              radio_state &_rxState);
+                                              radio_state &_rxState,
+                                              bool &_usingBreadcrumbs);
 
         /// \brief Whether the visibility model has been successfully
         /// initialized.

--- a/subt_ign/src/Common.cc
+++ b/subt_ign/src/Common.cc
@@ -106,6 +106,7 @@ bool FullWorldPath(const std::string &_worldName,
   const std::string tunnelPrefix = "tunnel_circuit_";
   const std::string urbanPrefix = "urban_circuit_";
   const std::string cavePrefix = "cave_circuit_";
+  const std::string finalPrefix = "final_event_";
   if (0 == _worldName.compare(0, tunnelPrefix.size(), tunnelPrefix))
   {
     std::string suffix = _worldName.substr(tunnelPrefix.size());
@@ -135,6 +136,12 @@ bool FullWorldPath(const std::string &_worldName,
       worldsDirectory = ignition::common::joinPaths(worldsDirectory,
           "cave_circuit", suffix);
     }
+  }
+  else if (_worldName.find(finalPrefix) != std::string::npos)
+  {
+    std::string suffix = _worldName.substr(finalPrefix.size());
+    worldsDirectory = ignition::common::joinPaths(worldsDirectory,
+        "final_event", suffix);
   }
   else if (_worldName.find("simple") == std::string::npos &&
            _worldName.find("_qual") == std::string::npos &&

--- a/subt_ign/src/CommsBrokerPlugin.cc
+++ b/subt_ign/src/CommsBrokerPlugin.cc
@@ -182,7 +182,8 @@ bool CommsBrokerPlugin::Load(const tinyxml2::XMLElement *_elem)
                 this->visibilityModel.get(),
                 std::placeholders::_1,
                 std::placeholders::_2,
-                std::placeholders::_3);
+                std::placeholders::_3,
+                std::placeholders::_4);
   }
 
   // Default comms model type is log_normal_range (will always work)


### PR DESCRIPTION
See issue #643.

This patch modifies the way we update the neighbor information. Now, we only update neighbor information when the message received came directly from a teammate, and not via a breadcrumb.

How to test it?

* Terminal 1 - Launch the simulation:
```
ign launch -v 4 competition.ign worldName:=simple_cave_01 circuit:=finals robotName1:=X1 robotConfig1:=X1_SENSOR_CONFIG_7 robotName2:=X2 robotConfig2:=X1_SENSOR_CONFIG_7
```

* Terminal 2 - Run an example node:
```
roslaunch subt_example example_robot.launch name:=X1
```

* Terminal 3 - Run an example node:
```
roslaunch subt_example example_robot.launch name:=X2
```

* Terminal 4 - Run the comms tester program:
```
rosrun subt_comms_test subt_comms_tester.py
```
* Start the comms from `X2` to `X1`:
```
Press the s key.
```

At this point you should see how `rssi` frequently updates indicating that `X2` is consider a neighbor.

Terminal 5:

* Move `X1`:
```
ign service -s /world/simple_cave_01/set_pose --reqtype ignition.msgs.Pose --reptype ignition.msgs.Boolean --timeout 1000 --req 'name: "X1", position: {x: 100, y: 0, z: 1}'
```
* Deploy a breadcrumb:
```
ign topic -t /model/X1/breadcrumb/deploy -m ignition.msgs.Empty -p 'unused:0'
```
* Move the robot:
```
ign service -s /world/simple_cave_01/set_pose --reqtype ignition.msgs.Pose --reptype ignition.msgs.Boolean --timeout 1000 --req 'name: "X1", position: {x: 175, y: 25, z: 4}'
data: true
```
Now you should observe how `rssi` stops updating and it should stay as `inf` indicating that `X2` is not a neighbor anymore. Note that communication is still happening via the breadcrumb as `Rx` keeps updating.

* Move the robot close to `X2` again:
```
ign service -s /world/simple_cave_01/set_pose --reqtype ignition.msgs.Pose --reptype ignition.msgs.Boolean --timeout 1000 --req 'name: "X1", position: {x: 50, y: 0, z: 1}'
```

`rssi` should resume updating indicating that `X2` is a neighbor again.


Signed-off-by: Carlos Agüero <caguero@openrobotics.org>