### PR TITLE
Compute gas concentration in ppm

### DIFF
--- a/subt_ign/src/GasEmitterDetectorPlugin.cc
+++ b/subt_ign/src/GasEmitterDetectorPlugin.cc
@@ -18,6 +18,7 @@
 #include "subt_ign/GasEmitterDetectorPlugin.hh"
 
 #include <ignition/msgs/boolean.pb.h>
+#include <ignition/msgs/double.pb.h>
 
 #include <ignition/common/StringUtils.hh>
 #include <ignition/common/Console.hh>
@@ -63,6 +64,9 @@ class subt::GasDetectorPrivate
   /// \brief publisher to publish detections
   public: transport::Node::Publisher pub;
 
+  /// \brief publisher to publish ppm
+  public: transport::Node::Publisher ppmPub;
+
   /// \brief update rate
   public: double updateRate;
 
@@ -71,6 +75,38 @@ class subt::GasDetectorPrivate
 
   /// \brief Entity this sensor is attached to
   public: gazebo::Entity entity;
+
+  /// \brief response time
+  /// Defaut to SCD30 sensor. Response time: (t63) with 2s sampling interval
+  /// based on specification:
+  /// https://www.sensirion.com/scd30/
+  /// This is the time it takes to detect 63% of an instance change in gas
+  // quantity. Actual response time may be longer
+  public: double responseTime = 20.0;
+
+  // accuracy +-(30ppm + 3%MV)
+  public: double precision = 30.0;
+
+  /// \brief Min CO2 concentration.
+  /// Set default to global average atmospheric CO2
+  public: double minConcentration = 412.0;
+
+  /// \brief CO2 gas concentration based on subt finals artifact specification:
+  /// "The gas will be released into a confined area to maintain a concentration
+  /// of at least 1500 parts per million (ppm)"
+  public: double gasConcentration = 1500.0;
+
+  /// \brief Gas concentration range
+  /// The range at which the gas sensor reading will vary. The closer the
+  ///  gas sensor is to the emitter source, the higher the value of the
+  /// readings. The max output will be gasConcentration + gasConcentrationRange.
+  public: double gasConcentrationRange = 150.0;
+
+  /// \brief max gas concentration. Negative means unspecified.
+  public: double maxConcentration = -1;
+
+  /// \brief Contentration in ppm
+  public: double concentration = 0.0;
 };
 
 //////////////////////////////////////////////////
@@ -151,17 +187,57 @@ void GasDetector::Configure(
       gazebo::scopedName(_entity, _ecm) + "/leak").first;
   this->dataPtr->updateRate = _sdf->Get<double>("update_rate", 0.0).first;
 
+  // response time
+  this->dataPtr->responseTime = _sdf->Get<double>("response_time",
+      this->dataPtr->responseTime).first;
+
+  // precision in ppm
+  this->dataPtr->precision = _sdf->Get<double>("precision",
+      this->dataPtr->precision).first;
+
+  // min concentration in ppm
+  this->dataPtr->minConcentration = _sdf->Get<double>("min_concentration",
+      this->dataPtr->minConcentration).first;
+
+  // gas concentration in ppm
+  this->dataPtr->gasConcentration = _sdf->Get<double>("gas_concentration",
+      this->dataPtr->gasConcentration).first;
+
+  // gas concentration range ppm
+  this->dataPtr->gasConcentrationRange = _sdf->Get<double>(
+      "gas_concentration_range", this->dataPtr->gasConcentrationRange).first;
+
+  // max concentration in ppm
+  this->dataPtr->maxConcentration = _sdf->Get<double>("max_concentration",
+      this->dataPtr->maxConcentration).first;
+
+  // check max and min concentration
+  if (this->dataPtr->maxConcentration < this->dataPtr->minConcentration)
+  {
+    ignwarn << "Max concentration is lower than min concentration. "
+      << "Setting max to unbounded." << std::endl;
+    this->dataPtr->maxConcentration = -1;
+  }
+
+  // initialize current gas concentration to min value
+  this->dataPtr->concentration = this->dataPtr->minConcentration;
 
   if (this->dataPtr->updateRate > 0.0)
   {
     transport::AdvertiseMessageOptions opts;
     opts.SetMsgsPerSec(this->dataPtr->updateRate);
-    this->dataPtr->pub =  this->dataPtr->node.Advertise<msgs::Boolean>(
+
+    this->dataPtr->pub = this->dataPtr->node.Advertise<msgs::Boolean>(
         topic, opts);
+
+    this->dataPtr->ppmPub = this->dataPtr->node.Advertise<msgs::Double>(
+        topic + "/ppm", opts);
   }
   else
   {
     this->dataPtr->pub =  this->dataPtr->node.Advertise<msgs::Boolean>(topic);
+    this->dataPtr->ppmPub = this->dataPtr->node.Advertise<msgs::Double>(
+        topic + "/ppm");
   }
 }
 
