### PR TITLE
 Creating Stable Ros Launch & Exit (Fortress Noetic)

### DIFF
--- a/subt_ros/launch/competition_init.launch
+++ b/subt_ros/launch/competition_init.launch
@@ -12,24 +12,27 @@
   <param name="/world_name" value="$(arg world_name)"/>
   <rosparam param="/robot_names" subst_value='true'>$(arg robot_names)</rosparam>
 
-  <node pkg="ros_ign_bridge" type="parameter_bridge" name="$(anon ros_ign_bridge)" args="/clock@rosgraph_msgs/Clock[ignition.msgs.Clock">
+  <node pkg="ros_ign_bridge" type="parameter_bridge" name="$(anon ros_ign_bridge)" args="/clock@rosgraph_msgs/Clock" required="true">
   </node>
 
   <node
     pkg="subt_ros"
     type="subt_ros_relay"
-    name="subt_ros_relay"/>
+    name="subt_ros_relay"
+    required="true"/>
 
   <node
     pkg="subt_ros"
     type="bridge_logger"
-    name="bridge_logger"/>
+    name="bridge_logger"
+    required="true"/>
 
 
   <node
     pkg="subt_ros"
     type="rostopic_stats_logger.sh"
-    name="rostopic_stats_logger"/>
+    name="rostopic_stats_logger"
+    required="true"/>
 
   <group if="$(arg enable_ground_truth)">
     <!-- In the case that ground truth is enabled, also relay the /set_pose
@@ -39,9 +42,10 @@
     <node
       pkg="subt_ros"
       type="set_pose_relay"
-      name="set_pose_relay"/>
+      name="set_pose_relay"
+      required="true"/>
   </group>
 
-  <node pkg="tf2_ros" type="static_transform_publisher" name="tf_world_static" args="0 0 0 0 0 0 world $(arg world_name)"/>
+  <node pkg="tf2_ros" type="static_transform_publisher" name="tf_world_static" args="0 0 0 0 0 0 world $(arg world_name)" required="true"/>
 
 </launch>


### PR DESCRIPTION
The way ros is currently launched leads to ros not shutting down properly when a node is shut down.

Adding required = true to all ros nodes mean that they can be cleanly exited when one of the nodes is shut down by calling the terminator node to end all ros nodes running. That means partial shutdowns are avoided after executing & ending a launch file and the code is more stable. This ensures a stable setup to use on a repeated basis for trial runs using the SubT simulator.