### PR TITLE
Record the teambase in the run.yml file

### DIFF
--- a/subt_ign/launch/cloudsim_sim.ign
+++ b/subt_ign/launch/cloudsim_sim.ign
@@ -1344,7 +1344,7 @@
       <model name='#{_name}'>
         <pose>#{_x} #{_y} #{_z} 0 0 #{_yaw}</pose>
         <static>true</static>
-        <link name='link'>
+        <link name='teambase_link'>
           <pose>0 0 0.05 0 0 0</pose>
           <visual name='visual'>
             <geometry>

--- a/subt_ign/launch/competition.ign
+++ b/subt_ign/launch/competition.ign
@@ -1261,7 +1261,7 @@
       <model name='#{_name}'>
         <pose>#{_x} #{_y} #{_z} 0 0 #{_yaw}</pose>
         <static>true</static>
-        <link name='link'>
+        <link name='teambase_link'>
           <pose>0 0 0.05 0 0 0</pose>
           <visual name='visual'>
             <geometry>


### PR DESCRIPTION
Signed-off-by: Nate Koenig <nate@openrobotics.org>

The `run.yml` files did not record the presence of a TEAMBASE model because the teambase model lacks a sensor which bypassed the ECM `Each` call used to record robot names and types. 

The PR renames a link in the teambase to `teambase_link` and adds a check in the GameLogic plugin for the correct link name and also lack of a filepath. A run.yml file will now record the TEAMBASE model.