### PR TITLE
Increase collision tolerance by increasing KE height 

### DIFF
--- a/subt_ign/include/subt_ign/RobotPlatformTypes.hh
+++ b/subt_ign/include/subt_ign/RobotPlatformTypes.hh
@@ -20,12 +20,12 @@
 /// \brief List of robot platform types and kinetic energy threshold factor. This is used to count unique robot types and determine crashes.
 const std::map<std::string, double> robotPlatformTypes = {
   {"ABSOLEM", 1},
-  {"ALLIE", 0.7},
+  {"ALLIE", 1},
   {"ANYMAL_B", 1},
   {"ANYMAL_C", 1},
   {"CRYSTAL", 8}, // UAV, no prop guards
   {"DS1", 6}, // UAV, prop guards
-  {"DTR", 0.7},
+  {"DTR", 1},
   {"FREYJA", 1},
   {"GAGARIN", 1}, // UAV, collision tolerant
   {"HD2", 1},

--- a/subt_ign/include/subt_ign/RobotPlatformTypes.hh
+++ b/subt_ign/include/subt_ign/RobotPlatformTypes.hh
@@ -20,12 +20,12 @@
 /// \brief List of robot platform types and kinetic energy threshold factor. This is used to count unique robot types and determine crashes.
 const std::map<std::string, double> robotPlatformTypes = {
   {"ABSOLEM", 1},
-  {"ALLIE", 1},
+  {"ALLIE", 0.7},
   {"ANYMAL_B", 1},
   {"ANYMAL_C", 1},
   {"CRYSTAL", 8}, // UAV, no prop guards
   {"DS1", 6}, // UAV, prop guards
-  {"DTR", 1},
+  {"DTR", 0.7},
   {"FREYJA", 1},
   {"GAGARIN", 1}, // UAV, collision tolerant
   {"HD2", 1},

--- a/subt_ign/launch/cloudsim_sim.ign
+++ b/subt_ign/launch/cloudsim_sim.ign
@@ -452,7 +452,7 @@
             name="subt::GameLogicPlugin">
       <world_name><%= $worldName %></world_name>
       <ros><%= $ros %></ros>
-      <ke_height>0.078</ke_height>
+      <ke_height>0.24</ke_height>
 
       <duration_seconds><%= $durationSec %></duration_seconds>
 

--- a/subt_ign/launch/competition.ign
+++ b/subt_ign/launch/competition.ign
@@ -367,7 +367,7 @@
       <!-- The collection of artifacts to locate -->
       <world_name><%= $worldName %></world_name>
       <ros>false</ros>
-      <ke_height>0.078</ke_height>
+      <ke_height>0.24</ke_height>
 
       <duration_seconds><%= $durationSec %></duration_seconds>
 


### PR DESCRIPTION
addresses #967 

The KE height is now increased to a number that allows all wheeled robots to go over the hallway in the urban tile without suffering from collisions.

For testing, 

1. comment out [this line](https://github.com/osrf/subt/blob/final_event/subt_ign/src/GameLogicPlugin.cc#L1307) so you can teleport the robot without the collision detector triggering then rebuild subt.

1. launch sim with finals_practice_02 world:

    ```
    ign launch -v 4 competition.ign worldName:=finals_practice_02 circuit:=finals robotName1:=X1 robotConfig1:=CSIRO_DATA61_DTR_SENSOR_CONFIG_1
    ```

1. Move the robot to a few meters before the hallway:
    ```
    IGN_TRANSPORT_TOPIC_STATISTICS=1 ign service -s /world/finals_practice_02/set_pose --reqtype ignition.msgs.Pose --reptype ignition.msgs.Boolean --timeout 300 --req 'name: "X1", position: {x:11.2 y:-47 z: 0.818} orientation: {x:0 y:0 z:-0.7068252 w: 0.7068252 }'
    ```

1. Send vel cmds:

    ```
    rostopic pub  /X1/cmd_vel geometry_msgs/Twist -- '[3.0, 0.0, 0.0]' '[0.0, 0.0, 0.0]'
    ```

1. Monitor the events.yml log for collisions when the robot moves forward. Note you should see one collision entry due to robot falling to the ground after it was teleported.

    ```
    tail -f /tmp/ign/logs/events.yml
    ```

With the changes in this PR, you should not see any more collisions in the events.yml log file as the robot drives over the hallway threshold.