@@ -175,6 +251,8 @@ void GasDetector::PostUpdate(
 
   auto detectorPose = gazebo::worldPose(this->dataPtr->entity, _ecm);
   auto detected = false;
+  math::Vector3d emitterPos;
+  math::Vector3d emitterBoxSize;
 
   _ecm.Each<GasType,
             gazebo::components::WorldPose,
@@ -186,7 +264,8 @@ void GasDetector::PostUpdate(
     {
       // If the set is empty, accept all types.
       if (this->dataPtr->detectorTypes.size() == 0 ||
-          this->dataPtr->detectorTypes.count(_gasType->Data())) {
+          this->dataPtr->detectorTypes.count(_gasType->Data()))
+      {
         auto emitterBox = _geometry->Data().BoxShape();
         if (nullptr == emitterBox)
         {
@@ -197,14 +276,72 @@ void GasDetector::PostUpdate(
         {
           ignition::math::OrientedBoxd emitterVolume { emitterBox->Size(),
                                                        _worldPose->Data() };
-          if (emitterVolume.Contains(detectorPose.Pos())) {
+          if (emitterVolume.Contains(detectorPose.Pos()))
+          {
             detected = true;
+            emitterPos = _worldPose->Data().Pos();
+            emitterBoxSize = emitterBox->Size();
+            return false;
           }
         }
       }
       return true;
     });
 
+  double dtSec = std::chrono::duration<double>(_info.dt).count();
+  double targetConcentration = this->dataPtr->minConcentration;
+
+  // Step 1: model concentration level based on distance to emitter origin
+  if (detected)
+  {
+    // assume concentration is the highest at the emitter origin
+    double distToOrigin = (emitterPos - detectorPose.Pos()).Length();
+    double distPercentage = distToOrigin / emitterBoxSize.Max();
+    targetConcentration = this->dataPtr->gasConcentration +
+      this->dataPtr->gasConcentrationRange * (1.0 - distPercentage);
+  }
+
+  // Step 2: model change in concentration by taking into account the sensor
+  // response time. Currently assuming linear rate change, however, this could
+  // be more like logarithmic
+  double rate = 0.0;
+  if (!detected ||
+      (detected && this->dataPtr->concentration <
+       this->dataPtr->gasConcentration))
+  {
+    // high concentration rate change if in recovery state (no detection) or
+    // min concentration is not reached
+    rate = this->dataPtr->gasConcentration / this->dataPtr->responseTime;
+    rate *= (detected ? 1.0 : -1.0);
+  }
+  else
+  {
+    // change in concentration proportional to diff between current and target
+    // concentration
+    rate = (targetConcentration - this->dataPtr->concentration) /
+      this->dataPtr->responseTime;
+  }
+  double step = dtSec * rate;
+  this->dataPtr->concentration += step;
+
+  this->dataPtr->concentration = std::max(this->dataPtr->concentration,
+      this->dataPtr->minConcentration);
+  if (this->dataPtr->maxConcentration > 0)
+    this->dataPtr->concentration = std::min(this->dataPtr->concentration,
+        this->dataPtr->maxConcentration);
+
+  // Step 3: apply Gaussian noise based on sensor accuracy
+  double noise = ignition::math::Rand::DblNormal(0.0, this->dataPtr->precision);
+  double concentrationWithNoise = this->dataPtr->concentration + noise;
+
+  // publish gas concentration in ppm
+  msgs::Double cMsg;
+  cMsg.mutable_header()->mutable_stamp()->CopyFrom(
+      gazebo::convert<msgs::Time>(_info.simTime));
+  cMsg.set_data(concentrationWithNoise);
+  this->dataPtr->ppmPub.Publish(cMsg);
+
+  // publish boolean value
   msgs::Boolean msg;
   msg.mutable_header()->mutable_stamp()->CopyFrom(
       gazebo::convert<msgs::Time>(_info.simTime));

--- a/subt_ros/launch/models_common/all_robots.launch
+++ b/subt_ros/launch/models_common/all_robots.launch
@@ -40,4 +40,9 @@
       args="/model/$(arg name)/gas_detected@std_msgs/Bool[ignition.msgs.Boolean">
       <remap from="/model/$(arg name)/gas_detected" to="gas_detected"/>
     </node>
+    <node pkg="ros_ign_bridge" type="parameter_bridge" name="ros_ign_bridge_gas_ppm" respawn="true"
+      args="/model/$(arg name)/gas_detected/ppm@std_msgs/Float64[ignition.msgs.Double">
+      <remap from="/model/$(arg name)/gas_detected/ppm" to="gas_detected/ppm"/>
+    </node>
+
 </launch>

--- a/subt_ros/launch/vehicle_topics.launch
+++ b/subt_ros/launch/vehicle_topics.launch
@@ -52,6 +52,13 @@
         args="/model/$(arg name)/gas_detected@std_msgs/Bool[ignition.msgs.Boolean">
         <remap from="/model/$(arg name)/gas_detected" to="gas_detected"/>
       </node>
+      <node
+        pkg="ros_ign_bridge"
+        type="parameter_bridge"
+        name="ros_ign_bridge_gas_ppm"
+        args="/model/$(arg name)/gas_detected/ppm@std_msgs/Float64[ignition.msgs.Double">
+        <remap from="/model/$(arg name)/gas_detected/ppm" to="gas_detected/ppm"/>
+      </node>
     </group>
 
     <!-- RGBD -->


### PR DESCRIPTION
I'm copying over work done by @iche033 that provides a `ppm` component to the gas sensor.


A few changes are made to the gas detector. ~~The main breaking change is that the gas detector now publishes gas concentration (ppm) values instead of boolean true/false values.~~. **Update**: It now publishes both bool and double (ppm) values.

Other changes include simulating: 
* gas detector response time
* gas concentration level (based on distance to emitter source which is assumed to be center of room)
* Gaussian noise

The new simulated gas sensor device is based on Sensirion SCD30:
https://www.sensirion.com/en/environmental-sensors/carbon-dioxide-sensors/carbon-dioxide-sensors-scd30/

key parameters extracted from its spec:
* response time: 20s (t63%) 
* accuracy: +- (30ppm + 3%)
* range: 400 - 10,000 ppm

The new gas detector includes a few new configurable params:
* ~~`<legacy_detection_mode>`: True to publish boolean values, false to publish gas concentration (ppm) values. Defaults to false.~~
* `<response_time>`: Gas detector response time. Defaults to 20
  * This particular sensor device has a response time of 20s (t63%) response time (time it takes to detect 63% of an instance change in gas quantity). Actual response time may be longer.
* `<min_concentration>` : min gas  concentration level. Defaults to 412
* `<max_concentration>` : defaults to unbounded
* `<gas_concentration>`: target gas artifact concentration. Defaults to 1500 ppm
* `<precision>`: gas detector precision. Defaults to 30ppm

**To test:**

launch finals_qual world:

```
ign launch -v 4 competition.ign worldName:=finals_qual circuit:=finals robotName1:=X1 robotConfig1:=X1_SENSOR_CONFIG_1
```

In one terminal, echo the `gas_detected/ppm` topic:

```
rostopic echo /X1/gas_detected/ppm
```

You should see that the values are roughly around 410 ppm, which is the average CO2 concentration level in Earth atmosphere.  

Teleport the robot to one of the urban tiles that contains a gas artifact:

```
ign service -s /world/finals_qual/set_pose --reqtype ignition.msgs.Pose --reptype ignition.msgs.Boolean --timeout 300 --req 'name: "X1", position {x:80 y:105.5 z:10.0}'
```

You should then see that the gas concentration level slowly starts to rise until it's roughly hovering above 1500.

Signed-off-by: Nate Koenig <nate@openrobotics.org>