### PR TITLE
Remove duplicate mapping server relays from Spot robots

### DIFF
--- a/submitted_models/ctu_cras_norlab_spot_sensor_config_1/launch/vehicle_topics.launch
+++ b/submitted_models/ctu_cras_norlab_spot_sensor_config_1/launch/vehicle_topics.launch
@@ -69,9 +69,6 @@
             <arg name="node_name_suffix" value="imu_vras" />
         </include>
 
-        <!-- Mapping Server -->
-        <include file="$(find subt_ros)/launch/models_common/mapping_server_relays.launch">
-          <arg name="name" value="$(arg name)"/>
-        </include>
+        <!-- Mapping Server relays are included from the base model -->
     </group>
 </launch>

--- a/submitted_models/marble_spot_sensor_config_1/launch/vehicle_topics.launch
+++ b/submitted_models/marble_spot_sensor_config_1/launch/vehicle_topics.launch
@@ -87,10 +87,7 @@
             <arg name="node_name_suffix" value="imu_vras" />
         </include>
 
-        <!-- Mapping Server -->
-        <include file="$(find subt_ros)/launch/models_common/mapping_server_relays.launch">
-          <arg name="name" value="$(arg name)"/>
-        </include>
+        <!-- Mapping Server relays are included from the base model -->
 
     </group>
 </launch>

--- a/submitted_models/marble_spot_sensor_config_2/launch/vehicle_topics.launch
+++ b/submitted_models/marble_spot_sensor_config_2/launch/vehicle_topics.launch
@@ -87,9 +87,6 @@
             <arg name="node_name_suffix" value="imu_vras" />
         </include>
 
-        <!-- Mapping Server -->
-        <include file="$(find subt_ros)/launch/models_common/mapping_server_relays.launch">
-          <arg name="name" value="$(arg name)"/>
-        </include>
+        <!-- Mapping Server relays are included from the base model -->
     </group>
 </launch>


### PR DESCRIPTION
Fixes #1044 .

bosdyn_spot model already has the mapping server relays in its vehicle_topics.launch. However, CCN_SPOT and MARBLE_SPOT also include the relays, but they also include the vehicle_topics.launch from bosdyn_spot. This leads to double inclusion of the launch file and the inability to launch the models.

The roslaunch error is:

```
$ roslaunch --screen ctu_cras_norlab_spot_sensor_config_1 vehicle_topics.launch world_name:=example name:=CTU_CRAS_NORLAB_SPOT_SENSOR_CONFIG_1
... logging to /home/peci1/.ros/log/c9e20822-4f0a-11ec-be5c-8c8caa865f82/roslaunch-cras-17-16222.log
Checking log directory for disk usage. This may take a while.
Press Ctrl-C to interrupt
Done checking log file disk usage. Usage is <1GB.

Rendering URDF of ctu_cras_norlab_spot_sensor_config_1 with the following Xacro arguments:
 leg_kp:=1e+7 leg_kd:=100.0 leg_mu1:=0.8 leg_mu2:=0.8  max_knee_effort:=80 max_knee_velocity:=15 max_hip_x_effort:=80 max_hip_x_velocity:=15 max_hip_y_effort:=80 max_hip_y_velocity:=15 rendering_target:=urdf num_breadcrumbs:=0 body_color_r:=0 body_color_g:=0.364705882 body_color_b:=0.678431373 has_big_collision_box_on_top:=1 name:=CTU_CRAS_NORLAB_SPOT_SENSOR_CONFIG_1
redefining global symbol: range
when instantiating macro: led_stripe (/media/data/subt_ws/install/share/ctu_cras_norlab_spot_sensor_config_1/urdf/lights.xacro)
in file: /media/data/subt_ws/install/share/ctu_cras_norlab_spot_sensor_config_1/scripts/../urdf/spot.urdf.xacro
redefining global symbol: range
when instantiating macro: led_stripe (/media/data/subt_ws/install/share/ctu_cras_norlab_spot_sensor_config_1/urdf/lights.xacro)
in file: /media/data/subt_ws/install/share/ctu_cras_norlab_spot_sensor_config_1/scripts/../urdf/spot.urdf.xacro
redefining global symbol: range
when instantiating macro: led_stripe (/media/data/subt_ws/install/share/ctu_cras_norlab_spot_sensor_config_1/urdf/lights.xacro)
in file: /media/data/subt_ws/install/share/ctu_cras_norlab_spot_sensor_config_1/scripts/../urdf/spot.urdf.xacro
redefining global symbol: range
when instantiating macro: led_stripe (/media/data/subt_ws/install/share/ctu_cras_norlab_spot_sensor_config_1/urdf/lights.xacro)
in file: /media/data/subt_ws/install/share/ctu_cras_norlab_spot_sensor_config_1/scripts/../urdf/spot.urdf.xacro
RLException: roslaunch file contains multiple nodes named [/CTU_CRAS_NORLAB_SPOT_SENSOR_CONFIG_1/cloud_downsampler].
Please check all <node> 'name' attributes to make sure they are unique.
Also check that $(anon id) use different ids.
The traceback for the exception was written to the log file
```

I just removed the superfluous includes from the downstream models and left a comment there to remind future editors that it is correct that the relays are missing there.